### PR TITLE
Animation improvements

### DIFF
--- a/Source/TitaniumKit/src/UI/Animation.cpp
+++ b/Source/TitaniumKit/src/UI/Animation.cpp
@@ -20,7 +20,8 @@ namespace Titanium
 			backgroundColor__(""),
 			bottom__(0),
 			color__(""),
-			curve__(ANIMATION_CURVE::EASE_IN),
+			curve__(ANIMATION_CURVE::EASE_IN), // FIXME on iOS, leaving the default value actually uses dfeault ease here: https://developer.apple.com/library/mac/documentation/Cocoa/Reference/CAMediaTimingFunction_class/index.html#//apple_ref/doc/constant_group/Predefined_Timing_Functions
+			// which is NOT lineaer, and NOT the same as that used for EASE_IN. Basically it's an unexposed "other" ease function!
 			delay__(0),
 			duration__(0),
 			height__(0),


### PR DESCRIPTION
- Implement [TIMOB-18753 Windows: Support curve/easing functions on Animations](https://jira.appcelerator.org/browse/TIMOB-18753)
- Implement [TIMOB-18752 Windows: Support animations of height, width and
  zIndex properties](https://jira.appcelerator.org/browse/TIMOB-18752)

This doesn't try to handle left/right/center because it'd involve dealing
with precedence and differing ways to calculate height/width.

ZIndex animations don't use curves or transition over time. They simply go
from one value at the beginning to suddenly changing to the new value at
the end.

Curves use Windows CubicEase. There's no equivalent to iOS's curve
functions. We also should consider exposing a new "default" curve option
because of undocumented use in iOS (it uses a different easing function
than the other constants allow us).