### PR TITLE
Fix: Database module doesn't properly clean up ResultSets

### DIFF
--- a/Examples/NMocha/src/Assets/ti.database.test.js
+++ b/Examples/NMocha/src/Assets/ti.database.test.js
@@ -256,7 +256,7 @@ describe('Titanium.Database', function () {
         finish();
     });
 
-    // Check if it guards against "closed" reesults
+    // Check if it guards against "closed" results
     it('closed_guard', function (finish) {
         // Database name
         var dbName = "testDbOpen";

--- a/Source/TitaniumKit/include/Titanium/Database/DB.hpp
+++ b/Source/TitaniumKit/include/Titanium/Database/DB.hpp
@@ -68,7 +68,7 @@ namespace Titanium
 			DB(const JSContext&) TITANIUM_NOEXCEPT;
 			virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;
 
-			virtual ~DB() = default;
+			virtual ~DB();
 			DB(const DB&) = default;
 			DB& operator=(const DB&) = default;
 #ifdef TITANIUM_MOVE_CTOR_AND_ASSIGN_DEFAULT_ENABLE
@@ -97,6 +97,7 @@ namespace Titanium
 #pragma warning(disable : 4251)
 			std::string name__;
 			std::string path__;
+			std::vector<std::shared_ptr<Titanium::Database::ResultSet>> resultSets__;
 #pragma warning(pop)
 			sqlite3* db__;
 			uint32_t affected_rows__;

--- a/Source/TitaniumKit/include/Titanium/Database/DB.hpp
+++ b/Source/TitaniumKit/include/Titanium/Database/DB.hpp
@@ -28,42 +28,42 @@ namespace Titanium
 			  @abstract file : Titanium.Filesystem.File READONLY
 			  @discussion A File object representing the file where this database is stored. Must only be used for setting file properties.
 			*/
-			virtual JSValue get_file() const TITANIUM_NOEXCEPT;
+			JSValue get_file() const TITANIUM_NOEXCEPT;
 
 			/*!
 			  @method
 			  @abstract lastInsertRowId : Number
 			  @discussion The identifier of the last populated row.
 			*/
-			virtual int64_t get_lastInsertRowId() const TITANIUM_NOEXCEPT;
+			int64_t get_lastInsertRowId() const TITANIUM_NOEXCEPT;
 
 			/*!
 			  @method
 			  @abstract name : String
 			  @discussion The name of the database.
 			*/
-			virtual std::string get_name() const TITANIUM_NOEXCEPT;
+			std::string get_name() const TITANIUM_NOEXCEPT;
 
 			/*!
 			  @method
 			  @abstract rowsAffected : Number
 			  @discussion The number of rows affected by the last query.
 			*/
-			virtual uint32_t get_rowsAffected() const TITANIUM_NOEXCEPT;
+			uint32_t get_rowsAffected() const TITANIUM_NOEXCEPT;
 	
 			/*!
 			  @method
 			  @abstract close( ) : void
 			  @discussion Closes the database and releases resources from memory. Once closed, this instance is no longer valid and should not be used. On iOS, also closes all Titanium.Database.ResultSet instances that exist.
 			*/
-			virtual void close() TITANIUM_NOEXCEPT;
+			void close() TITANIUM_NOEXCEPT;
 
 			/*!
 			  @method
 			  @abstract execute( sql, [vararg] ) : Titanium.Database.ResultSet
 			  @discussion Executes an SQL statement against the database and returns a ResultSet.
 			*/
-			virtual JSValue execute(const std::string& sql, const std::vector<JSValue>& arguments = {}) TITANIUM_NOEXCEPT;
+			JSValue execute(const std::string& sql, const std::vector<JSValue>& arguments = {}) TITANIUM_NOEXCEPT;
 
 			DB(const JSContext&) TITANIUM_NOEXCEPT;
 			virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;

--- a/Source/TitaniumKit/include/Titanium/Database/ResultSet.hpp
+++ b/Source/TitaniumKit/include/Titanium/Database/ResultSet.hpp
@@ -31,28 +31,28 @@ namespace Titanium
 			  @abstract fieldCount : Number READONLY
 			  @discussion The number of columns in this result set.
 			*/
-			virtual uint32_t get_fieldCount() const TITANIUM_NOEXCEPT;
+			uint32_t get_fieldCount() const TITANIUM_NOEXCEPT;
 
 			/*!
 			  @method
 			  @abstract rowCount : Number READONLY
 			  @discussion The number of rows in this result set.
 			*/
-			virtual uint32_t get_rowCount() const TITANIUM_NOEXCEPT;
+			uint32_t get_rowCount() const TITANIUM_NOEXCEPT;
 
 			/*!
 			  @method
 			  @abstract validRow : Boolean READONLY
 			  @discussion Indicates whether the current row is valid.
 			*/
-			virtual bool get_validRow() const TITANIUM_NOEXCEPT;
+			bool get_validRow() const TITANIUM_NOEXCEPT;
 	
 			/*!
 			  @method
 			  @abstract close( ) : void
 			  @discussion Closes this result set and release resources. Once closed, the result set must no longer be used.
 			*/
-			virtual void close() TITANIUM_NOEXCEPT;
+			void close() TITANIUM_NOEXCEPT;
 
 			/*!
 			  @method
@@ -74,8 +74,8 @@ namespace Titanium
 			  @param type : Number (optional)
 			  	Type to cast field value
 			*/
-			virtual JSValue field(const uint32_t& index) TITANIUM_NOEXCEPT;
-			virtual JSValue field(const uint32_t& index, const FIELD_TYPE& type) TITANIUM_NOEXCEPT;
+			JSValue field(const uint32_t& index) TITANIUM_NOEXCEPT;
+			JSValue field(const uint32_t& index, const FIELD_TYPE& type) TITANIUM_NOEXCEPT;
 
 			/*!
 			  @method
@@ -97,8 +97,8 @@ namespace Titanium
 			  @param type : Number (optional)
 			  	Type to cast field value
 			*/
-			virtual JSValue fieldByName(const std::string& name) TITANIUM_NOEXCEPT;
-			virtual JSValue fieldByName(const std::string& name, const FIELD_TYPE& type) TITANIUM_NOEXCEPT;
+			JSValue fieldByName(const std::string& name) TITANIUM_NOEXCEPT;
+			JSValue fieldByName(const std::string& name, const FIELD_TYPE& type) TITANIUM_NOEXCEPT;
 
 			/*!
 			  @method
@@ -107,7 +107,7 @@ namespace Titanium
 			  @param index : Number
 			  A zero-based column index for the field.
 			*/
-			virtual std::string fieldName(const uint32_t& index) TITANIUM_NOEXCEPT;
+			std::string fieldName(const uint32_t& index) TITANIUM_NOEXCEPT;
 
 			/*!
 			  @method
@@ -116,21 +116,21 @@ namespace Titanium
 			  @param index : Number
 			  A zero-based column index for the field.
 			*/
-			virtual std::string getFieldName(const uint32_t& index) TITANIUM_NOEXCEPT final;
+			std::string getFieldName(const uint32_t& index) TITANIUM_NOEXCEPT;
 
 			/*!
 			  @method
 			  @abstract isValidRow( ) : Boolean
 			  @discussion Returns whether the current row is valid.
 			*/
-			virtual bool isValidRow() TITANIUM_NOEXCEPT;
+			bool isValidRow() TITANIUM_NOEXCEPT;
 
 			/*!
 			  @method
 			  @abstract next( ) : Boolean
 			  @discussion Advances to the next row in the result set and returns true if one exists, or false otherwise.
 			*/
-			virtual bool next() TITANIUM_NOEXCEPT;
+			bool next() TITANIUM_NOEXCEPT;
 
 			ResultSet(const JSContext&) TITANIUM_NOEXCEPT;
 			virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;
@@ -172,7 +172,7 @@ namespace Titanium
 			  @abstract fieldIndex( name ) : int
 			  @discussion Finds the index of the field with the given name. Returns -1 if not found.
 			*/
-			virtual uint32_t fieldIndex(const std::string& fieldName) TITANIUM_NOEXCEPT final;
+			uint32_t fieldIndex(const std::string& fieldName) TITANIUM_NOEXCEPT;
 
 		};
 	} // namespace Database

