### PR TITLE
[TIMOB-18734] Fix: No way to navigate back to directory view

### DIFF
--- a/Examples/Corporate/src/Assets/alloy/controllers/profile.js
+++ b/Examples/Corporate/src/Assets/alloy/controllers/profile.js
@@ -72,6 +72,9 @@ function Controller() {
         title: "Profile",
         id: "profile"
     });
+    $.__views.profile.addEventListener('windows:back', function () {
+        $.__views.profile.close();
+    });
     $.__views.profile && $.addTopLevelView($.__views.profile);
     $.__views.contactInfo = Ti.UI.createScrollView({
         layout: "vertical",

--- a/Source/TitaniumKit/include/Titanium/Module.hpp
+++ b/Source/TitaniumKit/include/Titanium/Module.hpp
@@ -152,12 +152,12 @@ namespace Titanium
 		/*
 		 * Stop firing all events, especially used when module is closed/hidden.
 		 */
-		virtual void disableEvents() TITANIUM_NOEXCEPT final
+		virtual void disableEvents() TITANIUM_NOEXCEPT
 		{
 			enableEvents__ = false;
 		}
 
-		virtual void enableEvents() TITANIUM_NOEXCEPT final
+		virtual void enableEvents() TITANIUM_NOEXCEPT
 		{
 			enableEvents__ = true;
 		}

--- a/Source/UI/include/TitaniumWindows/UI/Window.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/Window.hpp
@@ -57,12 +57,20 @@ namespace TitaniumWindows
 				return bottomAppBar__;
 			}
 
+			virtual void enableEvents()  TITANIUM_NOEXCEPT override;
+			virtual void disableEvents() TITANIUM_NOEXCEPT override;
+
+			virtual void enableEvent(const std::string& event_name) TITANIUM_NOEXCEPT override;
+			virtual void disableEvent(const std::string& event_name) TITANIUM_NOEXCEPT override;
+
 		private:
 #pragma warning(push)
 #pragma warning(disable : 4251)
 			Windows::UI::Xaml::Controls::Canvas^ canvas__;
 			static std::vector<std::shared_ptr<Window>> window_stack__;
 			std::shared_ptr<TitaniumWindows::UI::WindowsXaml::CommandBar> bottomAppBar__;
+			Windows::Foundation::EventRegistrationToken backpressed_event__;
+			bool handle_backpress_event__ { false };
 #pragma warning(pop)
 		};
 

--- a/Source/UI/src/Windows/SystemIcon.cpp
+++ b/Source/UI/src/Windows/SystemIcon.cpp
@@ -419,7 +419,7 @@ namespace TitaniumWindows
 				TITANIUM_ADD_PROPERTY_READONLY(SystemIcon, PREVIEW);
 			}
 
-TITANIUM_PROPERTY_GETTER(SystemIcon, PREVIOUS)
+			TITANIUM_PROPERTY_GETTER(SystemIcon, PREVIOUS)
 			{
 				return previous__;
 			}


### PR DESCRIPTION
Fix for [TIMOB-18734](https://jira.appcelerator.org/browse/TIMOB-18734)

- Add `windows:back` event which handles hardware back button
- Navigate back to directory window on back button event (Corporate app)

To check how this works on Corporate app, navigate to profile view and then press hardware back button and see if it navigates back to directory view.