### PR TITLE
Support UTF-8 logging

### DIFF
--- a/Source/API/src/API.cpp
+++ b/Source/API/src/API.cpp
@@ -118,10 +118,7 @@ namespace TitaniumWindows
 			while (!API::done__) {
 				message = concurrency::receive(API::buffer__); // wait for next message to log
 				if (writer == nullptr) { // no TCP connection
-					// Use clog because OutputDebugString will choke and print nothing if the string is too long!
-					std::clog << message << std::endl;
-					// Use Windows-specific logger because TITANIUM_LOG_DEBUG doesn't support UTF-8
-					//OutputDebugString(TitaniumWindows::Utility::ConvertUTF8String(message + "\n")->Data());
+					std::wclog << TitaniumWindows::Utility::ConvertUTF8String(message)->Data() << std::endl;
 				} else { // forward over tcp socket
 					writer->WriteString(TitaniumWindows::Utility::ConvertUTF8String(message) + "\n");  // Logger assumes \n for newlines!
 					writer->StoreAsync();


### PR DESCRIPTION
Fix for [TIMOB-18322](https://jira.appcelerator.org/browse/TIMOB-18322).

To test this, copy & paste following code, make sure you saved your `app.js` as UTF-8 file, then you'll see these messages in VS output log. Note that you may need to wait for few seconds to see output in VS console because log functions are using async.

```
Ti.API.info('[TEST] TEST');
Ti.API.info('[TEST] 表示テスト');
```