### PR TITLE
Create helper macros for common functions - NOT READY

### DIFF
--- a/Source/TitaniumKit/include/Titanium/API.hpp
+++ b/Source/TitaniumKit/include/Titanium/API.hpp
@@ -129,13 +129,13 @@ namespace Titanium
 		static void JSExportInitialize();
 		static JSObject GetStaticObject(const JSContext& js_context) TITANIUM_NOEXCEPT;
 
-		JSValue js_info(const std::vector<JSValue>& arguments, JSObject& this_object);
-		JSValue js_warn(const std::vector<JSValue>& arguments, JSObject& this_object);
-		JSValue js_error(const std::vector<JSValue>& arguments, JSObject& this_object);
-		JSValue js_debug(const std::vector<JSValue>& arguments, JSObject& this_object);
-		JSValue js_trace(const std::vector<JSValue>& arguments, JSObject& this_object);
-		JSValue js_log(const std::vector<JSValue>& arguments, JSObject& this_object);
-
+		TITANIUM_MODULE_FUNCTION_DEF(info)
+		TITANIUM_MODULE_FUNCTION_DEF(warn)
+		TITANIUM_MODULE_FUNCTION_DEF(error)
+		TITANIUM_MODULE_FUNCTION_DEF(debug)
+		TITANIUM_MODULE_FUNCTION_DEF(trace)
+		TITANIUM_MODULE_FUNCTION_DEF(log)
+		
 	protected:
 		virtual void log(const std::string& message) const TITANIUM_NOEXCEPT;
 

--- a/Source/TitaniumKit/include/Titanium/Gesture.hpp
+++ b/Source/TitaniumKit/include/Titanium/Gesture.hpp
@@ -49,57 +49,58 @@ namespace Titanium
 		  @abstract js_get_orientation
 		  @discussion Orientation of the current window.
 		*/
-		virtual JSValue js_get_orientation() const TITANIUM_NOEXCEPT final;
+		TITANIUM_MODULE_PROPERTY_READONLY_DEF(orientation)
 
 		/*!
 		  @method
 		  @abstract js_get_landscape
 		  @discussion Indicates whether current window is considered landscape by the device.
 		*/
-		virtual JSValue js_get_landscape() const TITANIUM_NOEXCEPT final;
+		TITANIUM_MODULE_PROPERTY_READONLY_DEF(landscape)
+		
 		/*!
 		  @method
 		  @abstract js_get_portrait
 		  @discussion Indicates whether current window is considered portrait by the device.
 		*/
-		virtual JSValue js_get_portrait() const TITANIUM_NOEXCEPT final;
+		TITANIUM_MODULE_PROPERTY_READONLY_DEF(portrait)
 
 		/*!
 		  @method
 		  @abstract js_getLandscape
 		  @discussion Gets the value of the landscape property.
 		*/
-		virtual JSValue js_getLandscape(const std::vector<JSValue>& arguments, JSObject& this_object) TITANIUM_NOEXCEPT final;
+		TITANIUM_MODULE_FUNCTION_DEF(getLandscape)
 
 		/*!
 		  @method
 		  @abstract js_getPortrait
 		  @discussion Gets the value of the portrait property.
 		*/
-		virtual JSValue js_getPortrait(const std::vector<JSValue>& arguments, JSObject& this_object) TITANIUM_NOEXCEPT final;
+		TITANIUM_MODULE_FUNCTION_DEF(getPortrait)
 
 		/*!
 		  @method
 		  @abstract js_getOrientation
 		  @discussion Gets the value of the orientation property.
 		*/
-		virtual JSValue js_getOrientation(const std::vector<JSValue>& arguments, JSObject& this_object) TITANIUM_NOEXCEPT final;
+		TITANIUM_MODULE_FUNCTION_DEF(getOrientation)
 
 		/*!
 		  @method
 		  @abstract js_isFaceDown
 		  @discussion Returns whether current window is considered face down by the device.
 		*/
-		virtual JSValue js_isFaceDown(const std::vector<JSValue>& arguments, JSObject& this_object) TITANIUM_NOEXCEPT final;
+		TITANIUM_MODULE_FUNCTION_DEF(isFaceDown)
 
 		/*!
 		  @method
 		  @abstract js_isFaceUp
 		  @discussion Returns whether current window is considered face up by the device.
 		*/
-		virtual JSValue js_isFaceUp(const std::vector<JSValue>& arguments, JSObject& this_object) TITANIUM_NOEXCEPT final;
-		virtual JSValue js_isLandscape(const std::vector<JSValue>& arguments, JSObject& this_object) TITANIUM_NOEXCEPT final;
-		virtual JSValue js_isPortrait(const std::vector<JSValue>& arguments, JSObject& this_object) TITANIUM_NOEXCEPT final;
+		TITANIUM_MODULE_FUNCTION_DEF(isFaceUp)
+		TITANIUM_MODULE_FUNCTION_DEF(isLandscape)
+		TITANIUM_MODULE_FUNCTION_DEF(isPortrait)
 
 		virtual void enableEvent(const std::string& event_name) TITANIUM_NOEXCEPT override;
 		virtual void disableEvent(const std::string& event_name) TITANIUM_NOEXCEPT override;

--- a/Source/TitaniumKit/include/Titanium/GlobalObject.hpp
+++ b/Source/TitaniumKit/include/Titanium/GlobalObject.hpp
@@ -172,13 +172,14 @@ namespace Titanium
 		// TODO: The following functions can automatically be generated
 		// from the YAML API docs.
 		static void JSExportInitialize();