--- a/Source/TitaniumKit/include/Titanium/Database/ResultSet.hpp
+++ b/Source/TitaniumKit/include/Titanium/Database/ResultSet.hpp
@@ -135,7 +135,7 @@ namespace Titanium
 			ResultSet(const JSContext&) TITANIUM_NOEXCEPT;
 			virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;
 
-			virtual ~ResultSet() = default;
+			virtual ~ResultSet();
 			ResultSet(const ResultSet&) = default;
 			ResultSet& operator=(const ResultSet&) = default;
 #ifdef TITANIUM_MOVE_CTOR_AND_ASSIGN_DEFAULT_ENABLE

--- a/Source/TitaniumKit/src/Database/DB.cpp
+++ b/Source/TitaniumKit/src/Database/DB.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "Titanium/Database/DB.hpp"
+#include "Titanium/Filesystem/File.hpp"
 
 // Taken from iOS SDK
 #define SQLITE_BUSY_TIMEOUT 5000
@@ -19,7 +20,8 @@ namespace Titanium
 			TITANIUM_LOG_DEBUG("DB:: ctor ", this);
 		}
 
-		void DB::postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) {
+		void DB::postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) 
+		{
 			HAL_LOG_DEBUG("DB:: postCallAsConstructor ", this);
 
 			// When called to represent class
@@ -40,7 +42,7 @@ namespace Titanium
 					TITANIUM_LOG_WARN(L"[ERROR] Invalid database file path!\n");
 					return;
 				}
