### PR TITLE
Implement Window navigation

### DIFF
--- a/Examples/NMocha/src/Assets/app.js
+++ b/Examples/NMocha/src/Assets/app.js
@@ -89,9 +89,6 @@ mocha.setup({
 mocha.run(function () {
     win.backgroundColor = failed ? 'red' : 'green';
 
-    // force result to be shown
-    win.open();
-
     Ti.API.info('!TEST_RESULTS_START!\n' +
         (JSON.stringify({
             date: new Date,

--- a/Examples/NMocha/src/Assets/ti.ui.imageview.test.js
+++ b/Examples/NMocha/src/Assets/ti.ui.imageview.test.js
@@ -42,8 +42,10 @@ describe("Titanium.UI.ImageView", function () {
             should(innerView.size.height).eql(100);
             should(view.size.height).eql(innerView.size.height);
             should(view.size.width).eql(innerView.size.width);
-            win.close();
-            finish();
+            setTimeout(function () {
+                win.close();
+                finish();
+            }, 1000);
         });
         win.add(view);
         win.open();

--- a/Examples/NMocha/src/Assets/ti.ui.window.test.js
+++ b/Examples/NMocha/src/Assets/ti.ui.window.test.js
@@ -11,7 +11,7 @@ var should = require('should');
 describe("Titanium.UI.Window", function () {
 
     it("window_size_is_read_only", function (finish) {
-        this.timeout(1000);
+        this.timeout(5000);
         var w = Ti.UI.createWindow({
             backgroundColor: 'blue',
             width: 100,
@@ -20,14 +20,16 @@ describe("Titanium.UI.Window", function () {
         w.addEventListener('focus', function () {
             should(w.size.width).not.be.eql(100);
             should(w.size.height).not.be.eql(100);
-            w.close();
-            finish();
+            setTimeout(function () {
+                w.close();
+                finish();
+            }, 1000);
         });
         w.open();
     });
 
     it("window_position_is_read_only", function (finish) {
-        this.timeout(1000);
+        this.timeout(5000);
         var w = Ti.UI.createWindow({
             backgroundColor: 'green',
             left: 100,
@@ -36,8 +38,10 @@ describe("Titanium.UI.Window", function () {
         w.addEventListener("focus", function () {
             should(w.rect.left).not.be.eql(100);
             should(w.rect.right).not.be.eql(100);
-            w.close();
-            finish();
+            setTimeout(function () {
+                w.close();
+                finish();
+            }, 1000);
         });
         w.open();
     });
@@ -70,13 +74,15 @@ describe("Titanium.UI.Window", function () {
             should(win.children.length).be.eql(1);
             win.remove(win.children[0]);
             should(win.children.length).be.eql(0);
-            finish();
-            win.close();
+            setTimeout(function () {
+                w.close();
+                finish();
+            }, 1000);
         });
         win.open();
     });
 
-    it.skip("windows_events", function (finish) {
+    it("windows_events", function (finish) {
         this.timeout(5000);
         var win = Ti.UI.createWindow({
             backgroundColor: 'pink'
@@ -134,8 +140,10 @@ describe("Titanium.UI.Window", function () {
         });
         win.addEventListener("focus", function (e) {
             should(Ti.UI.currentWindow).be.eql(win);
-            win.close();
-            finish();
+            setTimeout(function () {
+                win.close();
+                finish();
+            }, 1000);
         });
         win.open();
     });

--- a/Source/TitaniumKit/include/Titanium/Module.hpp
+++ b/Source/TitaniumKit/include/Titanium/Module.hpp
@@ -97,7 +97,8 @@ namespace Titanium
 
 		  @result void
 		*/
-		virtual void fireEvent(const std::string& name, const JSObject& event) const TITANIUM_NOEXCEPT final;
+		virtual void fireEvent(const std::string& name) TITANIUM_NOEXCEPT final;
+		virtual void fireEvent(const std::string& name, const JSObject& event) TITANIUM_NOEXCEPT final;
 
 		Module(const JSContext&) TITANIUM_NOEXCEPT;
 		virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;
@@ -149,11 +150,16 @@ namespace Titanium
 		virtual void disableEvent(const std::string& event_name) TITANIUM_NOEXCEPT;
 
 		/*
-		 * Stop firing all events, especially used when module is closed/disabled.
+		 * Stop firing all events, especially used when module is closed/hidden.
 		 */
-		virtual void stopFiringEvents() TITANIUM_NOEXCEPT final
+		virtual void disableEvents() TITANIUM_NOEXCEPT final
 		{
-			stopFiringEvents__ = true;
+			enableEvents__ = false;
+		}
+
+		virtual void enableEvents() TITANIUM_NOEXCEPT final
+		{
+			enableEvents__ = true;
 		}
 
 		template<typename T>
@@ -172,7 +178,7 @@ namespace Titanium
 #pragma warning(push)
 #pragma warning(disable : 4251)
 		std::unordered_map<std::string, std::vector<JSObject>> event_listener_map__;
-		bool stopFiringEvents__;
+		bool enableEvents__ { true };
 #pragma warning(pop)
 	};
 }  // namespace Titanium

--- a/Source/TitaniumKit/src/Module.cpp
+++ b/Source/TitaniumKit/src/Module.cpp
@@ -13,7 +13,6 @@ namespace Titanium
 {
 	Module::Module(const JSContext& js_context) TITANIUM_NOEXCEPT
 	    : JSExportObject(js_context)
-	    , stopFiringEvents__(false)
 	{
 	}
 
@@ -115,16 +114,16 @@ namespace Titanium
 				this_object.SetProperty(property_name, props.GetProperty(property_name));
 			}
 		}
-
-		//TITANIUM_LOG_WARN("Module::applyProperties: Unimplemented");
-		//for (const auto& property_name : static_cast<std::vector<JSString>>(props.GetPropertyNames())) {
-		//	this_object.SetProperty(property_name, props.GetProperty(property_name));
-		//}
 	}
 
-	void Module::fireEvent(const std::string& name, const JSObject& event) const TITANIUM_NOEXCEPT
+	void Module::fireEvent(const std::string& name) TITANIUM_NOEXCEPT
 	{
-		if (stopFiringEvents__) {
+		fireEvent(name, get_context().CreateObject());
+	}
+
+	void Module::fireEvent(const std::string& name, const JSObject& event) TITANIUM_NOEXCEPT
+	{
+		if (!enableEvents__) {
 			TITANIUM_LOG_WARN("Module::fireEvent: Stopped firing '", name, "'");
 			return;
 		}
@@ -141,8 +140,10 @@ namespace Titanium
 			return;
 		}
 
-		// TODO Set "source" and "type" here!
 		auto event_copy = event;
+		if (!event_copy.HasProperty("source")) {
+			event_copy.SetProperty("source", get_object());
+		}
 		event_copy.SetProperty("type", event.get_context().CreateString(name));
 
 		for (size_t i = 0; i < event_listener_count; ++i) {

--- a/Source/UI/include/TitaniumWindows/UI/Window.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/Window.hpp
@@ -44,8 +44,17 @@ namespace TitaniumWindows
 			virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;
 			virtual void set_fullscreen(const bool& fullscreen) TITANIUM_NOEXCEPT override final;
 
+			virtual Windows::UI::Xaml::Controls::Canvas^ getComponent() const TITANIUM_NOEXCEPT
+			{
+				return canvas__;
+			}
+
 		private:
+#pragma warning(push)
+#pragma warning(disable : 4251)
 			Windows::UI::Xaml::Controls::Canvas^ canvas__;
+			static std::vector<std::shared_ptr<Window>> window_stack__;
+#pragma warning(pop)
 		};
 
 		class TITANIUMWINDOWS_UI_EXPORT WindowLayoutDelegate : public WindowsViewLayoutDelegate {

--- a/Source/UI/src/AlertDialog.cpp
+++ b/Source/UI/src/AlertDialog.cpp
@@ -49,9 +49,6 @@ namespace TitaniumWindows
 					auto command_invoked_handler = ref new Windows::UI::Popups::UICommandInvokedHandler([this, ctx, i](Windows::UI::Popups::IUICommand^ command) {
 						JSObject eventArgs = ctx.CreateObject();
 						eventArgs.SetProperty("index", ctx.CreateNumber(i));
-						eventArgs.SetProperty("source", get_object());
-						eventArgs.SetProperty("type", ctx.CreateString("click"));
-
 						this->fireEvent("click", eventArgs);
 					});
 

--- a/Source/UI/src/View.cpp
+++ b/Source/UI/src/View.cpp
@@ -67,13 +67,9 @@ namespace TitaniumWindows
 					
 					this->fireEvent("touchmove", eventArgs);
 				});
-			}
-			else if (event_name == "focus") {
+			} else if (event_name == "focus") {
 				focus_event_ = getComponent()->GotFocus += ref new RoutedEventHandler([this, ctx](Platform::Object^ sender, RoutedEventArgs^ e) {
-					JSObject eventArgs = ctx.CreateObject();
-					eventArgs.SetProperty("source", this->get_object());
-					eventArgs.SetProperty("type", ctx.CreateString("focus"));
-					this->fireEvent("focus", eventArgs);
+					this->fireEvent("focus");
 				});
 				return;
 			}

--- a/Source/UI/src/WebView.cpp
+++ b/Source/UI/src/WebView.cpp
@@ -81,14 +81,12 @@ namespace TitaniumWindows
 				loading__ = false;
 				if (e->IsSuccess && load_event_enabled__) {
 					JSObject obj = get_context().CreateObject();
-					obj.SetProperty("type", get_context().CreateString("load"));
 					if (webview__->Source != nullptr) {
 						obj.SetProperty("url", get_context().CreateString(TitaniumWindows::Utility::ConvertString(webview__->Source->ToString())));
 					}
 					fireEvent("load", obj);
 				} else if (!e->IsSuccess && error_event_enabled__) {
 					JSObject obj = get_context().CreateObject();
-					obj.SetProperty("type", get_context().CreateString("error"));
 					obj.SetProperty("success", get_context().CreateBoolean(false));
 					obj.SetProperty("url",  get_context().CreateString(get_url()));
 					obj.SetProperty("code", get_context().CreateString(Titanium::UI::Constants::to_string(getUrlError(e->WebErrorStatus))));
@@ -101,7 +99,6 @@ namespace TitaniumWindows
 				loading__ = true;
 				if (beforeload_event_enabled__) {
 					JSObject obj = get_context().CreateObject();
-					obj.SetProperty("type", get_context().CreateString("beforeload"));
 					obj.SetProperty("url",  get_context().CreateString(get_url()));
 					fireEvent("beforeload", obj);
 				}

--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -339,7 +339,6 @@ namespace TitaniumWindows
 					 	JSContext js_context = event_delegate->get_context();
 						JSObject eventArgs = js_context.CreateObject();
 						eventArgs.SetProperty("source", event_delegate->get_object());
-						eventArgs.SetProperty("type", js_context.CreateString("focus"));
 						event_delegate->fireEvent("focus", eventArgs);
 				 	}
 				});
@@ -502,7 +501,6 @@ namespace TitaniumWindows
 						JSContext js_context = event_delegate->get_context();
 						JSObject  eventArgs = js_context.CreateObject();
 						eventArgs.SetProperty("source", event_delegate->get_object());
-						eventArgs.SetProperty("type", js_context.CreateString("postlayout"));
 						event_delegate->fireEvent("postlayout", eventArgs);
 					}
 				}


### PR DESCRIPTION
Part of [TIMOB-18734](https://jira.appcelerator.org/browse/TIMOB-18734)

- Implement Window navigation
- Implement Window blur event
- Some tweaks around window events

To test this, use following code and see if window navigation stack works as expected. Note that application should exit when `win1` is closed.

```javascript
var win1 = Titanium.UI.createWindow({
    title: 'Window 1',
    backgroundColor: 'Blue'
});
var win2 = Titanium.UI.createWindow({
    title: 'Window 2',
    backgroundColor: 'Yellow'
});
var win3 = Titanium.UI.createWindow({
    title: 'Window 3',
    backgroundColor: 'Green'
});
win1.addEventListener('focus', function () {
    Ti.API.info('win1 focus');
});
win1.addEventListener('blur', function () {
    Ti.API.info('win1 blur');
});

var button1 = Ti.UI.createButton({
    top:  20,
    left: 10,
    title: 'Close Window',
    backgroundColor: 'Green'
});

var button2 = Ti.UI.createButton({
    top: 120,
    left: 110,
    title: 'Open Window',
    backgroundColor: 'Red'
});

var button3 = Ti.UI.createButton({
    top: 20,
    left: 10,
    title: 'Close Window',
    backgroundColor: 'Green'
});
var button3_1 = Ti.UI.createButton({
    top: 120,
    left: 110,
    title: 'Open Window',
    backgroundColor: 'Red'
});
var button4 = Ti.UI.createButton({
    top: 20,
    left: 10,
    title: 'Close Window',
    backgroundColor: 'Blue'
});

button1.addEventListener('click', function (e) {
    win1.close();
});

button2.addEventListener('click', function (e) {
    win2.open();
});

button3.addEventListener('click', function (e) {
    win2.close();
});
button3_1.addEventListener('click', function (e) {
    win3.open();
});
button4.addEventListener('click', function (e) {
    win3.close();
});

win1.add(button1);
win1.add(button2);
win2.add(button3);
win2.add(button3_1);
win3.add(button4);
win1.open();
```