### PR TITLE
DB should release ResultSet when it's closed

### DIFF
--- a/Source/TitaniumKit/include/Titanium/Database/DB.hpp
+++ b/Source/TitaniumKit/include/Titanium/Database/DB.hpp
@@ -8,6 +8,7 @@
 #define _TITANIUM_DATABASE_DB_HPP_
 
 #include "Titanium/Database/ResultSet.hpp"
+#include <unordered_map>
 
 namespace Titanium
 {
@@ -64,6 +65,13 @@ namespace Titanium
 			  @discussion Executes an SQL statement against the database and returns a ResultSet.
 			*/
 			JSValue execute(const std::string& sql, const std::vector<JSValue>& arguments = {}) TITANIUM_NOEXCEPT;
+			
+			/*!
+			 @method
+			 @abstract removeStatement( ) : void
+			 @discussion Callback when ResultSet is closed. Note that this does not close the statement.
+			 */
+			void removeStatement(sqlite3_stmt*);
 
 			DB(const JSContext&) TITANIUM_NOEXCEPT;
 			virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;
@@ -97,7 +105,7 @@ namespace Titanium
 #pragma warning(disable : 4251)
 			std::string name__;
 			std::string path__;
-			std::vector<std::shared_ptr<Titanium::Database::ResultSet>> resultSets__;
+			std::unordered_map<sqlite3_stmt*, std::shared_ptr<Titanium::Database::ResultSet>> resultSets__;
 #pragma warning(pop)
 			sqlite3* db__;
 			uint32_t affected_rows__;

--- a/Source/TitaniumKit/include/Titanium/Database/ResultSet.hpp
+++ b/Source/TitaniumKit/include/Titanium/Database/ResultSet.hpp
@@ -16,6 +16,8 @@ namespace Titanium
 {
 	namespace Database
 	{
+		class DB;
+
 		using namespace HAL;
 
 		/*!
@@ -135,6 +137,16 @@ namespace Titanium
 			ResultSet(const JSContext&) TITANIUM_NOEXCEPT;
 			virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;
 
+			/*!
+			  @method
+			  @abstract setDatabase( ) : void 
+			  @discussion Set DB which creates this ResultSet so that it can receive callback.
+			*/
+			void setDatabase(DB* db) TITANIUM_NOEXCEPT 
+			{
+				database__ = db;
+			}
+
 			virtual ~ResultSet();
 			ResultSet(const ResultSet&) = default;
 			ResultSet& operator=(const ResultSet&) = default;
@@ -161,6 +173,7 @@ namespace Titanium
 			uint32_t affected_rows__;
 			uint32_t step_result__;
 			sqlite3_stmt* statement__;
+			DB* database__ {nullptr};
 #pragma warning(push)
 #pragma warning(disable : 4251)
 			std::vector<std::string> column_names__;

--- a/Source/TitaniumKit/include/Titanium/Database/ResultSet.hpp
+++ b/Source/TitaniumKit/include/Titanium/Database/ResultSet.hpp
@@ -54,7 +54,7 @@ namespace Titanium
 			  @abstract close( ) : void
 			  @discussion Closes this result set and release resources. Once closed, the result set must no longer be used.
 			*/
-			void close() TITANIUM_NOEXCEPT;
+			void close(bool needCallback = true) TITANIUM_NOEXCEPT;
 
 			/*!
 			  @method

--- a/Source/TitaniumKit/include/Titanium/UI/TextArea.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/TextArea.hpp
@@ -82,8 +82,8 @@ namespace Titanium
 
 			  @discussion Determines how text is capitalized during typing.
 			*/
-			virtual TEXT_AUTOCAPITALIZATION get_autoCapitalization() const TITANIUM_NOEXCEPT final;
-			virtual void set_autoCapitalization(const TEXT_AUTOCAPITALIZATION& autoCapitalization) TITANIUM_NOEXCEPT;
+			virtual TEXT_AUTOCAPITALIZATION get_autocapitalization() const TITANIUM_NOEXCEPT final;
+			virtual void set_autocapitalization(const TEXT_AUTOCAPITALIZATION& autocapitalization) TITANIUM_NOEXCEPT;
 
 			/*!
 			  @method
@@ -113,7 +113,7 @@ namespace Titanium
 			TITANIUM_PROPERTY_DEF(keyboardType);
 			TITANIUM_PROPERTY_DEF(returnKeyType);
 			TITANIUM_PROPERTY_DEF(textAlign);
-			TITANIUM_PROPERTY_DEF(autoCapitalization);
+			TITANIUM_PROPERTY_DEF(autocapitalization);
 			TITANIUM_PROPERTY_DEF(verticalAlign);
 
 		private:
@@ -121,7 +121,7 @@ namespace Titanium
 			KEYBOARD keyboardType__;
 			RETURNKEY returnKeyType__;
 			TEXT_ALIGNMENT textAlign__;
-			TEXT_AUTOCAPITALIZATION autoCapitalization__;
+			TEXT_AUTOCAPITALIZATION autocapitalization__;
 			TEXT_VERTICAL_ALIGNMENT verticalAlign__;
 		};
 	} // namespace UI

--- a/Source/TitaniumKit/src/Database/DB.cpp
+++ b/Source/TitaniumKit/src/Database/DB.cpp
@@ -102,7 +102,7 @@ namespace Titanium
 		void DB::close() TITANIUM_NOEXCEPT
 		{
 			for (auto resultSet : resultSets__) {
-				resultSet.second->close();
+				resultSet.second->close(false);
 			}
 			resultSets__.clear();
 			

--- a/Source/TitaniumKit/src/Database/DB.cpp
+++ b/Source/TitaniumKit/src/Database/DB.cpp
@@ -102,7 +102,7 @@ namespace Titanium
 		void DB::close() TITANIUM_NOEXCEPT
 		{
 			for (auto resultSet : resultSets__) {
-				resultSet->close();
+				resultSet.second->close();
 			}
 			resultSets__.clear();
 			
@@ -171,7 +171,8 @@ namespace Titanium
 			// How would we pass along the statement pointer?
 			const auto resultSet_object = get_context().CreateObject(JSExport<Titanium::Database::ResultSet>::Class());
 			const auto resultSet = resultSet_object.GetPrivate<Titanium::Database::ResultSet>();
-			resultSets__.push_back(resultSet);
+			resultSet->setDatabase(this);
+			resultSets__.emplace(statement, resultSet);
 			int affectedRows = 0;
 			if (stepResult == SQLITE_DONE) {
 				sqlite3_finalize(statement);
@@ -203,6 +204,11 @@ namespace Titanium
 			}
 
 			return resultSet_object;
+		}
+		
+		void DB::removeStatement(sqlite3_stmt* statement)
+		{
+			resultSets__.erase(statement);
 		}
 
 		void DB::JSExportInitialize()

--- a/Source/TitaniumKit/src/Database/ResultSet.cpp
+++ b/Source/TitaniumKit/src/Database/ResultSet.cpp
@@ -43,14 +43,14 @@ namespace Titanium
 			return step_result__ == SQLITE_ROW;
 		}
 	
-		void ResultSet::close() TITANIUM_NOEXCEPT
+		void ResultSet::close(bool needCallback) TITANIUM_NOEXCEPT
 		{
 			if (statement__ != nullptr && column_names__.size()) {
 				sqlite3_finalize(statement__);
-			}
 
-			if (database__ != nullptr) {
-				database__->removeStatement(statement__);
+				if (needCallback && database__ != nullptr) {
+					database__->removeStatement(statement__);
+				}
 			}
 
 			statement__ = nullptr;

--- a/Source/TitaniumKit/src/Database/ResultSet.cpp
+++ b/Source/TitaniumKit/src/Database/ResultSet.cpp
@@ -4,6 +4,7 @@
  * Please see the LICENSE included with this distribution for details.
  */
 
+#include "Titanium/Database/DB.hpp"
 #include "Titanium/Database/ResultSet.hpp"
 #include <type_traits>
 
@@ -47,10 +48,16 @@ namespace Titanium
 			if (statement__ != nullptr && column_names__.size()) {
 				sqlite3_finalize(statement__);
 			}
+
+			if (database__ != nullptr) {
+				database__->removeStatement(statement__);
+			}
+
 			statement__ = nullptr;
 			step_result__ = 0;
 			affected_rows__ = 0;
 			column_names__.clear();
+			database__ = nullptr;
 		}
 
 		JSValue ResultSet::field(const uint32_t& index) TITANIUM_NOEXCEPT

--- a/Source/TitaniumKit/src/UI/TextArea.cpp
+++ b/Source/TitaniumKit/src/UI/TextArea.cpp
@@ -94,7 +94,7 @@ namespace Titanium
 			TITANIUM_ADD_PROPERTY(TextArea, keyboardType);
 			TITANIUM_ADD_PROPERTY(TextArea, returnKeyType);
 			TITANIUM_ADD_PROPERTY(TextArea, textAlign);
-			TITANIUM_ADD_PROPERTY(TextArea, autocapitalization);
+			TITANIUM_ADD_PROPERTY(TextArea, autoCapitalization);
 			TITANIUM_ADD_PROPERTY(TextArea, verticalAlign);
 		}
 

--- a/Source/TitaniumKit/src/UI/TextArea.cpp
+++ b/Source/TitaniumKit/src/UI/TextArea.cpp
@@ -18,7 +18,7 @@ namespace Titanium
 		      autoLink__({AUTOLINK::NONE}),
 		      returnKeyType__(RETURNKEY::DEFAULT),
 		      textAlign__(TEXT_ALIGNMENT::LEFT),
-		      autoCapitalization__(TEXT_AUTOCAPITALIZATION::NONE),
+		      autocapitalization__(TEXT_AUTOCAPITALIZATION::NONE),
 		      verticalAlign__(TEXT_VERTICAL_ALIGNMENT::CENTER)
 		{
 		}
@@ -63,14 +63,14 @@ namespace Titanium
 			TITANIUM_LOG_WARN("TextArea::set_textAlign: Unimplemented");
 		}
 
