### PR TITLE
[TIMOB-18684] View width/height is ignored when use with Ti.UI.SIZE

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
@@ -358,6 +358,9 @@ namespace TitaniumWindows
 			{
 				return is_loaded__;
 			}
+
+			// compute its fixed size when either width or height (not both) is Ti.UI.SIZE
+			virtual Titanium::LayoutEngine::Rect computeRelativeSize(const double& x, const double& y,  const double& baseWidth, const double& baseHeight);
  
 			static Windows::UI::Color ColorForName(const std::string& colorName);
 			static Windows::UI::Color ColorForHexCode(const std::string& hexCode);
@@ -374,8 +377,8 @@ namespace TitaniumWindows
 			Windows::Foundation::EventRegistrationToken loaded_event__;
 			Windows::Foundation::EventRegistrationToken focus_event__;
 
-			bool is_width_size__{false};
-			bool is_height_size__{false};
+			bool is_default_width_size__{false};
+			bool is_default_height_size__{false};
 			bool is_panel__{false};
 			bool is_control__{false};
 			bool is_loaded__{false};

--- a/Source/UI/src/ImageView.cpp
+++ b/Source/UI/src/ImageView.cpp
@@ -31,13 +31,14 @@ namespace TitaniumWindows
 			image__ = ref new Windows::UI::Xaml::Controls::Image();
 
 			internal_load_event_ = image__->ImageOpened += ref new RoutedEventHandler([this](::Platform::Object^ sender, RoutedEventArgs^ e) {
-				auto rect = Titanium::LayoutEngine::RectMake(
+				const auto layout = getViewLayoutDelegate<WindowsViewLayoutDelegate>();
+				auto rect = layout->computeRelativeSize(
 					Canvas::GetLeft(this->image__),
 					Canvas::GetTop(this->image__),
 					this->image__->ActualWidth,
 					this->image__->ActualHeight
 				);
-				getViewLayoutDelegate<WindowsViewLayoutDelegate>()->onComponentSizeChange(rect);
+				layout->onComponentSizeChange(rect);
 			});
 
 			Titanium::UI::ImageView::setLayoutDelegate<WindowsViewLayoutDelegate>();

--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -401,14 +401,14 @@ namespace TitaniumWindows
 			layout_node__->onLayout = onLayoutCallback;
 
 			if (get_defaultWidth() == Titanium::UI::LAYOUT::SIZE) {
-				is_width_size__ = true;
+				is_default_width_size__ = true;
 				layout_node__->properties.defaultWidthType = Titanium::LayoutEngine::ValueType::Size;
 			} else if (get_defaultWidth() == Titanium::UI::LAYOUT::FILL) {
 				layout_node__->properties.defaultWidthType = Titanium::LayoutEngine::ValueType::Fill;
 			}
 
 			if (get_defaultHeight() == Titanium::UI::LAYOUT::SIZE) {
-				is_height_size__ = true;
+				is_default_height_size__ = true;
 				layout_node__->properties.defaultHeightType = Titanium::LayoutEngine::ValueType::Size;
 			} else if (get_defaultHeight() == Titanium::UI::LAYOUT::FILL) {
 				layout_node__->properties.defaultHeightType = Titanium::LayoutEngine::ValueType::Fill;
@@ -419,9 +419,9 @@ namespace TitaniumWindows
 		{
 			using namespace Windows::UI::Xaml::Controls;
 			using namespace Windows::UI::Xaml;
-			if (is_height_size__ && rect.height == 0)
+			if (is_default_height_size__ && rect.height == 0)
 				return;
-			if (is_width_size__ && rect.width == 0)
+			if (is_default_width_size__ && rect.width == 0)
 				return;
 			if (rect.width < 0 || rect.height < 0)
 				return;
@@ -436,10 +436,10 @@ namespace TitaniumWindows
 
 			auto setWidth = false;
 			auto setHeight = false;
-			auto setWidthOnWidget = !is_width_size__;
-			auto setHeightOnWidget = !is_height_size__;
+			auto setWidthOnWidget = !is_default_width_size__;
+			auto setHeightOnWidget = !is_default_height_size__;
 
-			if (!is_panel__ && is_width_size__ && parentLayout != nullptr) {
+			if (!is_panel__ && is_default_width_size__ && parentLayout != nullptr) {
 				if (rect.width > parentLayout->element.measuredWidth && parentLayout->element.measuredWidth > 0) {
 					rect.width = parentLayout->element.measuredWidth;
 					setWidthOnWidget = true;
@@ -448,7 +448,7 @@ namespace TitaniumWindows
 				}
 			}
 
-			if (!is_panel__ && is_height_size__ && parentLayout != nullptr) {
+			if (!is_panel__ && is_default_height_size__ && parentLayout != nullptr) {
 				if (rect.height > parentLayout->element.measuredHeight && parentLayout->element.measuredHeight > 0) {
 					rect.height = parentLayout->element.measuredHeight;
 					setHeightOnWidget = true;
@@ -497,17 +497,38 @@ namespace TitaniumWindows
 			}
 		}
 
+		Titanium::LayoutEngine::Rect WindowsViewLayoutDelegate::computeRelativeSize(const double& x, const double& y, const double& baseWidth, const double& baseHeight) {
+			auto width  = baseWidth;
+			auto height = baseHeight;
+
+			const auto is_height_size = layout_node__->properties.height.valueType == Titanium::LayoutEngine::Size;
+			const auto is_width_size  = layout_node__->properties.width.valueType  == Titanium::LayoutEngine::Size;
+
+			// compute its fixed size when either width or height (not both) is Ti.UI.SIZE
+			if ((is_width_size != is_height_size) && (is_width_size || is_height_size)) {
+				if (is_width_size) {
+					height = layout_node__->properties.height.value;
+					width = baseWidth  * (height / baseHeight);
+				} else {
+					width = layout_node__->properties.width.value;
+					height = baseHeight * (width / baseWidth);
+				}
+			}
+
+			return Titanium::LayoutEngine::RectMake(x, y, width, height);
+		}
+
 		void WindowsViewLayoutDelegate::onComponentSizeChange(const Titanium::LayoutEngine::Rect& rect)
 		{
 			bool needsLayout = false;
 
-			if (is_width_size__ && !is_panel__) {
+			if (is_default_width_size__ && !is_panel__) {
 				layout_node__->properties.width.value = rect.width;
 				layout_node__->properties.width.valueType = Titanium::LayoutEngine::Fixed;
 				needsLayout = isLoaded();
 			}
 
-			if (is_height_size__ && !is_panel__) {
+			if (is_default_height_size__ && !is_panel__) {
 				layout_node__->properties.height.value = rect.height;
 				layout_node__->properties.height.valueType = Titanium::LayoutEngine::Fixed;
 				needsLayout = isLoaded();


### PR DESCRIPTION
Fix for [TIMOB-18684](https://jira.appcelerator.org/browse/TIMOB-18684)

To test this, make sure following code shows 75x75 image at (top=0,left=0), and also `NG` and `Corporate` app works as expected.

```javascript
var window = Ti.UI.createWindow({ backgroundColor: 'blue' });

var view = Ti.UI.createImageView({
    image: 'http://api.randomuser.me/portraits/women/0.jpg',
    width: 75,
    height: Ti.UI.SIZE,
    top: 0,
    left: 0
});

window.add(view);
window.open();
```