### PR TITLE
Make sure variables are properly initialized

### DIFF
--- a/Source/API/src/API.cpp
+++ b/Source/API/src/API.cpp
@@ -55,7 +55,7 @@ namespace TitaniumWindows
 				auto port = std::make_shared<Platform::String^>(TitaniumWindows::Utility::ConvertString(pt.get<std::string>("tcpPort", "8666")));
 				auto server_token = std::make_shared<Platform::String^>(TitaniumWindows::Utility::ConvertString(pt.get<std::string>("serverToken")));
 				// timeout value
-				std::chrono::milliseconds timeout((long long)pt.get<double>("logConnectionTimeout", 2000));
+				std::chrono::milliseconds timeout((std::int64_t)pt.get<double>("logConnectionTimeout", 2000));
 				std::chrono::duration<std::chrono::nanoseconds::rep, std::ratio_multiply<std::ratio<100>, std::nano>> timer_interval_ticks = timeout;
 				Windows::Foundation::TimeSpan time_span;
 				time_span.Duration = timer_interval_ticks.count();

--- a/Source/Accelerometer/src/Accelerometer.cpp
+++ b/Source/Accelerometer/src/Accelerometer.cpp
@@ -48,7 +48,7 @@ namespace TitaniumWindows
 					const auto ctx = self->get_context();
 					auto obj = ctx.CreateObject();
 					const auto reading = self->accelerometer_->GetCurrentReading();