-		TEXT_AUTOCAPITALIZATION TextArea::get_autoCapitalization() const TITANIUM_NOEXCEPT
+		TEXT_AUTOCAPITALIZATION TextArea::get_autocapitalization() const TITANIUM_NOEXCEPT
 		{
-			return autoCapitalization__;
+			return autocapitalization__;
 		}
 
-		void TextArea::set_autoCapitalization(const TEXT_AUTOCAPITALIZATION& textAlign) TITANIUM_NOEXCEPT
+		void TextArea::set_autocapitalization(const TEXT_AUTOCAPITALIZATION& textAlign) TITANIUM_NOEXCEPT
 		{
-			TITANIUM_LOG_WARN("TextArea::set_autoCapitalization: Unimplemented");
+			TITANIUM_LOG_WARN("TextArea::set_autocapitalization: Unimplemented");
 		}
 
 		TEXT_VERTICAL_ALIGNMENT TextArea::get_verticalAlign() const TITANIUM_NOEXCEPT
@@ -94,7 +94,7 @@ namespace Titanium
 			TITANIUM_ADD_PROPERTY(TextArea, keyboardType);
 			TITANIUM_ADD_PROPERTY(TextArea, returnKeyType);
 			TITANIUM_ADD_PROPERTY(TextArea, textAlign);