-		JSValue js_global() const TITANIUM_NOEXCEPT;
-		JSValue js_require(const std::vector<JSValue>& arguments, JSObject& this_object);
-		JSValue js_setTimeout(const std::vector<JSValue>& arguments, JSObject& this_object);
-		JSValue js_clearTimeout(const std::vector<JSValue>& arguments, JSObject& this_object);
-		JSValue js_setInterval(const std::vector<JSValue>& arguments, JSObject& this_object);
-		JSValue js_clearInterval(const std::vector<JSValue>& arguments, JSObject& this_object);
-
+		
+		TITANIUM_MODULE_PROPERTY_READONLY_DEF(global);
+		TITANIUM_MODULE_FUNCTION_DEF(require);
+		TITANIUM_MODULE_FUNCTION_DEF(setTimeout);
+		TITANIUM_MODULE_FUNCTION_DEF(clearTimeout);
+		TITANIUM_MODULE_FUNCTION_DEF(setInterval);
+		TITANIUM_MODULE_FUNCTION_DEF(clearInterval);
+		
 		using Callback_t = std::function<void()>;
 
 		/*!

--- a/Source/TitaniumKit/include/Titanium/UI/View.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/View.hpp
@@ -68,64 +68,30 @@ namespace Titanium
 
 			static void JSExportInitialize();
 
-			virtual JSValue js_add(const std::vector<JSValue>& arguments, JSObject& this_object) TITANIUM_NOEXCEPT final;
-			virtual JSValue js_animate(const std::vector<JSValue>& arguments, JSObject& this_object) TITANIUM_NOEXCEPT final;
-			virtual JSValue js_hide(const std::vector<JSValue>& arguments, JSObject& this_object) TITANIUM_NOEXCEPT final;
-			virtual JSValue js_show(const std::vector<JSValue>& arguments, JSObject& this_object) TITANIUM_NOEXCEPT final;
-
-			virtual JSValue js_get_backgroundColor() const TITANIUM_NOEXCEPT final;
-			virtual bool js_set_backgroundColor(const JSValue& argument) TITANIUM_NOEXCEPT final;
-
-			virtual JSValue js_get_borderColor() const TITANIUM_NOEXCEPT final;
-			virtual bool js_set_borderColor(const JSValue& argument) TITANIUM_NOEXCEPT final;
-
-			virtual JSValue js_get_borderRadius() const TITANIUM_NOEXCEPT final;
-			virtual bool js_set_borderRadius(const JSValue& argument) TITANIUM_NOEXCEPT final;
-
-			virtual JSValue js_get_borderWidth() const TITANIUM_NOEXCEPT final;
-			virtual bool js_set_borderWidth(const JSValue& argument) TITANIUM_NOEXCEPT final;
-
-			virtual JSValue js_get_bottom() const TITANIUM_NOEXCEPT final;
-			virtual bool js_set_bottom(const JSValue& argument) TITANIUM_NOEXCEPT final;
-
-			virtual JSValue js_get_center() const TITANIUM_NOEXCEPT final;
-			virtual bool js_set_center(const JSValue& argument) TITANIUM_NOEXCEPT final;
-
-			virtual JSValue js_get_children() const TITANIUM_NOEXCEPT final;
-
-			virtual JSValue js_get_height() const TITANIUM_NOEXCEPT final;
-			virtual bool js_set_height(const JSValue& argument) TITANIUM_NOEXCEPT final;
-
-			virtual JSValue js_get_layout() const TITANIUM_NOEXCEPT final;
-			virtual bool js_set_layout(const JSValue& argument) TITANIUM_NOEXCEPT final;
-
-			virtual JSValue js_get_left() const TITANIUM_NOEXCEPT final;
-			virtual bool js_set_left(const JSValue& argument) TITANIUM_NOEXCEPT final;
-
-			virtual JSValue js_get_opacity() const TITANIUM_NOEXCEPT final;
-			virtual bool js_set_opacity(const JSValue& argument) TITANIUM_NOEXCEPT final;
-
-			virtual JSValue js_get_rect() const TITANIUM_NOEXCEPT final;
-
-			virtual JSValue js_get_right() const TITANIUM_NOEXCEPT final;
-			virtual bool js_set_right(const JSValue& argument) TITANIUM_NOEXCEPT final;
-
-			virtual JSValue js_get_size() const TITANIUM_NOEXCEPT final;
+			TITANIUM_MODULE_FUNCTION_DEF(add);
+			TITANIUM_MODULE_FUNCTION_DEF(animate);
+			TITANIUM_MODULE_FUNCTION_DEF(hide);
+			TITANIUM_MODULE_FUNCTION_DEF(show);
 			
-			virtual JSValue js_get_tintColor() const TITANIUM_NOEXCEPT final;
-			virtual bool js_set_tintColor(const JSValue& argument) TITANIUM_NOEXCEPT final;
-
-			virtual JSValue js_get_touchEnabled() const TITANIUM_NOEXCEPT final;
-			virtual bool js_set_touchEnabled(const JSValue& argument) TITANIUM_NOEXCEPT final;
-
-			virtual JSValue js_get_visible() const TITANIUM_NOEXCEPT final;
-			virtual bool js_set_visible(const JSValue& argument) TITANIUM_NOEXCEPT final;
-
-			virtual JSValue js_get_top() const TITANIUM_NOEXCEPT final;
-			virtual bool js_set_top(const JSValue& argument) TITANIUM_NOEXCEPT final;
-
-			virtual JSValue js_get_width() const TITANIUM_NOEXCEPT final;
-			virtual bool js_set_width(const JSValue& argument) TITANIUM_NOEXCEPT final;
+			TITANIUM_MODULE_PROPERTY_DEF(backgroundColor);
+			TITANIUM_MODULE_PROPERTY_DEF(borderColor);
+			TITANIUM_MODULE_PROPERTY_DEF(borderRadius);
+			TITANIUM_MODULE_PROPERTY_DEF(borderWidth);
+			TITANIUM_MODULE_PROPERTY_DEF(bottom);
+			TITANIUM_MODULE_PROPERTY_DEF(center);
+			TITANIUM_MODULE_PROPERTY_READONLY_DEF(children);
+			TITANIUM_MODULE_PROPERTY_DEF(height);
+			TITANIUM_MODULE_PROPERTY_DEF(layout);
+			TITANIUM_MODULE_PROPERTY_DEF(left);
+			TITANIUM_MODULE_PROPERTY_DEF(opacity);
+			TITANIUM_MODULE_PROPERTY_READONLY_DEF(rect);
+			TITANIUM_MODULE_PROPERTY_DEF(right);
+			TITANIUM_MODULE_PROPERTY_READONLY_DEF(size);
+			TITANIUM_MODULE_PROPERTY_DEF(tintColor);
+			TITANIUM_MODULE_PROPERTY_DEF(touchEnabled);
+			TITANIUM_MODULE_PROPERTY_DEF(visible);
+			TITANIUM_MODULE_PROPERTY_DEF(top);
+			TITANIUM_MODULE_PROPERTY_DEF(width);
 
 			virtual void postInitialize(JSObject& this_object) override;
 			virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;

--- a/Source/TitaniumKit/include/Titanium/detail/TiBase.hpp
+++ b/Source/TitaniumKit/include/Titanium/detail/TiBase.hpp
@@ -57,4 +57,75 @@
 #include "Titanium/detail/TiLogger.hpp"
 #include "HAL/HAL.hpp"
 
+#define TITANIUM_MODULE_FUNCTION(MODULE, NAME) \
+JSValue MODULE::js_##NAME(const std::vector<JSValue>& arguments, JSObject& this_object)
+
+#define TITANIUM_MODULE_PROPERTY_GETTER(MODULE, NAME) \
+JSValue MODULE::js_get_##NAME() const
+
+#define TITANIUM_MODULE_PROPERTY_SETTER(MODULE, NAME) \
+bool MODULE::js_set_##NAME(const JSValue& argument)
+
+#define TITANIUM_MODULE_FUNCTION_DEF(NAME) \
+JSValue js_##NAME(const std::vector<JSValue>& arguments, JSObject& this_object);
+
+#define TITANIUM_MODULE_PROPERTY_READONLY_DEF(NAME) \
+JSValue js_get_##NAME() const;
+
+#define TITANIUM_MODULE_PROPERTY_DEF(NAME) \
+JSValue js_get_##NAME() const; \
+bool js_set_##NAME(const JSValue& argument);
+
+#define TITANIUM_MODULE_ADD_FUNCTION(MODULE, NAME) \
+JSExport<MODULE>::AddFunctionProperty(#NAME, std::mem_fn(&MODULE::js_##NAME))
+
+#define TITANIUM_MODULE_ADD_PROPERTY_READONLY(MODULE, NAME) \
+JSExport<MODULE>::AddValueProperty(#NAME, std::mem_fn(&MODULE::js_get_##NAME))
+
+#define TITANIUM_MODULE_ADD_PROPERTY(MODULE, NAME) \
+JSExport<MODULE>::AddValueProperty(#NAME, std::mem_fn(&MODULE::js_get_##NAME), std::mem_fn(&MODULE::js_set_##NAME))
+
+#define ENSURE_OPTIONAL_OBJECT_AT_INDEX(OUT,INDEX) \
+  auto OUT = this_object.get_context().CreateObject(); \
+  if (arguments.size() >= INDEX + 1) { \
+    const auto _##INDEX = arguments.at(INDEX); \
+    TITANIUM_ASSERT(_##INDEX.IsObject()); \
+    OUT = static_cast<JSObject>(_##INDEX);\
+  }
+
+#define ENSURE_NUMBER_AT_INDEX(OUT,INDEX,TYPE) \
+  TITANIUM_ASSERT(arguments.size() >= INDEX + 1); \
+  const auto _##INDEX = arguments.at(INDEX); \
+  TITANIUM_ASSERT(_##INDEX.IsNumber()); \
+  auto OUT = static_cast<TYPE>(_##INDEX);
+
+#define ENSURE_STRING_AT_INDEX(OUT,INDEX) \
+  TITANIUM_ASSERT(arguments.size() >= INDEX + 1); \
+  const auto _##INDEX = arguments.at(INDEX); \
+  TITANIUM_ASSERT(_##INDEX.IsString()); \
+  auto OUT = static_cast<std::string>(_##INDEX);
+
+#define ENSURE_OBJECT_AT_INDEX(OUT,INDEX) \
+  TITANIUM_ASSERT(arguments.size() >= INDEX + 1); \
+  const auto _##INDEX = arguments.at(INDEX); \
+  TITANIUM_ASSERT(_##INDEX.IsObject()); \
+  auto OUT = static_cast<JSObject>(_##INDEX);
+
+#define ENSURE_ARRAY_AT_INDEX(OUT,INDEX) \
+  TITANIUM_ASSERT(arguments.size() >= INDEX + 1); \
+  const auto _##INDEX = arguments.at(INDEX); \
+  TITANIUM_ASSERT(_##INDEX.IsObject()); \
+  const auto _obj_##INDEX = static_cast<JSObject>(_##INDEX); \
+  TITANIUM_ASSERT(_obj_##INDEX.IsArray());\
+  auto OUT = static_cast<JSArray>(_obj_##INDEX);
+
+#define ENSURE_INT_AT_INDEX(OUT,INDEX) \
+  ENSURE_NUMBER_AT_INDEX(OUT,INDEX,int32_t)
+
+#define ENSURE_UINT_AT_INDEX(OUT,INDEX) \
+  ENSURE_NUMBER_AT_INDEX(OUT,INDEX,uint32_t)
+
+#define ENSURE_DOUBLE_AT_INDEX(OUT,INDEX) \
+  ENSURE_NUMBER_AT_INDEX(OUT,INDEX,double)
+
 #endif  // _TITANIUM_DETAIL_TIBASE_HPP_

--- a/Source/TitaniumKit/src/API.cpp
+++ b/Source/TitaniumKit/src/API.cpp
@@ -125,12 +125,13 @@ namespace Titanium
 	{
 		JSExport<API>::SetClassVersion(1);
 		JSExport<API>::SetParent(JSExport<Module>::Class());
-		JSExport<API>::AddFunctionProperty("info", std::mem_fn(&API::js_info));
-		JSExport<API>::AddFunctionProperty("warn", std::mem_fn(&API::js_warn));
-		JSExport<API>::AddFunctionProperty("error", std::mem_fn(&API::js_error));
-		JSExport<API>::AddFunctionProperty("debug", std::mem_fn(&API::js_debug));
-		JSExport<API>::AddFunctionProperty("trace", std::mem_fn(&API::js_trace));
-		JSExport<API>::AddFunctionProperty("log", std::mem_fn(&API::js_log));
+		
+		TITANIUM_MODULE_ADD_FUNCTION(API, info);
+		TITANIUM_MODULE_ADD_FUNCTION(API, warn);
+		TITANIUM_MODULE_ADD_FUNCTION(API, error);
+		TITANIUM_MODULE_ADD_FUNCTION(API, debug);
+		TITANIUM_MODULE_ADD_FUNCTION(API, trace);
+		TITANIUM_MODULE_ADD_FUNCTION(API, log);
 	}
 
 	JSObject API::GetStaticObject(const JSContext& js_context) TITANIUM_NOEXCEPT
@@ -144,63 +145,56 @@ namespace Titanium
 		return static_cast<JSObject>(Object_property);
 	}
 
-	JSValue API::js_info(const std::vector<JSValue>& arguments, JSObject& this_object)
+	TITANIUM_MODULE_FUNCTION(API, info)
 	{
-		TITANIUM_ASSERT(arguments.size() >= 1);
-		const auto _0 = arguments.at(0);
-		std::string message = static_cast<std::string>(_0);
+		ENSURE_STRING_AT_INDEX(message, 0);
+		
 		const auto js_context = this_object.get_context();
 		GetStaticObject(js_context).GetPrivate<API>()->info(message);
 		return js_context.CreateUndefined();
 	}
 
-	JSValue API::js_warn(const std::vector<JSValue>& arguments, JSObject& this_object)
+	TITANIUM_MODULE_FUNCTION(API, warn)
 	{
-		TITANIUM_ASSERT(arguments.size() >= 1);
-		const auto _0 = arguments.at(0);
-		std::string message = static_cast<std::string>(_0);
+		ENSURE_STRING_AT_INDEX(message, 0);
+		
 		const auto js_context = this_object.get_context();
 		GetStaticObject(js_context).GetPrivate<API>()->warn(message);
 		return js_context.CreateUndefined();
 	}
 
-	JSValue API::js_error(const std::vector<JSValue>& arguments, JSObject& this_object)
+	TITANIUM_MODULE_FUNCTION(API, error)
 	{
-		TITANIUM_ASSERT(arguments.size() >= 1);
-		const auto _0 = arguments.at(0);
-		std::string message = static_cast<std::string>(_0);
+		ENSURE_STRING_AT_INDEX(message, 0);
+		
 		const auto js_context = this_object.get_context();
 		GetStaticObject(js_context).GetPrivate<API>()->error(message);
 		return js_context.CreateUndefined();
 	}
 
-	JSValue API::js_debug(const std::vector<JSValue>& arguments, JSObject& this_object)
+	TITANIUM_MODULE_FUNCTION(API, debug)
 	{
-		TITANIUM_ASSERT(arguments.size() >= 1);
-		const auto _0 = arguments.at(0);
-		std::string message = static_cast<std::string>(_0);
+		ENSURE_STRING_AT_INDEX(message, 0);
+		
 		const auto js_context = this_object.get_context();
 		GetStaticObject(js_context).GetPrivate<API>()->debug(message);
 		return js_context.CreateUndefined();
 	}
 
-	JSValue API::js_trace(const std::vector<JSValue>& arguments, JSObject& this_object)
+	TITANIUM_MODULE_FUNCTION(API, trace)
 	{
-		TITANIUM_ASSERT(arguments.size() >= 1);
-		const auto _0 = arguments.at(0);
-		std::string message = static_cast<std::string>(_0);
+		ENSURE_STRING_AT_INDEX(message, 0);
+		
 		const auto js_context = this_object.get_context();
 		GetStaticObject(js_context).GetPrivate<API>()->trace(message);
 		return js_context.CreateUndefined();
 	}
 
-	JSValue API::js_log(const std::vector<JSValue>& arguments, JSObject& this_object)
+	TITANIUM_MODULE_FUNCTION(API, log)
 	{
-		TITANIUM_ASSERT(arguments.size() >= 2);
-		const auto _0 = arguments.at(0);
-		std::string level = static_cast<std::string>(_0);
-		const auto _1 = arguments.at(1);
-		std::string message = static_cast<std::string>(_1);
+		ENSURE_STRING_AT_INDEX(level, 0);
+		ENSURE_STRING_AT_INDEX(message, 1);
+		
 		const auto js_context = this_object.get_context();
 		GetStaticObject(js_context).GetPrivate<API>()->log(message);
 		return js_context.CreateUndefined();

--- a/Source/TitaniumKit/src/Gesture.cpp
+++ b/Source/TitaniumKit/src/Gesture.cpp
@@ -29,16 +29,17 @@ namespace Titanium
 	{
 		JSExport<Gesture>::SetClassVersion(1);
 		JSExport<Gesture>::SetParent(JSExport<Module>::Class());
-		JSExport<Gesture>::AddFunctionProperty("getLandscape", std::mem_fn(&Gesture::js_getLandscape));
-		JSExport<Gesture>::AddFunctionProperty("getPortrait", std::mem_fn(&Gesture::js_getPortrait));
-		JSExport<Gesture>::AddFunctionProperty("getOrientation", std::mem_fn(&Gesture::js_getOrientation));
-		JSExport<Gesture>::AddFunctionProperty("isFaceDown", std::mem_fn(&Gesture::js_isFaceDown));
-		JSExport<Gesture>::AddFunctionProperty("isFaceUp", std::mem_fn(&Gesture::js_isFaceUp));
-		JSExport<Gesture>::AddFunctionProperty("isLandscape", std::mem_fn(&Gesture::js_isLandscape));
-		JSExport<Gesture>::AddFunctionProperty("isPortrait", std::mem_fn(&Gesture::js_isPortrait));
-		JSExport<Gesture>::AddValueProperty("orientation", std::mem_fn(&Gesture::js_get_orientation));
-		JSExport<Gesture>::AddValueProperty("landscape", std::mem_fn(&Gesture::js_get_landscape));
-		JSExport<Gesture>::AddValueProperty("portrait", std::mem_fn(&Gesture::js_get_portrait));
+		
+		TITANIUM_MODULE_ADD_FUNCTION(Gesture, getLandscape);
+		TITANIUM_MODULE_ADD_FUNCTION(Gesture, getPortrait);
+		TITANIUM_MODULE_ADD_FUNCTION(Gesture, getOrientation);
+		TITANIUM_MODULE_ADD_FUNCTION(Gesture, isFaceDown);
+		TITANIUM_MODULE_ADD_FUNCTION(Gesture, isFaceUp);
+		TITANIUM_MODULE_ADD_FUNCTION(Gesture, isLandscape);
+		TITANIUM_MODULE_ADD_FUNCTION(Gesture, isPortrait);
+		TITANIUM_MODULE_ADD_PROPERTY_READONLY(Gesture, orientation);
+		TITANIUM_MODULE_ADD_PROPERTY_READONLY(Gesture, landscape);
+		TITANIUM_MODULE_ADD_PROPERTY_READONLY(Gesture, portrait);
 	}
 
 	JSObject Gesture::GetStaticObject(const JSContext& js_context) TITANIUM_NOEXCEPT
@@ -52,74 +53,68 @@ namespace Titanium
 		return static_cast<JSObject>(Object_property);
 	}
 
-	JSValue Gesture::js_get_orientation() const TITANIUM_NOEXCEPT
+	TITANIUM_MODULE_PROPERTY_GETTER(Gesture, orientation)
 	{
 		return get_context().CreateNumber(UI::Constants::to_underlying_type(get_orientation()));
 	}
-	JSValue Gesture::js_getOrientation(
-	    const std::vector<JSValue>& arguments, JSObject& this_object) TITANIUM_NOEXCEPT
+	
+	TITANIUM_MODULE_FUNCTION(Gesture, getOrientation)
 	{
 		const auto js_context = this_object.get_context();
 		const auto gesture_ptr = GetStaticObject(js_context).GetPrivate<Gesture>();
 		return this_object.get_context().CreateNumber(UI::Constants::to_underlying_type(gesture_ptr->get_orientation()));
 	}
 
-	JSValue Gesture::js_isFaceDown(
-	    const std::vector<JSValue>& arguments, JSObject& this_object) TITANIUM_NOEXCEPT
+	TITANIUM_MODULE_FUNCTION(Gesture, isFaceDown)
 	{
 		const auto js_context = this_object.get_context();
 		const auto gesture_ptr = GetStaticObject(js_context).GetPrivate<Gesture>();
 		return this_object.get_context().CreateBoolean(gesture_ptr->get_orientation() == UI::ORIENTATION::FACE_DOWN);
 	}
 
-	JSValue Gesture::js_isFaceUp(
-	    const std::vector<JSValue>& arguments, JSObject& this_object) TITANIUM_NOEXCEPT
+	TITANIUM_MODULE_FUNCTION(Gesture, isFaceUp)
 	{
 		const auto js_context = this_object.get_context();
 		const auto gesture_ptr = GetStaticObject(js_context).GetPrivate<Gesture>();
 		return this_object.get_context().CreateBoolean(gesture_ptr->get_orientation() == UI::ORIENTATION::FACE_UP);
 	}
 
-	JSValue Gesture::js_isLandscape(
-	    const std::vector<JSValue>& arguments, JSObject& this_object) TITANIUM_NOEXCEPT
+	TITANIUM_MODULE_FUNCTION(Gesture, isLandscape)
 	{
 		const auto js_context = this_object.get_context();
 		const auto gesture_ptr = GetStaticObject(js_context).GetPrivate<Gesture>();
 		return gesture_ptr->js_get_landscape();
 	}
 
-	JSValue Gesture::js_isPortrait(
-	    const std::vector<JSValue>& arguments, JSObject& this_object) TITANIUM_NOEXCEPT
+	TITANIUM_MODULE_FUNCTION(Gesture, isPortrait)
 	{
 		const auto js_context = this_object.get_context();
 		const auto gesture_ptr = GetStaticObject(js_context).GetPrivate<Gesture>();
 		return gesture_ptr->js_get_portrait();
 	}
 
-	JSValue Gesture::js_getLandscape(
-	    const std::vector<JSValue>& arguments, JSObject& this_object) TITANIUM_NOEXCEPT
+	TITANIUM_MODULE_FUNCTION(Gesture, getLandscape)
 	{
 		const auto js_context = this_object.get_context();
 		const auto gesture_ptr = GetStaticObject(js_context).GetPrivate<Gesture>();
 		return gesture_ptr->js_get_landscape();
 	}
 
-	JSValue Gesture::js_get_landscape() const TITANIUM_NOEXCEPT
+	TITANIUM_MODULE_PROPERTY_GETTER(Gesture, landscape)
 	{
 		const auto o = get_orientation();
 		const bool isLandscape = (o == UI::ORIENTATION::LANDSCAPE_LEFT || o == UI::ORIENTATION::LANDSCAPE_RIGHT);
 		return get_context().CreateBoolean(isLandscape);
 	}
 
-	JSValue Gesture::js_getPortrait(
-	    const std::vector<JSValue>& arguments, JSObject& this_object) TITANIUM_NOEXCEPT
+	TITANIUM_MODULE_FUNCTION(Gesture, getPortrait)
 	{
 		const auto js_context = this_object.get_context();
 		const auto gesture_ptr = GetStaticObject(js_context).GetPrivate<Gesture>();
 		return gesture_ptr->js_get_portrait();
 	}
 
-	JSValue Gesture::js_get_portrait() const TITANIUM_NOEXCEPT
+	TITANIUM_MODULE_PROPERTY_GETTER(Gesture, portrait)
 	{
 		const auto o = get_orientation();
 		const bool isPortrait = (o == UI::ORIENTATION::PORTRAIT || o == UI::ORIENTATION::UPSIDE_PORTRAIT);

--- a/Source/TitaniumKit/src/GlobalObject.cpp
+++ b/Source/TitaniumKit/src/GlobalObject.cpp
@@ -436,27 +436,25 @@ namespace Titanium
 		TITANIUM_LOG_DEBUG("GlobalObject::JSExportInitialize");
 		JSExport<GlobalObject>::SetClassVersion(1);
 		JSExport<GlobalObject>::SetParent(JSExport<JSExportObject>::Class());
-		JSExport<GlobalObject>::AddValueProperty("global", std::mem_fn(&GlobalObject::js_global));
-		JSExport<GlobalObject>::AddFunctionProperty("require", std::mem_fn(&GlobalObject::js_require));
-		JSExport<GlobalObject>::AddFunctionProperty("setTimeout", std::mem_fn(&GlobalObject::js_setTimeout));
-		JSExport<GlobalObject>::AddFunctionProperty("clearTimeout", std::mem_fn(&GlobalObject::js_clearTimeout));
-		JSExport<GlobalObject>::AddFunctionProperty("setInterval", std::mem_fn(&GlobalObject::js_setInterval));
-		JSExport<GlobalObject>::AddFunctionProperty("clearInterval", std::mem_fn(&GlobalObject::js_clearInterval));
+		
+		TITANIUM_MODULE_ADD_PROPERTY_READONLY(GlobalObject, global);
+		TITANIUM_MODULE_ADD_FUNCTION(GlobalObject, require);
+		TITANIUM_MODULE_ADD_FUNCTION(GlobalObject, setTimeout);
+		TITANIUM_MODULE_ADD_FUNCTION(GlobalObject, clearTimeout);
+		TITANIUM_MODULE_ADD_FUNCTION(GlobalObject, setInterval);
+		TITANIUM_MODULE_ADD_FUNCTION(GlobalObject, clearInterval);
 	}
 
-	JSValue GlobalObject::js_global() const TITANIUM_NOEXCEPT
+	TITANIUM_MODULE_PROPERTY_GETTER(GlobalObject, global)
 	{
 		return get_context().JSEvaluateScript("this;");
 	}
 
-	JSValue GlobalObject::js_require(const std::vector<JSValue>& arguments, JSObject& this_object)
+	TITANIUM_MODULE_FUNCTION(GlobalObject, require)
 	{
 		// TODO: Validate these precondition checks (which could be
 		// automaticaly generated) with the team.
-		TITANIUM_ASSERT(arguments.size() >= 1);
-		const auto _0 = arguments.at(0);
-		TITANIUM_ASSERT(_0.IsString());
-		std::string moduleId = static_cast<std::string>(_0);
+		ENSURE_STRING_AT_INDEX(moduleId, 0);
 
 		const auto global_object = this_object.get_context().get_global_object();
 		const auto global_ptr = global_object.GetPrivate<GlobalObject>();
@@ -465,34 +463,27 @@ namespace Titanium
 		return global_ptr->requireModule(this_object, moduleId);
 	}
 
-	JSValue GlobalObject::js_setTimeout(const std::vector<JSValue>& arguments, JSObject& this_object)
+	TITANIUM_MODULE_FUNCTION(GlobalObject, setTimeout)
 	{
 		// TODO: Validate these precondition checks (which could be
 		// automaticaly generated) with the team.
-		TITANIUM_ASSERT(arguments.size() >= 2);
-		const auto _0 = arguments.at(0);
-		const auto _1 = arguments.at(1);
-		TITANIUM_ASSERT(_0.IsObject());
-		TITANIUM_ASSERT(_1.IsNumber());
-		JSObject function = static_cast<JSObject>(_0);
-		TITANIUM_ASSERT(function.IsFunction());
-		const auto delay = std::chrono::milliseconds(static_cast<std::chrono::milliseconds::rep>(static_cast<std::uint32_t>(_1)));
+		ENSURE_OBJECT_AT_INDEX(function, 0);
+		ENSURE_UINT_AT_INDEX(delay, 1);
+		
+		const auto chrono_delay = std::chrono::milliseconds(static_cast<std::chrono::milliseconds::rep>(delay));
 
 		const auto global_object = this_object.get_context().get_global_object();
 		const auto global_ptr = global_object.GetPrivate<GlobalObject>();
 		TITANIUM_ASSERT(global_ptr);
 
-		return this_object.get_context().CreateNumber(global_ptr->setTimeout(std::move(function), delay));
+		return this_object.get_context().CreateNumber(global_ptr->setTimeout(std::move(function), chrono_delay));
 	}
 
-	JSValue GlobalObject::js_clearTimeout(const std::vector<JSValue>& arguments, JSObject& this_object)
+	TITANIUM_MODULE_FUNCTION(GlobalObject, clearTimeout)
 	{
 		// TODO: Validate these precondition checks (which could be
 		// automaticaly generated) with the team.
-		TITANIUM_ASSERT(arguments.size() >= 1);
-		const auto _0 = arguments.at(0);
-		TITANIUM_ASSERT(_0.IsNumber());
-		const auto timerId = static_cast<unsigned>(_0);
+		ENSURE_UINT_AT_INDEX(timerId, 0);
 
 		const auto global_object = this_object.get_context().get_global_object();
 		const auto global_ptr = global_object.GetPrivate<GlobalObject>();
@@ -503,35 +494,29 @@ namespace Titanium
 		return this_object.get_context().CreateUndefined();
 	}
 
-	JSValue GlobalObject::js_setInterval(const std::vector<JSValue>& arguments, JSObject& this_object)
+	TITANIUM_MODULE_FUNCTION(GlobalObject, setInterval)
 	{
 		// TODO: Validate these precondition checks (which could be
 		// automaticaly generated) with the team.
-		TITANIUM_ASSERT(arguments.size() >= 2);
-		const auto _0 = arguments.at(0);
-		const auto _1 = arguments.at(1);
-		TITANIUM_ASSERT(_0.IsObject());
-		TITANIUM_ASSERT(_1.IsNumber());
-		JSObject function = static_cast<JSObject>(_0);
 		
+		ENSURE_OBJECT_AT_INDEX(function, 0);
+		ENSURE_UINT_AT_INDEX(delay, 1);
+
 		TITANIUM_ASSERT(function.IsFunction());
-		const auto delay = std::chrono::milliseconds(static_cast<std::chrono::milliseconds::rep>(static_cast<std::uint32_t>(_1)));
+		const auto chrono_delay = std::chrono::milliseconds(static_cast<std::chrono::milliseconds::rep>(delay));
 
 		const auto global_object = this_object.get_context().get_global_object();
 		const auto global_ptr = global_object.GetPrivate<GlobalObject>();
 		TITANIUM_ASSERT(global_ptr);
 
-		return this_object.get_context().CreateNumber(global_ptr->setInterval(std::move(function), delay));
+		return this_object.get_context().CreateNumber(global_ptr->setInterval(std::move(function), chrono_delay));
 	}
 
-	JSValue GlobalObject::js_clearInterval(const std::vector<JSValue>& arguments, JSObject& this_object)
+	TITANIUM_MODULE_FUNCTION(GlobalObject, clearInterval)
 	{
 		// TODO: Validate these precondition checks (which could be
 		// automaticaly generated) with the team.
-		TITANIUM_ASSERT(arguments.size() >= 1);
-		const auto _0 = arguments.at(0);
-		TITANIUM_ASSERT(_0.IsNumber());
-		const auto timerId = static_cast<unsigned>(_0);
+		ENSURE_UINT_AT_INDEX(timerId, 0);
 
 		const auto global_object = this_object.get_context().get_global_object();
 		const auto global_ptr = global_object.GetPrivate<GlobalObject>();

--- a/Source/TitaniumKit/src/UI/View.cpp
+++ b/Source/TitaniumKit/src/UI/View.cpp
@@ -43,150 +43,140 @@ namespace Titanium
 			JSExport<View>::SetClassVersion(1);
 			JSExport<View>::SetParent(JSExport<Module>::Class());
 			// methods
-			JSExport<View>::AddFunctionProperty("add", std::mem_fn(&View::js_add));
-			JSExport<View>::AddFunctionProperty("animate", std::mem_fn(&View::js_animate));
-			JSExport<View>::AddFunctionProperty("hide", std::mem_fn(&View::js_hide));
-			JSExport<View>::AddFunctionProperty("show", std::mem_fn(&View::js_show));
+
+			TITANIUM_MODULE_ADD_FUNCTION(View, add);
+			TITANIUM_MODULE_ADD_FUNCTION(View, animate);
+			TITANIUM_MODULE_ADD_FUNCTION(View, hide);
+			TITANIUM_MODULE_ADD_FUNCTION(View, show);
+
 			// properties
-			
-			JSExport<View>::AddValueProperty("backgroundColor", std::mem_fn(&View::js_get_backgroundColor), std::mem_fn(&View::js_set_backgroundColor));
-			JSExport<View>::AddValueProperty("borderColor", std::mem_fn(&View::js_get_borderColor), std::mem_fn(&View::js_set_borderColor));
-			JSExport<View>::AddValueProperty("borderRadius", std::mem_fn(&View::js_get_borderRadius), std::mem_fn(&View::js_set_borderRadius));
-			JSExport<View>::AddValueProperty("borderWidth", std::mem_fn(&View::js_get_borderWidth), std::mem_fn(&View::js_set_borderWidth));
-			JSExport<View>::AddValueProperty("bottom", std::mem_fn(&View::js_get_bottom), std::mem_fn(&View::js_set_bottom));
-			JSExport<View>::AddValueProperty("center", std::mem_fn(&View::js_get_center), std::mem_fn(&View::js_set_center));
-			JSExport<View>::AddValueProperty("children", std::mem_fn(&View::js_get_children));
-			JSExport<View>::AddValueProperty("height", std::mem_fn(&View::js_get_height), std::mem_fn(&View::js_set_height));
-			JSExport<View>::AddValueProperty("layout", std::mem_fn(&View::js_get_layout), std::mem_fn(&View::js_set_layout));
-			JSExport<View>::AddValueProperty("left", std::mem_fn(&View::js_get_left), std::mem_fn(&View::js_set_left));
-			JSExport<View>::AddValueProperty("opacity", std::mem_fn(&View::js_get_opacity), std::mem_fn(&View::js_set_opacity));
-			JSExport<View>::AddValueProperty("rect", std::mem_fn(&View::js_get_rect));
-			JSExport<View>::AddValueProperty("right", std::mem_fn(&View::js_get_right), std::mem_fn(&View::js_set_right));
-			JSExport<View>::AddValueProperty("size", std::mem_fn(&View::js_get_size));
-			JSExport<View>::AddValueProperty("tintColor", std::mem_fn(&View::js_get_tintColor), std::mem_fn(&View::js_set_tintColor));
-			JSExport<View>::AddValueProperty("top", std::mem_fn(&View::js_get_top), std::mem_fn(&View::js_set_top));
-			JSExport<View>::AddValueProperty("touchEnabled", std::mem_fn(&View::js_get_touchEnabled), std::mem_fn(&View::js_set_touchEnabled));
-			JSExport<View>::AddValueProperty("visible", std::mem_fn(&View::js_get_visible), std::mem_fn(&View::js_set_visible));
-			JSExport<View>::AddValueProperty("width", std::mem_fn(&View::js_get_width), std::mem_fn(&View::js_set_width));
+			TITANIUM_MODULE_ADD_PROPERTY(View, backgroundColor);
+			TITANIUM_MODULE_ADD_PROPERTY(View, borderColor);
+			TITANIUM_MODULE_ADD_PROPERTY(View, borderRadius);
+			TITANIUM_MODULE_ADD_PROPERTY(View, borderWidth);
+			TITANIUM_MODULE_ADD_PROPERTY(View, bottom);
+			TITANIUM_MODULE_ADD_PROPERTY(View, center);
+			TITANIUM_MODULE_ADD_PROPERTY_READONLY(View, children);
+			TITANIUM_MODULE_ADD_PROPERTY(View, height);
+			TITANIUM_MODULE_ADD_PROPERTY(View, layout);
+			TITANIUM_MODULE_ADD_PROPERTY(View, left);
+			TITANIUM_MODULE_ADD_PROPERTY(View, opacity);
+			TITANIUM_MODULE_ADD_PROPERTY_READONLY(View, rect);
+			TITANIUM_MODULE_ADD_PROPERTY(View, right);
+			TITANIUM_MODULE_ADD_PROPERTY_READONLY(View, size);
+			TITANIUM_MODULE_ADD_PROPERTY(View, tintColor);
+			TITANIUM_MODULE_ADD_PROPERTY(View, top);
+			TITANIUM_MODULE_ADD_PROPERTY(View, touchEnabled);
+			TITANIUM_MODULE_ADD_PROPERTY(View, visible);
+			TITANIUM_MODULE_ADD_PROPERTY(View, width);
 		}
 
-		JSValue View::js_add(const std::vector<JSValue>& arguments, JSObject& this_object) TITANIUM_NOEXCEPT
+		TITANIUM_MODULE_FUNCTION(View, add)
 		{
-			TITANIUM_ASSERT(arguments.size() >= 1);
-			const auto _0 = arguments.at(0);
-			TITANIUM_ASSERT(_0.IsObject());
-			JSObject view = static_cast<JSObject>(_0);
+			ENSURE_OBJECT_AT_INDEX(view, 0);
 			layoutDelegate__->add(view.GetPrivate<View>());
 			return get_context().CreateUndefined();
 		}
 
-		JSValue View::js_animate(const std::vector<JSValue>& arguments, JSObject& this_object) TITANIUM_NOEXCEPT
+		TITANIUM_MODULE_FUNCTION(View, animate)
 		{
-			TITANIUM_ASSERT(arguments.size() >= 1);
-			const auto _0 = arguments.at(0);
-			TITANIUM_ASSERT(_0.IsObject());
-			JSObject animation = static_cast<JSObject>(_0);
+			ENSURE_OBJECT_AT_INDEX(animation, 0);
 			// TODO Convert the animation object into a Ti.UI.Animation if it isn't one already?
 
-			JSObject callback = this_object.get_context().CreateObject();
-			if (arguments.size() > 1) {
-				const auto _1 = arguments.at(1);
-				TITANIUM_ASSERT(_1.IsObject());
-				callback = static_cast<JSObject>(_1);
-				TITANIUM_ASSERT(callback.IsFunction());
-			}
+			ENSURE_OPTIONAL_OBJECT_AT_INDEX(callback, 1);
+			TITANIUM_ASSERT(callback.IsFunction());
 
 			animate(animation, callback);
 			return get_context().CreateUndefined();
 		}
 
-		JSValue View::js_hide(const std::vector<JSValue>& arguments, JSObject& this_object) TITANIUM_NOEXCEPT
+		TITANIUM_MODULE_FUNCTION(View, hide)
 		{
 			TITANIUM_ASSERT(arguments.size() == 0);
 			layoutDelegate__->hide();
 			return get_context().CreateUndefined();
 		}
 
-		JSValue View::js_show(const std::vector<JSValue>& arguments, JSObject& this_object) TITANIUM_NOEXCEPT
+		TITANIUM_MODULE_FUNCTION(View, show)
 		{
 			TITANIUM_ASSERT(arguments.size() == 0);
 			layoutDelegate__->show();
 			return get_context().CreateUndefined();
 		}
 
-		JSValue View::js_get_backgroundColor() const TITANIUM_NOEXCEPT
+		TITANIUM_MODULE_PROPERTY_GETTER(View, backgroundColor)
 		{
 			return get_context().CreateString(layoutDelegate__->get_backgroundColor());
 		}
 
-		bool View::js_set_backgroundColor(const JSValue& argument) TITANIUM_NOEXCEPT
+		TITANIUM_MODULE_PROPERTY_SETTER(View, backgroundColor)
 		{
 			TITANIUM_ASSERT(argument.IsString());
 			layoutDelegate__->set_backgroundColor(static_cast<std::string>(argument));
 			return true;
 		}
 
-		JSValue View::js_get_borderColor() const TITANIUM_NOEXCEPT
+		TITANIUM_MODULE_PROPERTY_GETTER(View, borderColor)
 		{
 			return get_context().CreateString(layoutDelegate__->get_borderColor());
 		}
 
-		bool View::js_set_borderColor(const JSValue& argument) TITANIUM_NOEXCEPT
+		TITANIUM_MODULE_PROPERTY_SETTER(View, borderColor)
 		{
 			TITANIUM_ASSERT(argument.IsString());
 			layoutDelegate__->set_borderColor(static_cast<std::string>(argument));
 			return true;
 		}
 
-		JSValue View::js_get_borderRadius() const TITANIUM_NOEXCEPT
+		TITANIUM_MODULE_PROPERTY_GETTER(View, borderRadius)
 		{
 			return get_context().CreateNumber(layoutDelegate__->get_borderRadius());
 		}
 
-		bool View::js_set_borderRadius(const JSValue& argument) TITANIUM_NOEXCEPT
+		TITANIUM_MODULE_PROPERTY_SETTER(View, borderRadius)
 		{
 			TITANIUM_ASSERT(argument.IsNumber());
 			layoutDelegate__->set_borderRadius(static_cast<uint32_t>(argument));
 			return true;
 		}
 
-		JSValue View::js_get_borderWidth() const TITANIUM_NOEXCEPT
+		TITANIUM_MODULE_PROPERTY_GETTER(View, borderWidth)
 		{
 			return get_context().CreateNumber(layoutDelegate__->get_borderWidth());
 		}
 
-		bool View::js_set_borderWidth(const JSValue& argument) TITANIUM_NOEXCEPT
+		TITANIUM_MODULE_PROPERTY_SETTER(View, borderWidth)
 		{
 			TITANIUM_ASSERT(argument.IsNumber());
 			layoutDelegate__->set_borderWidth(static_cast<uint32_t>(argument));
 			return true;
 		}
 
-		JSValue View::js_get_bottom() const TITANIUM_NOEXCEPT
+		TITANIUM_MODULE_PROPERTY_GETTER(View, bottom)
 		{
 			return get_context().CreateString(layoutDelegate__->get_bottom());
 		}
 
-		bool View::js_set_bottom(const JSValue& argument) TITANIUM_NOEXCEPT
+		TITANIUM_MODULE_PROPERTY_SETTER(View, bottom)
 		{
 			TITANIUM_ASSERT(argument.IsString() || argument.IsNumber());
 			layoutDelegate__->set_bottom(static_cast<std::string>(argument));
 			return true;
 		}
 
-		bool View::js_set_center(const JSValue& argument) TITANIUM_NOEXCEPT
+		TITANIUM_MODULE_PROPERTY_SETTER(View, center)
 		{
 			TITANIUM_ASSERT(argument.IsObject());
 			layoutDelegate__->set_center(js_to_Point(static_cast<JSObject>(argument)));
 			return true;
 		}
 		
-		JSValue View::js_get_center() const TITANIUM_NOEXCEPT
+		TITANIUM_MODULE_PROPERTY_GETTER(View, center)
 		{
 			return Point_to_js(get_context(), layoutDelegate__->get_center());
 		}
 
-		JSValue View::js_get_children() const TITANIUM_NOEXCEPT
+		TITANIUM_MODULE_PROPERTY_GETTER(View, children)
 		{
 			std::vector<JSValue> js_children;
 			const auto children = layoutDelegate__->get_children();
@@ -196,48 +186,48 @@ namespace Titanium
 			return get_context().CreateArray(js_children);
 		}
 
-		JSValue View::js_get_height() const TITANIUM_NOEXCEPT
+		TITANIUM_MODULE_PROPERTY_GETTER(View, height)
 		{
 			return get_context().CreateString(layoutDelegate__->get_height());
 		}
 
-		bool View::js_set_height(const JSValue& argument) TITANIUM_NOEXCEPT
+		TITANIUM_MODULE_PROPERTY_SETTER(View, height)
 		{
 			TITANIUM_ASSERT(argument.IsString() || argument.IsNumber());
 			layoutDelegate__->set_height(static_cast<std::string>(argument));
 			return true;
 		}
 
-		JSValue View::js_get_layout() const TITANIUM_NOEXCEPT
+		TITANIUM_MODULE_PROPERTY_GETTER(View, layout)
 		{
 			return get_context().CreateString(layoutDelegate__->get_layout());
 		}
 
-		bool View::js_set_layout(const JSValue& argument) TITANIUM_NOEXCEPT
+		TITANIUM_MODULE_PROPERTY_SETTER(View, layout)
 		{
 			TITANIUM_ASSERT(argument.IsString());
 			layoutDelegate__->set_layout(static_cast<std::string>(argument));
 			return true;
 		}
 
-		JSValue View::js_get_left() const TITANIUM_NOEXCEPT
+		TITANIUM_MODULE_PROPERTY_GETTER(View, left)
 		{
 			return get_context().CreateString(layoutDelegate__->get_left());
 		}
 
-		bool View::js_set_left(const JSValue& argument) TITANIUM_NOEXCEPT
+		TITANIUM_MODULE_PROPERTY_SETTER(View, left)
 		{
 			TITANIUM_ASSERT(argument.IsString() || argument.IsNumber());
 			layoutDelegate__->set_left(static_cast<std::string>(argument));
 			return true;
 		}
 
-		JSValue View::js_get_opacity() const TITANIUM_NOEXCEPT
+		TITANIUM_MODULE_PROPERTY_GETTER(View, opacity)
 		{
 			return get_context().CreateNumber(layoutDelegate__->get_opacity());
 		}
 
-		bool View::js_set_opacity(const JSValue& argument) TITANIUM_NOEXCEPT
+		TITANIUM_MODULE_PROPERTY_SETTER(View, opacity)
 		{
 			if (argument.IsNumber()) {
 				layoutDelegate__->set_opacity(static_cast<double>(argument));
@@ -245,46 +235,46 @@ namespace Titanium
 			return true;
 		}
 
-		JSValue View::js_get_rect() const TITANIUM_NOEXCEPT
+		TITANIUM_MODULE_PROPERTY_GETTER(View, rect)
 		{
 			return Titanium::UI::Dimension_to_js(get_context(), layoutDelegate__->get_rect());
 		}
 
-		JSValue View::js_get_right() const TITANIUM_NOEXCEPT
+		TITANIUM_MODULE_PROPERTY_GETTER(View, right)
 		{
 			return get_context().CreateString(layoutDelegate__->get_right());
 		}
 
-		bool View::js_set_right(const JSValue& argument) TITANIUM_NOEXCEPT
+		TITANIUM_MODULE_PROPERTY_SETTER(View, right)
 		{
 			TITANIUM_ASSERT(argument.IsString() || argument.IsNumber());
 			layoutDelegate__->set_right(static_cast<std::string>(argument));
 			return true;
 		}
 
-		JSValue View::js_get_size() const TITANIUM_NOEXCEPT
+		TITANIUM_MODULE_PROPERTY_GETTER(View, size)
 		{
 			return Titanium::UI::Dimension_to_js(get_context(), layoutDelegate__->get_size());
 		}
 
-		JSValue View::js_get_tintColor() const TITANIUM_NOEXCEPT
+		TITANIUM_MODULE_PROPERTY_GETTER(View, tintColor)
 		{
 			return get_context().CreateString(layoutDelegate__->get_tintColor());
 		}
 
-		bool View::js_set_tintColor(const JSValue& argument) TITANIUM_NOEXCEPT
+		TITANIUM_MODULE_PROPERTY_SETTER(View, tintColor)
 		{
 			TITANIUM_ASSERT(argument.IsString());
 			layoutDelegate__->set_tintColor(static_cast<std::string>(argument));
 			return true;
 		}
 
-		JSValue View::js_get_top() const TITANIUM_NOEXCEPT
+		TITANIUM_MODULE_PROPERTY_GETTER(View, top)
 		{
 			return get_context().CreateString(layoutDelegate__->get_top());
 		}
 
-		bool View::js_set_top(const JSValue& argument) TITANIUM_NOEXCEPT
+		TITANIUM_MODULE_PROPERTY_SETTER(View, top)
 		{
 			// FIXME What does setting top to null mean? Because corporate directory does it...
 			if (argument.IsNull()) {
@@ -295,36 +285,36 @@ namespace Titanium
 			return true;
 		}
 
-		JSValue View::js_get_touchEnabled() const TITANIUM_NOEXCEPT
+		TITANIUM_MODULE_PROPERTY_GETTER(View, touchEnabled)
 		{
 			return get_context().CreateBoolean(layoutDelegate__->get_touchEnabled());
 		}
 
-		bool View::js_set_touchEnabled(const JSValue& argument) TITANIUM_NOEXCEPT
+		TITANIUM_MODULE_PROPERTY_SETTER(View, touchEnabled)
 		{
 			TITANIUM_ASSERT(argument.IsBoolean());
 			layoutDelegate__->set_touchEnabled(static_cast<bool>(argument));
 			return true;
 		}
 
-		JSValue View::js_get_visible() const TITANIUM_NOEXCEPT
+		TITANIUM_MODULE_PROPERTY_GETTER(View, visible)
 		{
 			return get_context().CreateBoolean(layoutDelegate__->get_visible());
 		}
 
-		bool View::js_set_visible(const JSValue& argument) TITANIUM_NOEXCEPT
+		TITANIUM_MODULE_PROPERTY_SETTER(View, visible)
 		{
 			TITANIUM_ASSERT(argument.IsBoolean());
 			layoutDelegate__->set_visible(static_cast<bool>(argument));
 			return true;
 		}
 
-		JSValue View::js_get_width() const TITANIUM_NOEXCEPT
+		TITANIUM_MODULE_PROPERTY_GETTER(View, width)
 		{
 			return get_context().CreateString(layoutDelegate__->get_width());
 		}
 
-		bool View::js_set_width(const JSValue& argument) TITANIUM_NOEXCEPT
+		TITANIUM_MODULE_PROPERTY_SETTER(View, width)
 		{
 			TITANIUM_ASSERT(argument.IsString() || argument.IsNumber());
 			layoutDelegate__->set_width(static_cast<std::string>(argument));

--- a/Source/TitaniumKit/src/UIModule.cpp
+++ b/Source/TitaniumKit/src/UIModule.cpp
@@ -9,6 +9,20 @@
 #include "Titanium/UIModule.hpp"
 #include <sstream>
 
+#define CREATE_TITANIUM_UI(NAME) \
+  JSValue Titanium_property = this_object.get_context().get_global_object().GetProperty("Titanium"); \
+  TITANIUM_ASSERT(Titanium_property.IsObject()); \
+  JSObject Titanium = static_cast<JSObject>(Titanium_property); \
+  JSValue UI_property = Titanium.GetProperty("UI"); \
+  TITANIUM_ASSERT(UI_property.IsObject()); \
+  JSObject UI = static_cast<JSObject>(UI_property); \
+  JSValue NAME##_property = UI.GetProperty(#NAME); \
+  TITANIUM_ASSERT(NAME##_property.IsObject()); \
+  JSObject NAME = static_cast<JSObject>(NAME##_property); \
+  auto NAME##_obj = NAME.CallAsConstructor(parameters); \
+  Titanium::applyProperties(NAME##_obj, parameters); \
+  return NAME##_obj;
+
 namespace Titanium
 {
 	static void applyProperties(JSObject& view, const JSObject& parameters)
@@ -139,190 +153,55 @@ namespace Titanium
 	JSObject UIModule::createAlertDialog(const JSObject& parameters, JSObject& this_object) TITANIUM_NOEXCEPT
 	{
 		TITANIUM_LOG_DEBUG("UI::createAlertDialog");
-
-		JSValue Titanium_property = this_object.get_context().get_global_object().GetProperty("Titanium");
-		TITANIUM_ASSERT(Titanium_property.IsObject());  // precondition
-		JSObject Titanium = static_cast<JSObject>(Titanium_property);
-
-		JSValue UI_property = Titanium.GetProperty("UI");
-		TITANIUM_ASSERT(UI_property.IsObject());  // precondition
-		JSObject UI = static_cast<JSObject>(UI_property);
-
-		JSValue AlertDialog_property = UI.GetProperty("AlertDialog");
-		TITANIUM_ASSERT(AlertDialog_property.IsObject());  // precondition
-		JSObject AlertDialog = static_cast<JSObject>(AlertDialog_property);
-
-		auto alertDialog = AlertDialog.CallAsConstructor(parameters);
-		Titanium::applyProperties(alertDialog, parameters);
-		return alertDialog;
+		CREATE_TITANIUM_UI(AlertDialog);
 	}
 
 	JSObject UIModule::createAnimation(const JSObject& parameters, JSObject& this_object) TITANIUM_NOEXCEPT
 	{
 		TITANIUM_LOG_DEBUG("UI::createAnimation");
-
-		JSValue Titanium_property = this_object.get_context().get_global_object().GetProperty("Titanium");
-		TITANIUM_ASSERT(Titanium_property.IsObject());  // precondition
-		JSObject Titanium = static_cast<JSObject>(Titanium_property);
-
-		JSValue UI_property = Titanium.GetProperty("UI");
-		TITANIUM_ASSERT(UI_property.IsObject());  // precondition
-		JSObject UI = static_cast<JSObject>(UI_property);
-
-		JSValue Animation_property = UI.GetProperty("Animation");
-		TITANIUM_ASSERT(Animation_property.IsObject());  // precondition
-		JSObject Animation = static_cast<JSObject>(Animation_property);
-
-		auto animation = Animation.CallAsConstructor(parameters);
-		Titanium::applyProperties(animation, parameters);
-		return animation;
+		CREATE_TITANIUM_UI(Animation);
 	}
 
 	JSObject UIModule::createButton(const JSObject& parameters, JSObject& this_object) TITANIUM_NOEXCEPT
 	{
 		TITANIUM_LOG_DEBUG("UI::createButton");
-
-		JSValue Titanium_property = this_object.get_context().get_global_object().GetProperty("Titanium");
-		TITANIUM_ASSERT(Titanium_property.IsObject());  // precondition
-		JSObject Titanium = static_cast<JSObject>(Titanium_property);
-
-		JSValue UI_property = Titanium.GetProperty("UI");
-		TITANIUM_ASSERT(UI_property.IsObject());  // precondition
-		JSObject UI = static_cast<JSObject>(UI_property);
-
-		JSValue Button_property = UI.GetProperty("Button");
-		TITANIUM_ASSERT(Button_property.IsObject());  // precondition
-		JSObject Button = static_cast<JSObject>(Button_property);
-
-		auto button = Button.CallAsConstructor(parameters);
-		Titanium::applyProperties(button, parameters);
-		return button;
+		CREATE_TITANIUM_UI(Button);
 	}
 
 	JSObject UIModule::createEmailDialog(const JSObject& parameters, JSObject& this_object) TITANIUM_NOEXCEPT
 	{
 		TITANIUM_LOG_DEBUG("UI::createEmailDialog");
-
-		JSValue Titanium_property = this_object.get_context().get_global_object().GetProperty("Titanium");
-		TITANIUM_ASSERT(Titanium_property.IsObject());  // precondition
-		JSObject Titanium = static_cast<JSObject>(Titanium_property);
-
-		JSValue UI_property = Titanium.GetProperty("UI");
-		TITANIUM_ASSERT(UI_property.IsObject());  // precondition
-		JSObject UI = static_cast<JSObject>(UI_property);
-
-		JSValue EmailDialog_property = UI.GetProperty("EmailDialog");
-		TITANIUM_ASSERT(EmailDialog_property.IsObject());  // precondition
-		JSObject EmailDialog = static_cast<JSObject>(EmailDialog_property);
-
-		auto emailDialog = EmailDialog.CallAsConstructor(parameters);
-		Titanium::applyProperties(emailDialog, parameters);
-		return emailDialog;
+		CREATE_TITANIUM_UI(EmailDialog);
 	}
 
 	JSObject UIModule::createImageView(const JSObject& parameters, JSObject& this_object) TITANIUM_NOEXCEPT
 	{
 		TITANIUM_LOG_DEBUG("UI::createImageView");
-
-		JSValue Titanium_property = this_object.get_context().get_global_object().GetProperty("Titanium");
-		TITANIUM_ASSERT(Titanium_property.IsObject());  // precondition
-		JSObject Titanium = static_cast<JSObject>(Titanium_property);
-
-		JSValue UI_property = Titanium.GetProperty("UI");
-		TITANIUM_ASSERT(UI_property.IsObject());  // precondition
-		JSObject UI = static_cast<JSObject>(UI_property);
-
-		JSValue ImageView_property = UI.GetProperty("ImageView");
-		TITANIUM_ASSERT(ImageView_property.IsObject());  // precondition
-		JSObject ImageView = static_cast<JSObject>(ImageView_property);
-
-		auto image_view = ImageView.CallAsConstructor(parameters);
-		Titanium::applyProperties(image_view, parameters);
-		return image_view;
+		CREATE_TITANIUM_UI(ImageView);
 	}
 
 	JSObject UIModule::createLabel(const JSObject& parameters, JSObject& this_object) TITANIUM_NOEXCEPT
 	{
 		TITANIUM_LOG_DEBUG("UI::createLabel");
-
-		JSValue Titanium_property = this_object.get_context().get_global_object().GetProperty("Titanium");
-		TITANIUM_ASSERT(Titanium_property.IsObject());  // precondition
-		JSObject Titanium = static_cast<JSObject>(Titanium_property);
-
-		JSValue UI_property = Titanium.GetProperty("UI");
-		TITANIUM_ASSERT(UI_property.IsObject());  // precondition
-		JSObject UI = static_cast<JSObject>(UI_property);
-
-		JSValue Label_property = UI.GetProperty("Label");
-		TITANIUM_ASSERT(Label_property.IsObject());  // precondition
-		JSObject Label = static_cast<JSObject>(Label_property);
-
-		auto label = Label.CallAsConstructor(parameters);
-		Titanium::applyProperties(label, parameters);
-		return label;
+		CREATE_TITANIUM_UI(Label);
 	}
 
 	JSObject UIModule::createScrollView(const JSObject& parameters, JSObject& this_object) TITANIUM_NOEXCEPT
 	{
 		TITANIUM_LOG_DEBUG("UI::createScrollView");
-
-		JSValue Titanium_property = this_object.get_context().get_global_object().GetProperty("Titanium");
-		TITANIUM_ASSERT(Titanium_property.IsObject());  // precondition
-		JSObject Titanium = static_cast<JSObject>(Titanium_property);
-
-		JSValue UI_property = Titanium.GetProperty("UI");
-		TITANIUM_ASSERT(UI_property.IsObject());  // precondition
-		JSObject UI = static_cast<JSObject>(UI_property);
-
-		JSValue ScrollView_property = UI.GetProperty("ScrollView");
-		TITANIUM_ASSERT(ScrollView_property.IsObject());  // precondition
-		JSObject ScrollView = static_cast<JSObject>(ScrollView_property);
-
-		auto view = ScrollView.CallAsConstructor(parameters);
-		Titanium::applyProperties(view, parameters);
-		return view;
+		CREATE_TITANIUM_UI(ScrollView);
 	}
 
 	JSObject UIModule::createSlider(const JSObject& parameters, JSObject& this_object) TITANIUM_NOEXCEPT
 	{
 		TITANIUM_LOG_DEBUG("UI::createSlider");
-
-		JSValue Titanium_property = this_object.get_context().get_global_object().GetProperty("Titanium");
-		TITANIUM_ASSERT(Titanium_property.IsObject());  // precondition
-		JSObject Titanium = static_cast<JSObject>(Titanium_property);
-
-		JSValue UI_property = Titanium.GetProperty("UI");
-		TITANIUM_ASSERT(UI_property.IsObject());  // precondition
-		JSObject UI = static_cast<JSObject>(UI_property);
-
-		JSValue Slider_property = UI.GetProperty("Slider");
-		TITANIUM_ASSERT(Slider_property.IsObject());  // precondition
-		JSObject Slider = static_cast<JSObject>(Slider_property);
-
-		auto slider = Slider.CallAsConstructor(parameters);
-		Titanium::applyProperties(slider, parameters);
-		return slider;
+		CREATE_TITANIUM_UI(Slider);
 	}
 
 	JSObject UIModule::createSwitch(const JSObject& parameters, JSObject& this_object) TITANIUM_NOEXCEPT
 	{
 		TITANIUM_LOG_DEBUG("UI::createSwitch");
-
-		JSValue Titanium_property = this_object.get_context().get_global_object().GetProperty("Titanium");
-		TITANIUM_ASSERT(Titanium_property.IsObject());  // precondition
-		JSObject Titanium = static_cast<JSObject>(Titanium_property);
-
-		JSValue UI_property = Titanium.GetProperty("UI");
-		TITANIUM_ASSERT(UI_property.IsObject());  // precondition
-		JSObject UI = static_cast<JSObject>(UI_property);
-
-		JSValue Switch_property = UI.GetProperty("Switch");
-		TITANIUM_ASSERT(Switch_property.IsObject());  // precondition
-		JSObject Switch = static_cast<JSObject>(Switch_property);
-
-		auto switch_ = Switch.CallAsConstructor(parameters);
-		Titanium::applyProperties(switch_, parameters);
-		return switch_;
+		CREATE_TITANIUM_UI(Switch);
 	}
 
 	JSObject UIModule::createTab(const JSObject& parameters, JSObject& this_object) TITANIUM_NOEXCEPT
@@ -483,211 +362,61 @@ namespace Titanium
 	JSObject UIModule::createTextField(const JSObject& parameters, JSObject& this_object) TITANIUM_NOEXCEPT
 	{
 		TITANIUM_LOG_DEBUG("UI::createTextField");
-
-		JSValue Titanium_property = this_object.get_context().get_global_object().GetProperty("Titanium");
-		TITANIUM_ASSERT(Titanium_property.IsObject());  // precondition
-		JSObject Titanium = static_cast<JSObject>(Titanium_property);
-
-		JSValue UI_property = Titanium.GetProperty("UI");
-		TITANIUM_ASSERT(UI_property.IsObject());  // precondition
-		JSObject UI = static_cast<JSObject>(UI_property);
-
-		JSValue TextField_property = UI.GetProperty("TextField");
-		TITANIUM_ASSERT(TextField_property.IsObject());  // precondition
-		JSObject TextField = static_cast<JSObject>(TextField_property);
-
-		auto textField = TextField.CallAsConstructor(parameters);
-		Titanium::applyProperties(textField, parameters);
-		return textField;
+		CREATE_TITANIUM_UI(TextField);
 	}
 
 	JSObject UIModule::createListView(const JSObject& parameters, JSObject& this_object) TITANIUM_NOEXCEPT
 	{
 		TITANIUM_LOG_DEBUG("UI::createListView");
-
-		JSValue Titanium_property = this_object.get_context().get_global_object().GetProperty("Titanium");
-		TITANIUM_ASSERT(Titanium_property.IsObject());  // precondition
-		JSObject Titanium = static_cast<JSObject>(Titanium_property);
-
-		JSValue UI_property = Titanium.GetProperty("UI");
-		TITANIUM_ASSERT(UI_property.IsObject());  // precondition
-		JSObject UI = static_cast<JSObject>(UI_property);
-
-		JSValue View_property = UI.GetProperty("ListView");
-		TITANIUM_ASSERT(View_property.IsObject());  // precondition
-		JSObject View = static_cast<JSObject>(View_property);
-
-		auto view = View.CallAsConstructor(parameters);
-		Titanium::applyProperties(view, parameters);
-		return view;
+		CREATE_TITANIUM_UI(ListView);
 	}
 
 	JSObject UIModule::createListSection(const JSObject& parameters, JSObject& this_object) TITANIUM_NOEXCEPT
 	{
 		TITANIUM_LOG_DEBUG("UI::createListSection");
-
-		JSValue Titanium_property = this_object.get_context().get_global_object().GetProperty("Titanium");
-		TITANIUM_ASSERT(Titanium_property.IsObject());  // precondition
-		JSObject Titanium = static_cast<JSObject>(Titanium_property);
-
-		JSValue UI_property = Titanium.GetProperty("UI");
-		TITANIUM_ASSERT(UI_property.IsObject());  // precondition
-		JSObject UI = static_cast<JSObject>(UI_property);
-
-		JSValue View_property = UI.GetProperty("ListSection");
-		TITANIUM_ASSERT(View_property.IsObject());  // precondition
-		JSObject View = static_cast<JSObject>(View_property);
-
-		auto view = View.CallAsConstructor(parameters);
-		Titanium::applyProperties(view, parameters);
-		return view;
+		CREATE_TITANIUM_UI(ListSection);
 	}
 
 	JSObject UIModule::createListItem(const JSObject& parameters, JSObject& this_object) TITANIUM_NOEXCEPT
 	{
 		TITANIUM_LOG_DEBUG("UI::createListItem");
-
-		JSValue Titanium_property = this_object.get_context().get_global_object().GetProperty("Titanium");
-		TITANIUM_ASSERT(Titanium_property.IsObject());  // precondition
-		JSObject Titanium = static_cast<JSObject>(Titanium_property);
-
-		JSValue UI_property = Titanium.GetProperty("UI");
-		TITANIUM_ASSERT(UI_property.IsObject());  // precondition
-		JSObject UI = static_cast<JSObject>(UI_property);
-
-		JSValue View_property = UI.GetProperty("ListItem");
-		TITANIUM_ASSERT(View_property.IsObject());  // precondition
-		JSObject View = static_cast<JSObject>(View_property);
-
-		auto view = View.CallAsConstructor(parameters);
-		Titanium::applyProperties(view, parameters);
-		return view;
+		CREATE_TITANIUM_UI(ListItem);
 	}
 
 	JSObject UIModule::createView(const JSObject& parameters, JSObject& this_object) TITANIUM_NOEXCEPT
 	{
 		TITANIUM_LOG_DEBUG("UI::createView");
-
-		JSValue Titanium_property = this_object.get_context().get_global_object().GetProperty("Titanium");
-		TITANIUM_ASSERT(Titanium_property.IsObject());  // precondition
-		JSObject Titanium = static_cast<JSObject>(Titanium_property);
-
-		JSValue UI_property = Titanium.GetProperty("UI");
-		TITANIUM_ASSERT(UI_property.IsObject());  // precondition
-		JSObject UI = static_cast<JSObject>(UI_property);
-
-		JSValue View_property = UI.GetProperty("View");
-		TITANIUM_ASSERT(View_property.IsObject());  // precondition
-		JSObject View = static_cast<JSObject>(View_property);
-
-		auto view = View.CallAsConstructor(parameters);
-		Titanium::applyProperties(view, parameters);
-		return view;
+		CREATE_TITANIUM_UI(View);
 	}
 
 	JSObject UIModule::createWindow(const JSObject& parameters, JSObject& this_object) TITANIUM_NOEXCEPT
 	{
 		TITANIUM_LOG_DEBUG("UI::createWindow");
-
-		JSValue Titanium_property = this_object.get_context().get_global_object().GetProperty("Titanium");
-		TITANIUM_ASSERT(Titanium_property.IsObject());  // precondition
-		JSObject Titanium = static_cast<JSObject>(Titanium_property);
-
-		JSValue UI_property = Titanium.GetProperty("UI");
-		TITANIUM_ASSERT(UI_property.IsObject());  // precondition
-		JSObject UI = static_cast<JSObject>(UI_property);
-
-		JSValue Window_property = UI.GetProperty("Window");
-		TITANIUM_ASSERT(Window_property.IsObject());  // precondition
-		JSObject Window = static_cast<JSObject>(Window_property);
-
-		auto window = Window.CallAsConstructor(parameters);
-		Titanium::applyProperties(window, parameters);
-		return window;
+		CREATE_TITANIUM_UI(Window);
 	}
 
 	JSObject UIModule::createWebView(const JSObject& parameters, JSObject& this_object) TITANIUM_NOEXCEPT
 	{
 		TITANIUM_LOG_DEBUG("UI::createWebView");
-
-		JSValue Titanium_property = this_object.get_context().get_global_object().GetProperty("Titanium");
-		TITANIUM_ASSERT(Titanium_property.IsObject());  // precondition
-		JSObject Titanium = static_cast<JSObject>(Titanium_property);
-
-		JSValue UI_property = Titanium.GetProperty("UI");
-		TITANIUM_ASSERT(UI_property.IsObject());  // precondition
-		JSObject UI = static_cast<JSObject>(UI_property);
-
-		JSValue WebView_property = UI.GetProperty("WebView");
-		TITANIUM_ASSERT(WebView_property.IsObject());  // precondition
-		JSObject WebView = static_cast<JSObject>(WebView_property);
-
-		auto webview = WebView.CallAsConstructor(parameters);
-		Titanium::applyProperties(webview, parameters);
-		return webview;
+		CREATE_TITANIUM_UI(WebView);
 	}
 
 	JSObject UIModule::createTableView(const JSObject& parameters, JSObject& this_object) TITANIUM_NOEXCEPT
 	{
 		TITANIUM_LOG_DEBUG("UI::createTableView");
-
-		JSValue Titanium_property = this_object.get_context().get_global_object().GetProperty("Titanium");
-		TITANIUM_ASSERT(Titanium_property.IsObject());  // precondition
-		JSObject Titanium = static_cast<JSObject>(Titanium_property);
-
-		JSValue UI_property = Titanium.GetProperty("UI");
-		TITANIUM_ASSERT(UI_property.IsObject());  // precondition
-		JSObject UI = static_cast<JSObject>(UI_property);
-
-		JSValue TableView_property = UI.GetProperty("TableView");
-		TITANIUM_ASSERT(TableView_property.IsObject());  // precondition
-		JSObject TableView = static_cast<JSObject>(TableView_property);
-
-		auto view = TableView.CallAsConstructor(parameters);
-		Titanium::applyProperties(view, parameters);
-		return view;
+		CREATE_TITANIUM_UI(TableView);
 	}
 
 	JSObject UIModule::createTableViewSection(const JSObject& parameters, JSObject& this_object) TITANIUM_NOEXCEPT
 	{
 		TITANIUM_LOG_DEBUG("UI::createTableViewSection");
-
-		JSValue Titanium_property = this_object.get_context().get_global_object().GetProperty("Titanium");
-		TITANIUM_ASSERT(Titanium_property.IsObject());  // precondition
-		JSObject Titanium = static_cast<JSObject>(Titanium_property);
-
-		JSValue UI_property = Titanium.GetProperty("UI");
-		TITANIUM_ASSERT(UI_property.IsObject());  // precondition
-		JSObject UI = static_cast<JSObject>(UI_property);
-
-		JSValue TableViewSection_property = UI.GetProperty("TableViewSection");
-		TITANIUM_ASSERT(TableViewSection_property.IsObject());  // precondition
-		JSObject TableViewSection = static_cast<JSObject>(TableViewSection_property);
-
-		auto view = TableViewSection.CallAsConstructor(parameters);
-		Titanium::applyProperties(view, parameters);
-		return view;
+		CREATE_TITANIUM_UI(TableViewSection);
 	}
 
 	JSObject UIModule::createTableViewRow(const JSObject& parameters, JSObject& this_object) TITANIUM_NOEXCEPT
 	{
 		TITANIUM_LOG_DEBUG("UI::createTableViewRow");
-
-		JSValue Titanium_property = this_object.get_context().get_global_object().GetProperty("Titanium");
-		TITANIUM_ASSERT(Titanium_property.IsObject());  // precondition
-		JSObject Titanium = static_cast<JSObject>(Titanium_property);
-
-		JSValue UI_property = Titanium.GetProperty("UI");
-		TITANIUM_ASSERT(UI_property.IsObject());  // precondition
-		JSObject UI = static_cast<JSObject>(UI_property);
-
-		JSValue TableViewRow_property = UI.GetProperty("TableViewRow");
-		TITANIUM_ASSERT(TableViewRow_property.IsObject());  // precondition
-		JSObject TableViewRow = static_cast<JSObject>(TableViewRow_property);
-
-		auto view = TableViewRow.CallAsConstructor(parameters);
-		Titanium::applyProperties(view, parameters);
-		return view;
+		CREATE_TITANIUM_UI(TableViewRow);
 	}
 
 	JSValue UIModule::ANIMATION_CURVE_EASE_IN() const TITANIUM_NOEXCEPT
@@ -1243,221 +972,121 @@ namespace Titanium
 
 	JSValue UIModule::js_createAlertDialog(const std::vector<JSValue>& arguments, JSObject& this_object)
 	{
-		JSObject parameters = this_object.get_context().CreateObject();
-		if (arguments.size() >= 1) {
-			const auto _0 = arguments.at(0);
-			TITANIUM_ASSERT(_0.IsObject());
-			parameters = static_cast<JSObject>(_0);
-		}
+		ENSURE_OPTIONAL_OBJECT_AT_INDEX(parameters, 0);
 		return createAlertDialog(parameters, this_object);
 	}
 
 	JSValue UIModule::js_createButton(const std::vector<JSValue>& arguments, JSObject& this_object)
 	{
-		JSObject parameters = this_object.get_context().CreateObject();
-		if (arguments.size() >= 1) {
-			const auto _0 = arguments.at(0);
-			TITANIUM_ASSERT(_0.IsObject());
-			parameters = static_cast<JSObject>(_0);
-		}
+		ENSURE_OPTIONAL_OBJECT_AT_INDEX(parameters, 0);
 		return createButton(parameters, this_object);
 	}
 
 	JSValue UIModule::js_createEmailDialog(const std::vector<JSValue>& arguments, JSObject& this_object)
 	{
-		JSObject parameters = this_object.get_context().CreateObject();
-		if (arguments.size() >= 1) {
-			const auto _0 = arguments.at(0);
-			TITANIUM_ASSERT(_0.IsObject());
-			parameters = static_cast<JSObject>(_0);
-		}
+		ENSURE_OPTIONAL_OBJECT_AT_INDEX(parameters, 0);
 		return createEmailDialog(parameters, this_object);
 	}
 
 	JSValue UIModule::js_createImageView(const std::vector<JSValue>& arguments, JSObject& this_object)
 	{
-		JSObject parameters = this_object.get_context().CreateObject();
-		if (arguments.size() >= 1) {
-			const auto _0 = arguments.at(0);
-			TITANIUM_ASSERT(_0.IsObject());
-			parameters = static_cast<JSObject>(_0);
-		}
+		ENSURE_OPTIONAL_OBJECT_AT_INDEX(parameters, 0);
 		return createImageView(parameters, this_object);
 	}
 
 	JSValue UIModule::js_createLabel(const std::vector<JSValue>& arguments, JSObject& this_object)
 	{
-		JSObject parameters = this_object.get_context().CreateObject();
-		if (arguments.size() >= 1) {
-			const auto _0 = arguments.at(0);
-			TITANIUM_ASSERT(_0.IsObject());
-			parameters = static_cast<JSObject>(_0);
-		}
+		ENSURE_OPTIONAL_OBJECT_AT_INDEX(parameters, 0);
 		return createLabel(parameters, this_object);
 	}
 
 	JSValue UIModule::js_createScrollView(const std::vector<JSValue>& arguments, JSObject& this_object)
 	{
-		JSObject parameters = this_object.get_context().CreateObject();
-		if (arguments.size() >= 1) {
-			const auto _0 = arguments.at(0);
-			TITANIUM_ASSERT(_0.IsObject());
-			parameters = static_cast<JSObject>(_0);
-		}
+		ENSURE_OPTIONAL_OBJECT_AT_INDEX(parameters, 0);
 		return createScrollView(parameters, this_object);
 	}
 
 	JSValue UIModule::js_createSlider(const std::vector<JSValue>& arguments, JSObject& this_object)
 	{
-		JSObject parameters = this_object.get_context().CreateObject();
-		if (arguments.size() >= 1) {
-			const auto _0 = arguments.at(0);
-			TITANIUM_ASSERT(_0.IsObject());
-			parameters = static_cast<JSObject>(_0);
-		}
+		ENSURE_OPTIONAL_OBJECT_AT_INDEX(parameters, 0);
 		return createSlider(parameters, this_object);
 	}
 
 	JSValue UIModule::js_createSwitch(const std::vector<JSValue>& arguments, JSObject& this_object)
 	{
-		JSObject parameters = this_object.get_context().CreateObject();
-		if (arguments.size() >= 1) {
-			const auto _0 = arguments.at(0);
-			TITANIUM_ASSERT(_0.IsObject());
-			parameters = static_cast<JSObject>(_0);
-		}
+		ENSURE_OPTIONAL_OBJECT_AT_INDEX(parameters, 0);
 		return createSwitch(parameters, this_object);
 	}
 
 	JSValue UIModule::js_createTab(const std::vector<JSValue>& arguments, JSObject& this_object)
 	{
-		JSObject parameters = this_object.get_context().CreateObject();
-		if (arguments.size() >= 1) {
-			const auto _0 = arguments.at(0);
-			TITANIUM_ASSERT(_0.IsObject());
-			parameters = static_cast<JSObject>(_0);
-		}
+		ENSURE_OPTIONAL_OBJECT_AT_INDEX(parameters, 0);
 		return createTab(parameters, this_object);
 	}
 
 	JSValue UIModule::js_createTabGroup(const std::vector<JSValue>& arguments, JSObject& this_object)
 	{
-		JSObject parameters = this_object.get_context().CreateObject();
-		if (arguments.size() >= 1) {
-			const auto _0 = arguments.at(0);
-			TITANIUM_ASSERT(_0.IsObject());
-			parameters = static_cast<JSObject>(_0);
-		}
+		ENSURE_OPTIONAL_OBJECT_AT_INDEX(parameters, 0);
 		return createTabGroup(parameters, this_object);
 	}
 
 	JSValue UIModule::js_createTextField(const std::vector<JSValue>& arguments, JSObject& this_object)
 	{
-		JSObject parameters = this_object.get_context().CreateObject();
-		if (arguments.size() >= 1) {
-			const auto _0 = arguments.at(0);
-			TITANIUM_ASSERT(_0.IsObject());
-			parameters = static_cast<JSObject>(_0);
-		}
+		ENSURE_OPTIONAL_OBJECT_AT_INDEX(parameters, 0);
 		return createTextField(parameters, this_object);
 	}
 
 	JSValue UIModule::js_createListView(const std::vector<JSValue>& arguments, JSObject& this_object)
 	{
-		JSObject parameters = this_object.get_context().CreateObject();
-		if (arguments.size() >= 1) {
-			const auto _0 = arguments.at(0);
-			TITANIUM_ASSERT(_0.IsObject());
-			parameters = static_cast<JSObject>(_0);
-		}
+		ENSURE_OPTIONAL_OBJECT_AT_INDEX(parameters, 0);
 		return createListView(parameters, this_object);
 	}
 
 	JSValue UIModule::js_createListSection(const std::vector<JSValue>& arguments, JSObject& this_object)
 	{
-		JSObject parameters = this_object.get_context().CreateObject();
-		if (arguments.size() >= 1) {
-			const auto _0 = arguments.at(0);
-			TITANIUM_ASSERT(_0.IsObject());
-			parameters = static_cast<JSObject>(_0);
-		}
+		ENSURE_OPTIONAL_OBJECT_AT_INDEX(parameters, 0);
 		return createListSection(parameters, this_object);
 	}
 
 	JSValue UIModule::js_createListItem(const std::vector<JSValue>& arguments, JSObject& this_object)
 	{
-		JSObject parameters = this_object.get_context().CreateObject();
-		if (arguments.size() >= 1) {
-			const auto _0 = arguments.at(0);
-			TITANIUM_ASSERT(_0.IsObject());
-			parameters = static_cast<JSObject>(_0);
-		}
+		ENSURE_OPTIONAL_OBJECT_AT_INDEX(parameters, 0);
 		return createListItem(parameters, this_object);
 	}
 
 	JSValue UIModule::js_createView(const std::vector<JSValue>& arguments, JSObject& this_object)
 	{
-		JSObject parameters = this_object.get_context().CreateObject();
-		if (arguments.size() >= 1) {
-			const auto _0 = arguments.at(0);
-			TITANIUM_ASSERT(_0.IsObject());
-			parameters = static_cast<JSObject>(_0);
-		}
+		ENSURE_OPTIONAL_OBJECT_AT_INDEX(parameters, 0);
 		return createView(parameters, this_object);
 	}
 
 	JSValue UIModule::js_createWindow(const std::vector<JSValue>& arguments, JSObject& this_object)
 	{
-		JSObject parameters = this_object.get_context().CreateObject();
-		if (arguments.size() >= 1) {
-			const auto _0 = arguments.at(0);
-			TITANIUM_ASSERT(_0.IsObject());
-			parameters = static_cast<JSObject>(_0);
-		}
+		ENSURE_OPTIONAL_OBJECT_AT_INDEX(parameters, 0);
 		return createWindow(parameters, this_object);
 	}
 
 	JSValue UIModule::js_createWebView(const std::vector<JSValue>& arguments, JSObject& this_object)
 	{
-		JSObject parameters = this_object.get_context().CreateObject();
-		if (arguments.size() >= 1) {
-			const auto _0 = arguments.at(0);
-			TITANIUM_ASSERT(_0.IsObject());
-			parameters = static_cast<JSObject>(_0);
-		}
+		ENSURE_OPTIONAL_OBJECT_AT_INDEX(parameters, 0);
 		return createWebView(parameters, this_object);
 	}
 
 	JSValue UIModule::js_createTableView(const std::vector<JSValue>& arguments, JSObject& this_object)
 	{
-		JSObject parameters = this_object.get_context().CreateObject();
-		if (arguments.size() >= 1) {
-			const auto _0 = arguments.at(0);
-			TITANIUM_ASSERT(_0.IsObject());
-			parameters = static_cast<JSObject>(_0);
-		}
+		ENSURE_OPTIONAL_OBJECT_AT_INDEX(parameters, 0);
 		return createTableView(parameters, this_object);
 	}
 
 	JSValue UIModule::js_createTableViewSection(const std::vector<JSValue>& arguments, JSObject& this_object)
 	{
-		JSObject parameters = this_object.get_context().CreateObject();
-		if (arguments.size() >= 1) {
-			const auto _0 = arguments.at(0);
-			TITANIUM_ASSERT(_0.IsObject());
-			parameters = static_cast<JSObject>(_0);
-		}
+		ENSURE_OPTIONAL_OBJECT_AT_INDEX(parameters, 0);
 		return createTableViewSection(parameters, this_object);
 	}
 
 	JSValue UIModule::js_createTableViewRow(const std::vector<JSValue>& arguments, JSObject& this_object)
 	{
-		JSObject parameters = this_object.get_context().CreateObject();
-		if (arguments.size() >= 1) {
-			const auto _0 = arguments.at(0);
-			TITANIUM_ASSERT(_0.IsObject());
-			parameters = static_cast<JSObject>(_0);
-		}
+		ENSURE_OPTIONAL_OBJECT_AT_INDEX(parameters, 0);
 		return createTableViewRow(parameters, this_object);
 	}
 


### PR DESCRIPTION
*NOT READY FOR MERGE*

Define helper macros for common functions/properties which can be used for both header and implementation. It also contains argument check/conversion macro such as `ENSURE_STRING_AT_INDEX`.

- [TIMOB-18403](https://jira.appcelerator.org/browse/TIMOB-18403)
- [TIMOB-18404](https://jira.appcelerator.org/browse/TIMOB-18404)
- [TIMOB-18405](https://jira.appcelerator.org/browse/TIMOB-18405)