-					unsigned long long timestamp = 0;
+					std::uint64_t timestamp = 0;
 					if (self->previous_acceleromter_time_.UniversalTime > 0) {
 						timestamp = (reading->Timestamp.UniversalTime - self->previous_acceleromter_time_.UniversalTime) / 10000;
 						// Suppress fireEvent so that it doesn't block UI thread (taken from Titanium Android)

--- a/Source/LayoutEngine/src/Horizontal.cpp
+++ b/Source/LayoutEngine/src/Horizontal.cpp
@@ -31,14 +31,19 @@ namespace Titanium
 			    sandboxHeightLayoutCoefficients, leftLayoutCoefficients, minWidthLayoutCoefficients, minHeightLayoutCoefficients;
 			struct FourCoefficients topLayoutCoefficients;
 			struct ComputedSize childSize;
-			double measuredWidth, measuredHeight, measuredSandboxHeight, measuredSandboxWidth, measuredLeft, measuredTop;
+			double measuredWidth = 0;
+			double measuredHeight = 0;
+			double measuredSandboxHeight = 0;
+			double measuredSandboxWidth = 0;
+			double measuredLeft = 0;
+			double measuredTop = 0;
 			std::string pixelUnits = "px";
 			double runningHeight = 0;
 			double runningWidth = 0;
 			// ToDo Russ - remove hard coded c arrays
 			std::vector<std::vector<Element*>> rows;
 			std::vector<double> rowHeights;
-			double rowHeight;
+			double rowHeight = 0;
 			std::vector<struct Element*> deferredTopCalculations;
 			double verticalAlignmentOffset = 0;
 			unsigned int len = children.size();

--- a/Source/LayoutEngine/src/ParseProperty.cpp
+++ b/Source/LayoutEngine/src/ParseProperty.cpp
@@ -32,7 +32,7 @@ namespace Titanium
 		double _computeValue(const std::string& value, enum ValueType valueType, double ppi)
 		{
 			std::string units;
-			double parsedValue;
+			double parsedValue = 0;
 
 			if (valueType == Percent) {
 				return atof(value.c_str()) / 100;

--- a/Source/LayoutEngine/src/Vertical.cpp
+++ b/Source/LayoutEngine/src/Vertical.cpp
@@ -27,7 +27,11 @@ namespace Titanium
 			    sandboxHeightLayoutCoefficients, leftLayoutCoefficients, minWidthLayoutCoefficients, minHeightLayoutCoefficients;
 			struct FourCoefficients topLayoutCoefficients;
 			struct ComputedSize childSize;
-			double measuredWidth, measuredHeight, measuredSandboxHeight, measuredSandboxWidth, measuredLeft;
+			double measuredWidth = 0;
+			double measuredHeight = 0;
+			double measuredSandboxHeight = 0;
+			double measuredSandboxWidth = 0;
+			double measuredLeft = 0;
 			std::string pixelUnits = "px";
 			std::vector<struct Element*> deferredLeftCalculations;
 			double runningHeight = 0;

--- a/Source/Titanium/src/File.cpp
+++ b/Source/Titanium/src/File.cpp
@@ -235,7 +235,7 @@ namespace TitaniumWindows
 			return ((item->Attributes & FileAttributes::ReadOnly) != FileAttributes::ReadOnly);
 		}
 
-		unsigned long long File::get_size() const TITANIUM_NOEXCEPT
+		std::uint64_t File::get_size() const TITANIUM_NOEXCEPT
 		{
 			const auto prop = getStorageProperties(getStorageItem());
 			if (prop == nullptr) {
@@ -569,17 +569,17 @@ namespace TitaniumWindows
 			return path_;
 		}
 
-		unsigned long long File::spaceAvailable() TITANIUM_NOEXCEPT
+		std::uint64_t File::spaceAvailable() TITANIUM_NOEXCEPT
 		{
 			const auto prop = getStorageProperties(getStorageItem());
 			const auto propertiesName = ref new Platform::Collections::Vector<Platform::String^>();
 			propertiesName->Append("System.FreeSpace");
-			uint64 freeSpace;
+			std::uint64_t freeSpace = 0;
 			concurrency::event event;
 			task<IMap<Platform::String^, Platform::Object^>^>(prop->RetrievePropertiesAsync(propertiesName)).then([&freeSpace, &event](task<IMap<Platform::String^, Platform::Object^>^> task) {
 					try {
 						const auto extraProperties = task.get();
-						freeSpace = (uint64)extraProperties->Lookup("System.FreeSpace");
+						freeSpace = (std::uint64_t)extraProperties->Lookup("System.FreeSpace");
 					}
 					catch (Platform::COMException^ ex) {
 						TITANIUM_LOG_DEBUG(TitaniumWindows::Utility::ConvertString(ex->Message));

--- a/Source/Titanium/src/File.hpp
+++ b/Source/Titanium/src/File.hpp
@@ -32,7 +32,7 @@ namespace TitaniumWindows
 			virtual std::shared_ptr<Titanium::Filesystem::File> get_parent() const TITANIUM_NOEXCEPT override;
 			virtual bool get_readonly() const TITANIUM_NOEXCEPT override;
 			virtual bool get_remoteBackup() const TITANIUM_NOEXCEPT override;
-			virtual unsigned long long get_size() const TITANIUM_NOEXCEPT override;
+			virtual std::uint64_t get_size() const TITANIUM_NOEXCEPT override;
 			virtual bool get_symbolicLink() const TITANIUM_NOEXCEPT override;
 			virtual bool get_writable() const TITANIUM_NOEXCEPT override;
 
@@ -57,7 +57,7 @@ namespace TitaniumWindows
 			virtual std::shared_ptr<Titanium::Blob> read() TITANIUM_NOEXCEPT override;
 			virtual bool rename(const std::string& newname) TITANIUM_NOEXCEPT override;
 			virtual std::string resolve() TITANIUM_NOEXCEPT override;
-			virtual unsigned long long spaceAvailable() TITANIUM_NOEXCEPT override;
+			virtual std::uint64_t spaceAvailable() TITANIUM_NOEXCEPT override;
 			virtual bool write(const std::string& data, const bool& append) TITANIUM_NOEXCEPT override;
 			virtual bool write(const std::shared_ptr<Titanium::Blob>& data, const bool& append) TITANIUM_NOEXCEPT override;
 			virtual bool write(const std::shared_ptr<Titanium::Filesystem::File>& data, const bool& append) TITANIUM_NOEXCEPT override;

--- a/Source/TitaniumKit/examples/NativeFileExample.cpp
+++ b/Source/TitaniumKit/examples/NativeFileExample.cpp
@@ -63,7 +63,7 @@ bool NativeFileExample::get_writable() const TITANIUM_NOEXCEPT
 	TITANIUM_LOG_DEBUG("NativeFileExample::get_writable");
 	return false;
 }
-unsigned long long NativeFileExample::get_size() const TITANIUM_NOEXCEPT
+std::uint64_t NativeFileExample::get_size() const TITANIUM_NOEXCEPT
 {
 	TITANIUM_LOG_DEBUG("NativeFileExample::get_size");
 	return 0;
@@ -160,7 +160,7 @@ std::string NativeFileExample::resolve() TITANIUM_NOEXCEPT
 	TITANIUM_LOG_DEBUG("NativeFileExample::resolve");
 	return "";
 }
-unsigned long long NativeFileExample::spaceAvailable() TITANIUM_NOEXCEPT
+std::uint64_t NativeFileExample::spaceAvailable() TITANIUM_NOEXCEPT
 {
 	TITANIUM_LOG_DEBUG("NativeFileExample::spaceAvailable");
 	return false;

--- a/Source/TitaniumKit/examples/NativeFileExample.hpp
+++ b/Source/TitaniumKit/examples/NativeFileExample.hpp
@@ -38,7 +38,7 @@ public:
 	virtual std::shared_ptr<Titanium::Filesystem::File> get_parent() const TITANIUM_NOEXCEPT;
 	virtual bool get_readonly() const TITANIUM_NOEXCEPT;
 	virtual bool get_remoteBackup() const TITANIUM_NOEXCEPT;
-	virtual unsigned long long get_size() const TITANIUM_NOEXCEPT;
+	virtual std::uint64_t get_size() const TITANIUM_NOEXCEPT;
 	virtual bool get_symbolicLink() const TITANIUM_NOEXCEPT;
 	virtual bool get_writable() const TITANIUM_NOEXCEPT;
 
@@ -60,7 +60,7 @@ public:
 	virtual std::shared_ptr<Titanium::Blob> read() TITANIUM_NOEXCEPT;
 	virtual bool rename(const std::string& newname) TITANIUM_NOEXCEPT;
 	virtual std::string resolve() TITANIUM_NOEXCEPT;
-	virtual unsigned long long spaceAvailable() TITANIUM_NOEXCEPT;
+	virtual std::uint64_t spaceAvailable() TITANIUM_NOEXCEPT;
 	virtual bool write(const std::shared_ptr<Titanium::Filesystem::File>& data, const bool& append) TITANIUM_NOEXCEPT;
 
 protected:

--- a/Source/TitaniumKit/include/Titanium/Blob.hpp
+++ b/Source/TitaniumKit/include/Titanium/Blob.hpp
@@ -87,9 +87,9 @@ namespace Titanium
 		  @abstract append
 		  @discussion Appends the data from another blob to this blob.
 		*/
-		virtual void append(std::shared_ptr<Blob>&) TITANIUM_NOEXCEPT;
+		virtual void append(const std::shared_ptr<Blob>&) TITANIUM_NOEXCEPT;
 
-		virtual void construct(std::vector<std::uint8_t> data) TITANIUM_NOEXCEPT;
+		virtual void construct(const std::vector<std::uint8_t> data) TITANIUM_NOEXCEPT;
 		virtual std::vector<std::uint8_t> getData() TITANIUM_NOEXCEPT;
 
 		Blob(const JSContext&) TITANIUM_NOEXCEPT;

--- a/Source/TitaniumKit/include/Titanium/Filesystem/File.hpp
+++ b/Source/TitaniumKit/include/Titanium/Filesystem/File.hpp
@@ -78,7 +78,7 @@ namespace Titanium
 			  @abstract get_size
 			  @discussion Size, in bytes, of the file identified by this object.
 			*/
-			virtual unsigned long long get_size() const TITANIUM_NOEXCEPT;
+			virtual std::uint64_t get_size() const TITANIUM_NOEXCEPT;
 			/*!
 			  @method
 			  @abstract get_symbolicLink
@@ -209,7 +209,7 @@ namespace Titanium
 			  @abstract spaceAvailable
 			  @discussion Returns the amount of free space available on the device where the file identified by this file object is stored.
 			*/
-			virtual unsigned long long spaceAvailable() TITANIUM_NOEXCEPT;
+			virtual std::uint64_t spaceAvailable() TITANIUM_NOEXCEPT;
 			/*!
 			  @method
 			  @abstract write

--- a/Source/TitaniumKit/src/Blob.cpp
+++ b/Source/TitaniumKit/src/Blob.cpp
@@ -14,7 +14,7 @@ namespace Titanium
 	{
 	}
 
-	void Blob::construct(std::vector<std::uint8_t> data) TITANIUM_NOEXCEPT
+	void Blob::construct(const std::vector<std::uint8_t> data) TITANIUM_NOEXCEPT
 	{
 		height_ = 0;
 		width_ = 0;
@@ -120,7 +120,7 @@ namespace Titanium
 		return width_;
 	}
 
-	void Blob::append(std::shared_ptr<Blob>& other) TITANIUM_NOEXCEPT
+	void Blob::append(const std::shared_ptr<Blob>& other) TITANIUM_NOEXCEPT
 	{
 		auto blob = std::dynamic_pointer_cast<Blob>(other).get();
 		const auto b = blob->getData();

--- a/Source/TitaniumKit/src/Filesystem/File.cpp
+++ b/Source/TitaniumKit/src/Filesystem/File.cpp
@@ -120,7 +120,7 @@ namespace Titanium
 			return false;
 		}
 
-		unsigned long long File::get_size() const TITANIUM_NOEXCEPT
+		std::uint64_t File::get_size() const TITANIUM_NOEXCEPT
 		{
 			TITANIUM_LOG_WARN("File::get_size: Unimplemented");
 			return 0;
@@ -247,7 +247,7 @@ namespace Titanium
 			return "";
 		}
 
-		unsigned long long File::spaceAvailable() TITANIUM_NOEXCEPT
+		std::uint64_t File::spaceAvailable() TITANIUM_NOEXCEPT
 		{
 			TITANIUM_LOG_WARN("File::spaceAvailable: Unimplemented");
 			return false;

--- a/Source/TitaniumKit/src/Network/HTTPClient.cpp
+++ b/Source/TitaniumKit/src/Network/HTTPClient.cpp
@@ -497,7 +497,7 @@ namespace Titanium
 		{
 			TITANIUM_ASSERT(argument.IsNumber());
 			double d = static_cast<double>(argument);
-			std::chrono::milliseconds timeout((long long)d);
+			std::chrono::milliseconds timeout((std::int64_t)d);
 			set_timeout(timeout);
 			return true;
 		}

--- a/Source/UI/src/ImageView.cpp
+++ b/Source/UI/src/ImageView.cpp
@@ -10,7 +10,6 @@
 #include "TitaniumWindows/Utility.hpp"
 #include "LayoutEngine/LayoutEngine.hpp"
 #include "TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp"
-#include "TitaniumWindows/Utility.hpp"
 
 namespace TitaniumWindows
 {

--- a/Source/UI/src/Label.cpp
+++ b/Source/UI/src/Label.cpp
@@ -10,8 +10,6 @@
 #include "TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp"
 #include "TitaniumWindows/Utility.hpp"
 
-#include "TitaniumWindows/Utility.hpp"
-
 #define DEFAULT_FONT_SIZE 20
 
 namespace TitaniumWindows


### PR DESCRIPTION
Related to #212, and reflect cpplint result for better code.

- Update to latest HAL
- Make sure variables are properly initialized
- Use `std::int64_t` instead of `long long`
- Remove duplicate `include`
