### PR TITLE
[TIMOB-18856] Hardware back button should close Ti.Window

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/Window.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/Window.hpp
@@ -36,7 +36,7 @@ namespace TitaniumWindows
 
 			Window(const JSContext&) TITANIUM_NOEXCEPT;
 
-			virtual ~Window() = default;
+			virtual ~Window();
 			Window(const Window&) = default;
 			Window& operator=(const Window&) = default;
 #ifdef TITANIUM_MOVE_CTOR_AND_ASSIGN_DEFAULT_ENABLE
@@ -70,7 +70,8 @@ namespace TitaniumWindows
 			static std::vector<std::shared_ptr<Window>> window_stack__;
 			std::shared_ptr<TitaniumWindows::UI::WindowsXaml::CommandBar> bottomAppBar__;
 			Windows::Foundation::EventRegistrationToken backpressed_event__;
-			bool handle_backpress_event__ { false };
+			bool is_custom_backpress_event__ { false };
+			bool is_window_event_active__ { false };
 #pragma warning(pop)
 		};
 


### PR DESCRIPTION
Fix for [TIMOB-18856](https://jira.appcelerator.org/browse/TIMOB-18856).

To test this, use following code and see if hardware back button closes current Window.

```javascript
var win1 = Titanium.UI.createWindow({
    title: 'Window 1',
    backgroundColor: 'Blue'
});
var win2 = Titanium.UI.createWindow({
    title: 'Window 2',
    backgroundColor: 'Yellow'
});
var win3 = Titanium.UI.createWindow({
    title: 'Window 3',
    backgroundColor: 'Green'
});

/*
win1.addEventListener('windows:back', function () {
    win1.close();
});
win2.addEventListener('windows:back', function () {
    win2.close();
});
win3.addEventListener('windows:back', function () {
    win3.close();
});
*/


win1.addEventListener('focus', function () {
    Ti.API.info('win1 focus');
});
win1.addEventListener('blur', function () {
    Ti.API.info('win1 blur');
});
win2.addEventListener('focus', function () {
    Ti.API.info('win2 focus');
});
win2.addEventListener('blur', function () {
    Ti.API.info('win2 blur');
});

var button1 = Ti.UI.createButton({
    top:  20,
    left: 10,
    title: 'Close Window',
    backgroundColor: 'Green'
});

var button2 = Ti.UI.createButton({
    top: 120,
    left: 110,
    title: 'Open Window',
    backgroundColor: 'Red'
});

var button3 = Ti.UI.createButton({
    top: 20,
    left: 10,
    title: 'Close Window',
    backgroundColor: 'Green'
});
var button3_1 = Ti.UI.createButton({
    top: 120,
    left: 110,
    title: 'Open Window',
    backgroundColor: 'Red'
});
var button4 = Ti.UI.createButton({
    top: 20,
    left: 10,
    title: 'Close Window',
    backgroundColor: 'Blue'
});

button1.addEventListener('click', function (e) {
    win1.close();
});

button2.addEventListener('click', function (e) {
    win2.open();
});

button3.addEventListener('click', function (e) {
    win2.close();
});
button3_1.addEventListener('click', function (e) {
    win3.open();
});
button4.addEventListener('click', function (e) {
    win3.close();
});

win1.add(button1);
win1.add(button2);
win2.add(button3);
win2.add(button3_1);
win3.add(button4);
win1.open();
```