-			TITANIUM_ADD_PROPERTY(TextArea, autoCapitalization);
+			TITANIUM_ADD_PROPERTY(TextArea, autocapitalization);
 			TITANIUM_ADD_PROPERTY(TextArea, verticalAlign);
 		}
 
@@ -158,16 +158,16 @@ namespace Titanium
 			return result;
 		}
 
-		TITANIUM_PROPERTY_GETTER(TextArea, autoCapitalization)
+		TITANIUM_PROPERTY_GETTER(TextArea, autocapitalization)
 		{
-			return get_context().CreateNumber(static_cast<std::underlying_type<TEXT_AUTOCAPITALIZATION>::type>(get_autoCapitalization()));
+			return get_context().CreateNumber(static_cast<std::underlying_type<TEXT_AUTOCAPITALIZATION>::type>(get_autocapitalization()));
 		}
 
-		TITANIUM_PROPERTY_SETTER(TextArea, autoCapitalization)
+		TITANIUM_PROPERTY_SETTER(TextArea, autocapitalization)
 		{
 			TITANIUM_ASSERT(argument.IsNumber());
-			autoCapitalization__ = Constants::to_TEXT_AUTOCAPITALIZATION(static_cast<std::underlying_type<TEXT_AUTOCAPITALIZATION>::type>(argument));
-			set_autoCapitalization(autoCapitalization__);
+			autocapitalization__ = Constants::to_TEXT_AUTOCAPITALIZATION(static_cast<std::underlying_type<TEXT_AUTOCAPITALIZATION>::type>(argument));
+			set_autocapitalization(autocapitalization__);
 			return true;
 		}
 


### PR DESCRIPTION
Related to #220 

Database should receive callback from ResultSet when it's closed and then DB should release shared pointer to the ResultSet. Pretty similar logic that how Ti.Current (iOS) does. 