-				int error = sqlite3_open_v2(path__.c_str(), &db__, SQLITE_OPEN_SHAREDCACHE | SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE, NULL);
+				auto error = sqlite3_open_v2(path__.c_str(), &db__, SQLITE_OPEN_SHAREDCACHE | SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE, NULL);
 				if (error != SQLITE_OK) {
 					//sqlite3_errmsg(db_); // Error message
 					TITANIUM_LOG_WARN(L"[ERROR] Could not open database!\n");
@@ -105,10 +107,9 @@ namespace Titanium
 				return get_context().CreateNull();
 			}
 
-			int error;
 			sqlite3_stmt* statement;
 			
-			error = sqlite3_prepare_v2(db__, sql.c_str(), static_cast<int>(sql.size()), &statement, NULL);
+			auto error = sqlite3_prepare_v2(db__, sql.c_str(), static_cast<int>(sql.size()), &statement, NULL);
 			if (error != SQLITE_OK) {
 				TITANIUM_LOG_WARN("[ERROR] SQLite prepare error!");
 				sqlite3_finalize(statement);
@@ -128,7 +129,7 @@ namespace Titanium
 					}
 
 					for (int j = 0; j < parameter_count; j++) {
-						int bind_index = i;
+						auto bind_index = i;
 						if (arg_object.IsArray()) {
 							arg = arg_object.GetProperty(j);
 							bind_index = j + 1;
@@ -152,13 +153,13 @@ namespace Titanium
 			}
 
 			// Execute query statement
-			int stepResult = sqlite3_step(statement);
+			auto stepResult = sqlite3_step(statement);
 
 			// Now let's wrap the results in our ResultSet proxy
 			// FIXME Pass these values into the constructor, don't expose the fields
 			// How would we pass along the statement pointer?
-			JSObject resultSet_object = get_context().CreateObject(JSExport<Titanium::Database::ResultSet>::Class());
-			std::shared_ptr<ResultSet> resultSet = resultSet_object.GetPrivate<Titanium::Database::ResultSet>();
+			const auto resultSet_object = get_context().CreateObject(JSExport<Titanium::Database::ResultSet>::Class());
+			const auto resultSet = resultSet_object.GetPrivate<Titanium::Database::ResultSet>();
 			int affectedRows = 0;
 			if (stepResult == SQLITE_DONE) {
 				sqlite3_finalize(statement);
@@ -256,12 +257,12 @@ namespace Titanium
 			TITANIUM_ASSERT(file.IsObject());  // precondition
 			JSObject FileObject = static_cast<JSObject>(file);
 
-			JSValue deleteFile_property = FileObject.GetProperty("deleteFile");
-			TITANIUM_ASSERT(deleteFile_property.IsObject());  // precondition
-			JSObject deleteFile = static_cast<JSObject>(deleteFile_property);
-			TITANIUM_ASSERT(deleteFile.IsFunction());  // precondition
+			const auto file_ptr = FileObject.GetPrivate<Titanium::Filesystem::File>();
 
-			deleteFile(FileObject);
+			if (file_ptr != nullptr && file_ptr->exists()) {
+				file_ptr->deleteFile();
+			}
+
 			return get_context().CreateUndefined();
 		}
 	} // namespace Database

--- a/Source/TitaniumKit/src/Database/ResultSet.cpp
+++ b/Source/TitaniumKit/src/Database/ResultSet.cpp
@@ -19,9 +19,7 @@ namespace Titanium
 
 		ResultSet::~ResultSet() {
 			TITANIUM_LOG_DEBUG("ResultSet:: dtor ", this);
-			if (statement__ != nullptr) {
-				close();
-			}
+			close();
 		}
 
 		void ResultSet::postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) 

--- a/Source/TitaniumKit/src/DatabaseModule.cpp
+++ b/Source/TitaniumKit/src/DatabaseModule.cpp
@@ -53,7 +53,8 @@ namespace Titanium
 		TITANIUM_LOG_DEBUG("DatabaseModule:: ctor ", this);
 	}
 
-	void DatabaseModule::postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) {
+	void DatabaseModule::postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) 
+	{
 		HAL_LOG_DEBUG("DatabaseModule:: postCallAsConstructor ", this);
 	}
 


### PR DESCRIPTION
- [TIMOB-18562](https://jira.appcelerator.org/browse/TIMOB-18562) Database module doesn't properly clean up ResultSets
- [TIMOB-18696](https://jira.appcelerator.org/browse/TIMOB-18696) Ti.Database.ResultSet interface should not use HAL types
- [TIMOB-18695](https://jira.appcelerator.org/browse/TIMOB-18695) Ti.Database.DB interface should not use HAL types 

For "removing HAL types", I noticed that you don't have to make methods `virtual` and just use HAL types as it is because Database module is cross-platform and thus nobody extends it. Because original purpose of "removing HAL types" is meant to separate TitaniumKit from platform-specific modules, I think this fix fits the requirement.
