### PR TITLE
Fix: Remove "virtual" from Database modules

### DIFF
--- a/Source/TitaniumKit/include/Titanium/Database/DB.hpp
+++ b/Source/TitaniumKit/include/Titanium/Database/DB.hpp
@@ -28,42 +28,42 @@ namespace Titanium
 			  @abstract file : Titanium.Filesystem.File READONLY
 			  @discussion A File object representing the file where this database is stored. Must only be used for setting file properties.
 			*/
-			virtual JSValue get_file() const TITANIUM_NOEXCEPT;
+			JSValue get_file() const TITANIUM_NOEXCEPT;
 
 			/*!
 			  @method
 			  @abstract lastInsertRowId : Number
 			  @discussion The identifier of the last populated row.
 			*/
-			virtual int64_t get_lastInsertRowId() const TITANIUM_NOEXCEPT;
+			int64_t get_lastInsertRowId() const TITANIUM_NOEXCEPT;
 
 			/*!
 			  @method
 			  @abstract name : String
 			  @discussion The name of the database.
 			*/
-			virtual std::string get_name() const TITANIUM_NOEXCEPT;
+			std::string get_name() const TITANIUM_NOEXCEPT;
 
 			/*!
 			  @method
 			  @abstract rowsAffected : Number
 			  @discussion The number of rows affected by the last query.
 			*/
-			virtual uint32_t get_rowsAffected() const TITANIUM_NOEXCEPT;
+			uint32_t get_rowsAffected() const TITANIUM_NOEXCEPT;
 	
 			/*!
 			  @method
 			  @abstract close( ) : void
 			  @discussion Closes the database and releases resources from memory. Once closed, this instance is no longer valid and should not be used. On iOS, also closes all Titanium.Database.ResultSet instances that exist.
 			*/
-			virtual void close() TITANIUM_NOEXCEPT;
+			void close() TITANIUM_NOEXCEPT;
 
 			/*!
 			  @method
 			  @abstract execute( sql, [vararg] ) : Titanium.Database.ResultSet
 			  @discussion Executes an SQL statement against the database and returns a ResultSet.
 			*/
-			virtual JSValue execute(const std::string& sql, const std::vector<JSValue>& arguments = {}) TITANIUM_NOEXCEPT;
+			JSValue execute(const std::string& sql, const std::vector<JSValue>& arguments = {}) TITANIUM_NOEXCEPT;
 
 			DB(const JSContext&) TITANIUM_NOEXCEPT;
 			virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;

--- a/Source/TitaniumKit/include/Titanium/Database/ResultSet.hpp
+++ b/Source/TitaniumKit/include/Titanium/Database/ResultSet.hpp
@@ -31,28 +31,28 @@ namespace Titanium
 			  @abstract fieldCount : Number READONLY
 			  @discussion The number of columns in this result set.
 			*/
-			virtual uint32_t get_fieldCount() const TITANIUM_NOEXCEPT;
+			uint32_t get_fieldCount() const TITANIUM_NOEXCEPT;
 
 			/*!
 			  @method
 			  @abstract rowCount : Number READONLY
 			  @discussion The number of rows in this result set.
 			*/
-			virtual uint32_t get_rowCount() const TITANIUM_NOEXCEPT;
+			uint32_t get_rowCount() const TITANIUM_NOEXCEPT;
 
 			/*!
 			  @method
 			  @abstract validRow : Boolean READONLY
 			  @discussion Indicates whether the current row is valid.
 			*/
-			virtual bool get_validRow() const TITANIUM_NOEXCEPT;
+			bool get_validRow() const TITANIUM_NOEXCEPT;
 	
 			/*!
 			  @method
 			  @abstract close( ) : void
 			  @discussion Closes this result set and release resources. Once closed, the result set must no longer be used.
 			*/
-			virtual void close() TITANIUM_NOEXCEPT;
+			void close() TITANIUM_NOEXCEPT;
 
 			/*!
 			  @method
@@ -74,8 +74,8 @@ namespace Titanium
 			  @param type : Number (optional)
 			  	Type to cast field value
 			*/
-			virtual JSValue field(const uint32_t& index) TITANIUM_NOEXCEPT;
-			virtual JSValue field(const uint32_t& index, const FIELD_TYPE& type) TITANIUM_NOEXCEPT;
+			JSValue field(const uint32_t& index) TITANIUM_NOEXCEPT;
+			JSValue field(const uint32_t& index, const FIELD_TYPE& type) TITANIUM_NOEXCEPT;
 
 			/*!
 			  @method
@@ -97,8 +97,8 @@ namespace Titanium
 			  @param type : Number (optional)
 			  	Type to cast field value
 			*/
-			virtual JSValue fieldByName(const std::string& name) TITANIUM_NOEXCEPT;
-			virtual JSValue fieldByName(const std::string& name, const FIELD_TYPE& type) TITANIUM_NOEXCEPT;
+			JSValue fieldByName(const std::string& name) TITANIUM_NOEXCEPT;
+			JSValue fieldByName(const std::string& name, const FIELD_TYPE& type) TITANIUM_NOEXCEPT;
 
 			/*!
 			  @method
@@ -107,7 +107,7 @@ namespace Titanium
 			  @param index : Number
 			  A zero-based column index for the field.
 			*/
-			virtual std::string fieldName(const uint32_t& index) TITANIUM_NOEXCEPT;
+			std::string fieldName(const uint32_t& index) TITANIUM_NOEXCEPT;
 
 			/*!
 			  @method
@@ -116,21 +116,21 @@ namespace Titanium
 			  @param index : Number
 			  A zero-based column index for the field.
 			*/
-			virtual std::string getFieldName(const uint32_t& index) TITANIUM_NOEXCEPT final;
+			std::string getFieldName(const uint32_t& index) TITANIUM_NOEXCEPT;
 
 			/*!
 			  @method
 			  @abstract isValidRow( ) : Boolean
 			  @discussion Returns whether the current row is valid.
 			*/
-			virtual bool isValidRow() TITANIUM_NOEXCEPT;
+			bool isValidRow() TITANIUM_NOEXCEPT;
 
 			/*!
 			  @method
 			  @abstract next( ) : Boolean
 			  @discussion Advances to the next row in the result set and returns true if one exists, or false otherwise.
 			*/
-			virtual bool next() TITANIUM_NOEXCEPT;
+			bool next() TITANIUM_NOEXCEPT;
 
 			ResultSet(const JSContext&) TITANIUM_NOEXCEPT;
 			virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;
@@ -172,7 +172,7 @@ namespace Titanium
 			  @abstract fieldIndex( name ) : int
 			  @discussion Finds the index of the field with the given name. Returns -1 if not found.
 			*/
-			virtual uint32_t fieldIndex(const std::string& fieldName) TITANIUM_NOEXCEPT final;
+			uint32_t fieldIndex(const std::string& fieldName) TITANIUM_NOEXCEPT;
 
 		};
 	} // namespace Database


### PR DESCRIPTION
Fix for [TIMOB-18696](https://jira.appcelerator.org/browse/TIMOB-18696) and [TIMOB-18695](https://jira.appcelerator.org/browse/TIMOB-18695). I noticed that you don't have to make them `virtual` and just use HAL types as it is because Database module is cross-platform and thus nobody extends it. Because original purpose of "removing HAL types" is meant to separate TitaniumKit from platform-specific modules, I think this fix fits the requirement.
