### PR TITLE
Stub out all properties/methods of Titanium.Network in TitaniumKit

### DIFF
--- a/Source/Network/include/TitaniumWindows/Network/HTTPClient.hpp
+++ b/Source/Network/include/TitaniumWindows/Network/HTTPClient.hpp
@@ -17,14 +17,6 @@ namespace TitaniumWindows
 {
 	namespace Network
 	{
-		enum NATIVE_HTTPCLIENT_METHOD {
-			N_HTTPCLIENT_METHOD_GET,
-			N_HTTPCLIENT_METHOD_PUT,
-			N_HTTPCLIENT_METHOD_POST,
-			N_HTTPCLIENT_METHOD_DELETE,
-			N_HTTPCLIENT_METHOD_HEAD
-		};
-
 		using namespace HAL;
 
 		class TITANIUMWINDOWS_NETWORK_EXPORT HTTPClient final : public Titanium::Network::HTTPClient, public JSExport<HTTPClient>
@@ -52,20 +44,13 @@ namespace TitaniumWindows
 			virtual void setRequestHeader(const std::string& name, const std::string& value) TITANIUM_NOEXCEPT override final;
 			// properties
 			virtual std::string get_allResponseHeaders() const TITANIUM_NOEXCEPT override final;
-			virtual std::uint32_t get_readyState() const TITANIUM_NOEXCEPT override final;
-			virtual std::vector<std::uint8_t> get_responseData() const TITANIUM_NOEXCEPT override final;
-			virtual std::string get_responseText() const TITANIUM_NOEXCEPT override final;		
-			virtual std::uint32_t get_status() const TITANIUM_NOEXCEPT override final;
 			virtual void set_timeout(const std::chrono::milliseconds& timeout) TITANIUM_NOEXCEPT override final;
 			
-
-		private:
+		protected:
 #pragma warning(push)
 #pragma warning(disable : 4251)
 			// method_ - type of HTTP request (GET, POST, PUT)
-			NATIVE_HTTPCLIENT_METHOD method__;
-			// url__ - the full address of the HTTP request for example http://www.appcelerator.com
-			std::string url__;
+			Titanium::Network::RequestMethod method__;
 			// filter__ - controls the HTTP session and data flow
 			Windows::Web::Http::Filters::HttpBaseProtocolFilter^ filter__;
 			// httpClient__ - higher level HTTP client that provides WinRT API to HTTP sessions and communications
@@ -79,31 +64,24 @@ namespace TitaniumWindows
 			Windows::UI::Xaml::DispatcherTimer^ dispatcherTimer__;
 			// responseStream__ - holds response string, the stream is not exposed
 			Windows::Storage::Streams::IBuffer^ responseStream__;
-			// responseData__ - vector used holds raw response data
-			std::vector<std::uint8_t>  responseData__;
 			// responseDataLen__ - count of character contained in data vector
-			long responseDataLen__;
+			long responseDataLen__ { 0 };
 			// timeoutSpan__ - the span in milliseconds during which the request is active
 			Windows::Foundation::TimeSpan timeoutSpan__;
-			// requestStatus__ - the http status returned from the server
-			std::uint32_t requestStatus__;
-			// readyState__ - current state of the connection
-			std::uint32_t readyState__;
 			// responseHeaders__ - the collection of key value pairs returned from the server
+
 			std::map<const std::string, std::string> responseHeaders__;
 			// contentLength__ - the value in the Content-Length attribute of the response header
 			// If no length is returned the server has returned the data using chunked encoding
-			long contentLength__; // -1 if response is using chunked encoding
+			long contentLength__ { 0 }; // -1 if response is using chunked encoding
 			// requestHeaders__ - the collection of key value pairs to be sent to the server
 			std::map<const std::string, std::string> requestHeaders__;
 
-			bool disposed__;
+			bool disposed__ { false };
 #pragma warning(pop)
 
 			void startDispatcherTimer();
-
 			task<Windows::Storage::Streams::IBuffer^> HTTPClient::HTTPResultAsync(Windows::Storage::Streams::IInputStream^ stream, concurrency::cancellation_token token);
-
 			Windows::Storage::Streams::Buffer^ charVecToBuffer(std::vector<std::uint8_t> char_vector);
 
 			void SerializeHeaders(Windows::Web::Http::HttpResponseMessage^ response);

--- a/Source/TitaniumKit/CMakeLists.txt
+++ b/Source/TitaniumKit/CMakeLists.txt
@@ -134,6 +134,18 @@ set(SOURCE_Network
   src/Network/HTTPClient.cpp
   include/Titanium/Network/Constants.hpp
   src/Network/Constants.cpp
+  include/Titanium/Network/Cookie.hpp
+  src/Network/Cookie.cpp
+  include/Titanium/Network/PushNotificationConfig.hpp
+  src/Network/PushNotificationConfig.cpp
+  include/Titanium/Network/Socket.hpp
+  src/Network/Socket.cpp
+  include/Titanium/Network/Socket/TCP.hpp
+  src/Network/Socket/TCP.cpp
+  include/Titanium/Network/Socket/UDP.hpp
+  src/Network/Socket/UDP.cpp
+  include/Titanium/Network/Socket/AcceptDict.hpp
+  src/Network/Socket/AcceptDict.cpp
   )
 
 set(SOURCE_UI

--- a/Source/TitaniumKit/examples/NativeBlobExample.cpp
+++ b/Source/TitaniumKit/examples/NativeBlobExample.cpp
@@ -60,7 +60,7 @@ unsigned NativeBlobExample::get_width() const TITANIUM_NOEXCEPT
 	return 0;
 }
 
-void NativeBlobExample::append(std::shared_ptr<Blob>&) TITANIUM_NOEXCEPT
+void NativeBlobExample::append(const std::shared_ptr<Blob>&) TITANIUM_NOEXCEPT
 {
 	TITANIUM_LOG_DEBUG("NativeBlobExample::append");
 }

--- a/Source/TitaniumKit/examples/NativeBlobExample.hpp
+++ b/Source/TitaniumKit/examples/NativeBlobExample.hpp
@@ -31,14 +31,14 @@ public:
 
 	static void JSExportInitialize();
 
-	virtual unsigned get_length() const TITANIUM_NOEXCEPT;
-	virtual unsigned get_height() const TITANIUM_NOEXCEPT;
-	virtual std::string get_mimeType() const TITANIUM_NOEXCEPT;
-	virtual std::string get_nativePath() const TITANIUM_NOEXCEPT;
-	virtual unsigned get_size() const TITANIUM_NOEXCEPT;
-	virtual std::string get_text() const TITANIUM_NOEXCEPT;
-	virtual unsigned get_width() const TITANIUM_NOEXCEPT;
-	virtual void append(std::shared_ptr<Blob>&) TITANIUM_NOEXCEPT;
+	virtual unsigned get_length() const TITANIUM_NOEXCEPT override;
+	virtual unsigned get_height() const TITANIUM_NOEXCEPT override;
+	virtual std::string get_mimeType() const TITANIUM_NOEXCEPT override;
+	virtual std::string get_nativePath() const TITANIUM_NOEXCEPT override;
+	virtual unsigned get_size() const TITANIUM_NOEXCEPT override;
+	virtual std::string get_text() const TITANIUM_NOEXCEPT override;
+	virtual unsigned get_width() const TITANIUM_NOEXCEPT override;
+	virtual void append(const std::shared_ptr<Blob>&) TITANIUM_NOEXCEPT override;
 
 protected:
 };

--- a/Source/TitaniumKit/include/Titanium/ApplicationBuilder.hpp
+++ b/Source/TitaniumKit/include/Titanium/ApplicationBuilder.hpp
@@ -118,8 +118,17 @@ namespace Titanium
 		JSObject HTTPClientObject() const TITANIUM_NOEXCEPT;
 		ApplicationBuilder& HTTPClientObject(const JSObject&) TITANIUM_NOEXCEPT;
 
+		JSObject CookieObject() const TITANIUM_NOEXCEPT;
+		ApplicationBuilder& CookieObject(const JSObject&) TITANIUM_NOEXCEPT;
+
 		JSObject NetworkObject() const TITANIUM_NOEXCEPT;
 		ApplicationBuilder& NetworkObject(const JSObject&) TITANIUM_NOEXCEPT;
+
+		JSObject TCPObject() const TITANIUM_NOEXCEPT;
+		ApplicationBuilder& TCPObject(const JSObject&) TITANIUM_NOEXCEPT;
+
+		JSObject UDPObject() const TITANIUM_NOEXCEPT;
+		ApplicationBuilder& UDPObject(const JSObject&) TITANIUM_NOEXCEPT;
 		
 		JSObject XMLObject() const TITANIUM_NOEXCEPT;
 		ApplicationBuilder& XMLObject(const JSObject&) TITANIUM_NOEXCEPT;
@@ -212,7 +221,10 @@ namespace Titanium
 		JSObject database__;
 		JSObject webview__;
 		JSObject httpclient__;
+		JSObject cookie__;
 		JSObject network__;
+		JSObject tcp__;
+		JSObject udp__;
 		JSObject xml__;
 		JSObject tableview__;
 		JSObject tableviewsection__;

--- a/Source/TitaniumKit/include/Titanium/Network/Constants.hpp
+++ b/Source/TitaniumKit/include/Titanium/Network/Constants.hpp
@@ -31,10 +31,25 @@ namespace Titanium
 		};
 
 		enum class TITANIUMKIT_EXPORT TLS_VERSION {
-			ONE_ZERO,
-			ONE_ONE,
-			ONE_TWO
+			_1_0,
+			_1_1,
+			_1_2
 		};
+
+		enum class TITANIUMKIT_EXPORT MODE {
+			READ,
+			WRITE,
+			READ_WRITE
+		};
+
+		enum class TITANIUMKIT_EXPORT SOCKET {
+			INITIALIZED,
+			CONNECTED,
+			LISTENING,
+			CLOSED,
+			ERROR
+		};
+
 	} // namespace Network
 }  // namespace Titanium
 
@@ -86,6 +101,36 @@ namespace std
 			return hash_function(static_cast<underlying_type>(property_attribute));
 		}
 	};
+
+	template <>
+	struct hash<Titanium::Network::MODE>
+	{
+		using argument_type = Titanium::Network::MODE;
+		using result_type = std::size_t;
+		using underlying_type = std::underlying_type<argument_type>::type;
+		std::hash<underlying_type> hash_function = std::hash<underlying_type>();
+
+		result_type operator()(const argument_type& property_attribute) const
+		{
+			return hash_function(static_cast<underlying_type>(property_attribute));
+		}
+	};
+
+	using Titanium::Network::SOCKET;
+	template <>
+	struct hash<SOCKET>
+	{
+		using argument_type = SOCKET;
+		using result_type = std::size_t;
+		using underlying_type = std::underlying_type<argument_type>::type;
+		std::hash<underlying_type> hash_function = std::hash<underlying_type>();
+
+		result_type operator()(const argument_type& property_attribute) const
+		{
+			return hash_function(static_cast<underlying_type>(property_attribute));
+		}
+	};
+
 }  // namespace std
 
 namespace Titanium
@@ -95,9 +140,8 @@ namespace Titanium
 		class TITANIUMKIT_EXPORT Constants final
 		{
 		public:
-
 			static const int32_t PROGRESS_UNKNOWN = -1;
-
+			
 			static std::string to_string(const TYPE&) TITANIUM_NOEXCEPT;
 			static TYPE to_TYPE(const std::string& typeName) TITANIUM_NOEXCEPT;
 			static TYPE to_TYPE(std::underlying_type<TYPE>::type) TITANIUM_NOEXCEPT;
@@ -112,6 +156,17 @@ namespace Titanium
 			static TLS_VERSION to_TLS_VERSION(const std::string& tlsVersionName) TITANIUM_NOEXCEPT;
 			static TLS_VERSION to_TLS_VERSION(std::underlying_type<TLS_VERSION>::type) TITANIUM_NOEXCEPT;
 			static std::underlying_type<TLS_VERSION>::type to_underlying_type(const TLS_VERSION&) TITANIUM_NOEXCEPT;
+
+			static std::string to_string(const MODE&) TITANIUM_NOEXCEPT;
+			static MODE to_MODE(const std::string& name) TITANIUM_NOEXCEPT;
+			static MODE to_MODE(std::underlying_type<MODE>::type) TITANIUM_NOEXCEPT;
+			static std::underlying_type<MODE>::type to_underlying_type(const MODE&) TITANIUM_NOEXCEPT;
+
+			static std::string to_string(const SOCKET&) TITANIUM_NOEXCEPT;
+			static SOCKET to_SOCKET(const std::string& name) TITANIUM_NOEXCEPT;
+			static SOCKET to_SOCKET(std::underlying_type<SOCKET>::type) TITANIUM_NOEXCEPT;
+			static std::underlying_type<SOCKET>::type to_underlying_type(const SOCKET&) TITANIUM_NOEXCEPT;
+
 		};
 	} // namespace Network
 }  // namespace Titanium

--- a/Source/TitaniumKit/include/Titanium/Network/Cookie.hpp
+++ b/Source/TitaniumKit/include/Titanium/Network/Cookie.hpp
@@ -1,0 +1,170 @@
+/**
+ * TitaniumKit Titanium.Network.Cookie
+ *
+ * Copyright (c) 2015 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License.
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#ifndef _TITANIUM_COOKIE_HPP_
+#define _TITANIUM_COOKIE_HPP_
+
+#include "Titanium/Module.hpp"
+
+namespace Titanium
+{
+	namespace Network
+	{
+
+		using namespace HAL;
+
+		/*!
+		  @class
+		  @discussion This is the Titanium Cookie Module.
+		  See http://docs.appcelerator.com/titanium/latest/#!/api/Titanium.Network.Cookie
+		*/
+		class TITANIUMKIT_EXPORT Cookie : public Module, public JSExport<Cookie>
+		{
+
+		public:
+
+			/*!
+			  @property
+			  @abstract comment
+			  @discussion The comment describing the purpose of this cookie
+			*/
+			TITANIUM_PROPERTY_IMPL_DEF(std::string, comment);
+
+			/*!
+			  @property
+			  @abstract domain
+			  @discussion The domain attribute of the cookie.
+			*/
+			TITANIUM_PROPERTY_IMPL_DEF(std::string, domain);
+
+			/*!
+			  @property
+			  @abstract expiryDate
+			  @discussion The expiration Date of the cookie.
+			*/
+			TITANIUM_PROPERTY_IMPL_DEF(std::string, expiryDate);
+
+			/*!
+			  @property
+			  @abstract httponly
+			  @discussion The httponly attribute of the cookie.
+			*/
+			TITANIUM_PROPERTY_IMPL_DEF(bool, httponly);
+
+			/*!
+			  @property
+			  @abstract name
+			  @discussion The name of the cookie.
+			*/
+			TITANIUM_PROPERTY_IMPL_READONLY_DEF(std::string, name);
+
+			/*!
+			  @property
+			  @abstract originalUrl
+			  @discussion The origual url attribute of the cookie.
+			*/
+			TITANIUM_PROPERTY_IMPL_DEF(std::string, originalUrl);
+
+			/*!
+			  @property
+			  @abstract path
+			  @discussion The path attribute of the cookie.
+			*/
+			TITANIUM_PROPERTY_IMPL_DEF(std::string, path);
+
+			/*!
+			  @property
+			  @abstract secure
+			  @discussion The secure attribute of the cookie.
+			*/
+			TITANIUM_PROPERTY_IMPL_DEF(bool, secure);
+
+			/*!
+			  @property
+			  @abstract value
+			  @discussion The value of the cookie.
+			*/
+			TITANIUM_PROPERTY_IMPL_DEF(std::string, value);
+
+			/*!
+			  @property
+			  @abstract version
+			  @discussion The version of the cookie specification to which this cookie conforms.
+			*/
+			TITANIUM_PROPERTY_IMPL_DEF(std::uint32_t, version);
+
+			/*!
+			  @method
+			  @abstract isValid
+			  @discussion Returns true if the cookie is valid.
+			*/
+			virtual bool isValid() TITANIUM_NOEXCEPT;
+
+			Cookie(const JSContext&) TITANIUM_NOEXCEPT;
+
+			virtual ~Cookie() = default;
+			Cookie(const Cookie&) = default;
+			Cookie& operator=(const Cookie&) = default;
+#ifdef TITANIUM_MOVE_CTOR_AND_ASSIGN_DEFAULT_ENABLE
+			Cookie(Cookie&&)                 = default;
+			Cookie& operator=(Cookie&&)      = default;
+#endif
+
+			static void JSExportInitialize();
+
+			TITANIUM_PROPERTY_DEF(comment);
+			TITANIUM_PROPERTY_DEF(domain);
+			TITANIUM_PROPERTY_DEF(expiryDate);
+			TITANIUM_PROPERTY_DEF(httponly);
+			TITANIUM_PROPERTY_READONLY_DEF(name);
+			TITANIUM_PROPERTY_DEF(originalUrl);
+			TITANIUM_PROPERTY_DEF(path);
+			TITANIUM_PROPERTY_DEF(secure);
+			TITANIUM_PROPERTY_DEF(value);
+			TITANIUM_PROPERTY_DEF(version);
+
+			TITANIUM_FUNCTION_DEF(isValid);
+			TITANIUM_FUNCTION_DEF(getComment);
+			TITANIUM_FUNCTION_DEF(setComment);
+			TITANIUM_FUNCTION_DEF(getDomain);
+			TITANIUM_FUNCTION_DEF(setDomain);
+			TITANIUM_FUNCTION_DEF(getExpiryDate);
+			TITANIUM_FUNCTION_DEF(setExpiryDate);
+			TITANIUM_FUNCTION_DEF(getHttponly);
+			TITANIUM_FUNCTION_DEF(setHttponly);
+			TITANIUM_FUNCTION_DEF(getName);
+			TITANIUM_FUNCTION_DEF(getOriginalUrl);
+			TITANIUM_FUNCTION_DEF(setOriginalUrl);
+			TITANIUM_FUNCTION_DEF(getPath);
+			TITANIUM_FUNCTION_DEF(setPath);
+			TITANIUM_FUNCTION_DEF(getSecure);
+			TITANIUM_FUNCTION_DEF(setSecure);
+			TITANIUM_FUNCTION_DEF(getValue);
+			TITANIUM_FUNCTION_DEF(setValue);
+			TITANIUM_FUNCTION_DEF(getVersion);
+			TITANIUM_FUNCTION_DEF(setVersion);
+
+		protected:
+#pragma warning(push)
+#pragma warning(disable : 4251)
+			std::string comment__;
+			std::string domain__;
+			std::string expiryDate__;
+			bool httponly__;
+			std::string name__;
+			std::string originalUrl__;
+			std::string path__;
+			bool secure__;
+			std::string value__;
+			std::uint32_t version__;
+#pragma warning(pop)
+		};
+
+	} // namespace Network
+} // namespace Titanium
+#endif // _TITANIUM_COOKIE_HPP_

--- a/Source/TitaniumKit/include/Titanium/Network/HTTPClient.hpp
+++ b/Source/TitaniumKit/include/Titanium/Network/HTTPClient.hpp
@@ -8,6 +8,8 @@
 #define _TITANIUM_NETWORK_HTTPCLIENT_HPP_
 
 #include "Titanium/Module.hpp"
+#include "Titanium/Blob.hpp"
+#include "Titanium/Network/Constants.hpp"
 
 #define BOOST_BIND_NO_PLACEHOLDERS
 #include <boost/signals2/signal.hpp>
@@ -16,12 +18,20 @@ namespace Titanium
 {
 	namespace Network
 	{
-		enum NATIVE_REQUEST_STATE {
-			N_REQUEST_STATE_LOADING,
-			N_REQUEST_STATE_OPENED,
-			N_REQUEST_STATE_DONE,
-			N_REQUEST_STATE_UNSENT,
-			N_REQUEST_STATE_HEADERS_RECEIVED
+		enum class RequestState {
+			Loading,
+			Opened,
+			Done,
+			Unsent,
+			Headers_Received
+		};
+
+		enum class RequestMethod {
+			Get,
+			Put,
+			Post,
+			Delete,
+			Head
 		};
 
 		using namespace HAL;
@@ -34,81 +44,154 @@ namespace Titanium
 		class TITANIUMKIT_EXPORT HTTPClient : public Module, public JSExport<HTTPClient>
 		{
 		public:
+
 			/*!
-			  @method
-			  @abstract allResponseHeaders : String
+			  @property
+			  @abstract allResponseHeaders
 			  @discussion All of the response headers.
-
-			  Contains a single string, or an empty string if no headers are available.
-
-			  See also: getResponseHeader.
 			*/
-			virtual std::string get_allResponseHeaders() const TITANIUM_NOEXCEPT;
+			TITANIUM_PROPERTY_IMPL_READONLY_DEF(std::string, allResponseHeaders);
 
 			/*!
-			  @method
-			  @abstract readyState : Number
+			  @property
+			  @abstract autoEncodeUrl
+			  @discussion Determines whether automatic encoding is enabled for the specified URL.
+			*/
+			TITANIUM_PROPERTY_IMPL_DEF(bool, autoEncodeUrl);
+
+			/*!
+			  @property
+			  @abstract autoRedirect
+			  @discussion Determines whether automatic automatic handling of HTTP redirects is enabled.
+			*/
+			TITANIUM_PROPERTY_IMPL_DEF(bool, autoRedirect);
+
+			/*!
+			  @property
+			  @abstract connected
+			  @discussion Indicates whether the response was successful.
+			*/
+			TITANIUM_PROPERTY_IMPL_READONLY_DEF(bool, connected);
+
+			/*!
+			  @property
+			  @abstract connectionType
+			  @discussion Connection type, normally either `GET` or `POST`.
+			*/
+			TITANIUM_PROPERTY_IMPL_READONLY_DEF(std::string, connectionType);
+
+			/*!
+			  @property
+			  @abstract domain
+			  @discussion Sets the domain parameter for authentication credentials.
+			*/
+			TITANIUM_PROPERTY_IMPL_DEF(std::string, domain);
+
+			/*!
+			  @property
+			  @abstract enableKeepAlive
+			  @discussion Determines whether the client should attempt to keep a persistent connection.
+			*/
+			TITANIUM_PROPERTY_IMPL_DEF(bool, enableKeepAlive);
+
+			/*!
+			  @property
+			  @abstract file
+			  @discussion Target local file to receive data.
+			*/
+			TITANIUM_PROPERTY_IMPL_DEF(std::string, file);
+
+			/*!
+			  @property
+			  @abstract location
+			  @discussion Absolute URL of the request.
+			*/
+			TITANIUM_PROPERTY_IMPL_READONLY_DEF(std::string, location);
+
+
+			/*!
+			  @property
+			  @abstract password
+			  @discussion Sets the password parameter for authentication credentials.
+			*/
+			TITANIUM_PROPERTY_IMPL_DEF(std::string, password);
+
+			/*!
+			  @property
+			  @abstract readyState
 			  @discussion The current ready state of this HTTP request.
-
-			  The ready state describes the current state of the request. The ready state is set to one of the five Titanium.Network.HTTPClient ready state constants. A typical HTTP request goes through the states in this order:
-
-			  UNSENT
-			  OPENED
-			  HEADERS_RECEIVED
-			  LOADING
-			  DONE
-			  The onreadystatechange callback is invoked each time the ready state changes.
-
-			  This property can be assigned the following constants:
-
-			  Titanium.Network.HTTPClient.UNSENT
-			  Titanium.Network.HTTPClient.OPENED
-			  Titanium.Network.HTTPClient.HEADERS_RECEIVED
-			  Titanium.Network.HTTPClient.LOADING
-			  Titanium.Network.HTTPClient.DONE
 			*/
-			// FIXME Use an enum for the value!
-			virtual std::uint32_t get_readyState() const TITANIUM_NOEXCEPT;
+			TITANIUM_PROPERTY_IMPL_READONLY_DEF(RequestState, readyState);
 
 			/*!
-			  @method
-			  @abstract responseData : Titanium.Blob
-			  @discussion Response data as a Blob object.
+			  @property
+			  @abstract responseData
+			  @discussion Response data as a `Blob` object.
 			*/
-			virtual std::vector<std::uint8_t> get_responseData() const TITANIUM_NOEXCEPT;
+			TITANIUM_PROPERTY_IMPL_READONLY_DEF(std::vector<std::uint8_t>, responseData);
 
 			/*!
-			  @method
-			  @abstract responseText : String
+			  @property
+			  @abstract responseText
 			  @discussion Response as text.
 			*/
-			virtual std::string get_responseText() const TITANIUM_NOEXCEPT;
+			TITANIUM_PROPERTY_IMPL_READONLY_DEF(std::string, responseText);
 
 			/*!
-			  @method
-			  @abstract status : Number
+			  @property
+			  @abstract status
 			  @discussion Response HTTP status code.
 			*/
-			virtual std::uint32_t get_status() const TITANIUM_NOEXCEPT;
+			TITANIUM_PROPERTY_IMPL_READONLY_DEF(std::uint32_t, status);
 
 			/*!
-			  @method
-			  @abstract statusText : String
+			  @property
+			  @abstract statusText
 			  @discussion Human-readable status message associated with the status code.
 			*/
-			virtual std::string get_statusText() const TITANIUM_NOEXCEPT;
+			TITANIUM_PROPERTY_IMPL_READONLY_DEF(std::string, statusText);
 
 			/*!
-			  @method
-
-			  @abstract timeout : Number
-
+			  @property
+			  @abstract timeout
 			  @discussion Timeout in milliseconds when the connection should be aborted.
-
-			  On Mobile Web and Tizen, the timeout only works when making asynchronous requests.
 			*/
-			virtual std::chrono::milliseconds get_timeout() const TITANIUM_NOEXCEPT final;
-			virtual void set_timeout(const std::chrono::milliseconds& timeout) TITANIUM_NOEXCEPT;
+			TITANIUM_PROPERTY_IMPL_DEF(std::chrono::milliseconds, timeout);
+
+			/*!
+			  @property
+			  @abstract username
+			  @discussion Sets the username parameter for authentication credentials.
+			*/
+			TITANIUM_PROPERTY_IMPL_DEF(std::string, username);
+
+			/*!
+			  @property
+			  @abstract validatesSecureCertificate
+			  @discussion Determines how SSL certification validation is performed on connection.
+			*/
+			TITANIUM_PROPERTY_IMPL_DEF(bool, validatesSecureCertificate);
+
+			/*!
+			  @property
+			  @abstract withCredentials
+			  @discussion Determines whether the request should include any cookies and HTTP authentication information.
+			*/
+			TITANIUM_PROPERTY_IMPL_DEF(bool, withCredentials);
+
+			/*!
+			  @property
+			  @abstract tlsVersion
+			  @discussion Sets the TLS version to use for handshakes.
+			*/
+			TITANIUM_PROPERTY_IMPL_DEF(TLS_VERSION, tlsVersion);
+
+			/*!
+			  @property
+			  @abstract cache
+			  @discussion Determines whether HTTP responses are cached.
+			*/
+			TITANIUM_PROPERTY_IMPL_DEF(bool, cache);
 
 			// ----------------------------------------- Methods
 
@@ -180,92 +263,152 @@ namespace Titanium
 
 			static void JSExportInitialize();
 
-			/////// constant properties
+			TITANIUM_PROPERTY_DEF(autoEncodeUrl);
+			TITANIUM_PROPERTY_DEF(autoRedirect);
+			TITANIUM_PROPERTY_DEF(cache);
+			TITANIUM_PROPERTY_DEF(domain);
+			TITANIUM_PROPERTY_DEF(enableKeepAlive);
+			TITANIUM_PROPERTY_DEF(file);
+			TITANIUM_PROPERTY_DEF(ondatastream);
+			TITANIUM_PROPERTY_DEF(onerror);
+			TITANIUM_PROPERTY_DEF(onload);
+			TITANIUM_PROPERTY_DEF(onreadystatechange);
+			TITANIUM_PROPERTY_DEF(onsendstream);
+			TITANIUM_PROPERTY_DEF(password);
+			TITANIUM_PROPERTY_DEF(securityManager);
+			TITANIUM_PROPERTY_DEF(timeout);
+			TITANIUM_PROPERTY_DEF(tlsVersion);
+			TITANIUM_PROPERTY_DEF(username);
+			TITANIUM_PROPERTY_DEF(validatesSecureCertificate);
+			TITANIUM_PROPERTY_DEF(withCredentials);
+			TITANIUM_PROPERTY_READONLY_DEF(DONE);
+			TITANIUM_PROPERTY_READONLY_DEF(HEADERS_RECEIVED);
 			TITANIUM_PROPERTY_READONLY_DEF(LOADING);
 			TITANIUM_PROPERTY_READONLY_DEF(OPENED);
-			TITANIUM_PROPERTY_READONLY_DEF(DONE);
 			TITANIUM_PROPERTY_READONLY_DEF(UNSENT);
-			TITANIUM_PROPERTY_READONLY_DEF(HEADERS_RECEIVED);
-
-			/////// properties
 			TITANIUM_PROPERTY_READONLY_DEF(allResponseHeaders);
-			TITANIUM_FUNCTION_DEF(getAllResponseHeaders);
-
-			TITANIUM_PROPERTY_DEF(ondatastream);
-			TITANIUM_FUNCTION_DEF(getOndatastream);
-			TITANIUM_FUNCTION_DEF(setOndatastream);
-
-			TITANIUM_PROPERTY_DEF(onerror);
-			TITANIUM_FUNCTION_DEF(getOnerror);
-			TITANIUM_FUNCTION_DEF(setOnerror);
-
-			TITANIUM_PROPERTY_DEF(onload);
-			TITANIUM_FUNCTION_DEF(getOnload);
-			TITANIUM_FUNCTION_DEF(setOnload);
-
-			TITANIUM_PROPERTY_DEF(onreadystatechange);
-			TITANIUM_FUNCTION_DEF(getOnreadystatechange);
-			TITANIUM_FUNCTION_DEF(setOnreadystatechange);
-
-			TITANIUM_PROPERTY_DEF(onsendstream);
-			TITANIUM_FUNCTION_DEF(getOnsendstream);
-			TITANIUM_FUNCTION_DEF(setOnsendstream);
-
+			TITANIUM_PROPERTY_READONLY_DEF(connected);
+			TITANIUM_PROPERTY_READONLY_DEF(connectionType);
+			TITANIUM_PROPERTY_READONLY_DEF(location);
 			TITANIUM_PROPERTY_READONLY_DEF(readyState);
-			TITANIUM_FUNCTION_DEF(getReadyState);
-
 			TITANIUM_PROPERTY_READONLY_DEF(responseData);
-			TITANIUM_FUNCTION_DEF(getResponseData);
-
 			TITANIUM_PROPERTY_READONLY_DEF(responseText);
-			TITANIUM_FUNCTION_DEF(getResponseText);
-			
+			TITANIUM_PROPERTY_READONLY_DEF(responseXML);
 			TITANIUM_PROPERTY_READONLY_DEF(status);
-			TITANIUM_FUNCTION_DEF(getStatus);
-
 			TITANIUM_PROPERTY_READONLY_DEF(statusText);
-			TITANIUM_FUNCTION_DEF(getStatusText);
 
-			TITANIUM_PROPERTY_DEF(timeout);
-			TITANIUM_FUNCTION_DEF(getTimeout);
-			TITANIUM_FUNCTION_DEF(setTimeout);
-
-			/////// methods
 			TITANIUM_FUNCTION_DEF(abort);
+			TITANIUM_FUNCTION_DEF(addAuthFactory);
+			TITANIUM_FUNCTION_DEF(addKeyManager);
+			TITANIUM_FUNCTION_DEF(addTrustManager);
 			TITANIUM_FUNCTION_DEF(clearCookies);
+			TITANIUM_FUNCTION_DEF(getAllResponseHeaders);
+			TITANIUM_FUNCTION_DEF(getAutoEncodeUrl);
+			TITANIUM_FUNCTION_DEF(getAutoRedirect);
+			TITANIUM_FUNCTION_DEF(getCache);
+			TITANIUM_FUNCTION_DEF(getConnected);
+			TITANIUM_FUNCTION_DEF(getConnectionType);
+			TITANIUM_FUNCTION_DEF(getDomain);
+			TITANIUM_FUNCTION_DEF(getEnableKeepAlive);
+			TITANIUM_FUNCTION_DEF(getFile);
+			TITANIUM_FUNCTION_DEF(getLocation);
+			TITANIUM_FUNCTION_DEF(getOndatastream);
+			TITANIUM_FUNCTION_DEF(getOnerror);
+			TITANIUM_FUNCTION_DEF(getOnload);
+			TITANIUM_FUNCTION_DEF(getOnreadystatechange);
+			TITANIUM_FUNCTION_DEF(getOnsendstream);
+			TITANIUM_FUNCTION_DEF(getPassword);
+			TITANIUM_FUNCTION_DEF(getReadyState);
+			TITANIUM_FUNCTION_DEF(getResponseData);
 			TITANIUM_FUNCTION_DEF(getResponseHeader);
+			TITANIUM_FUNCTION_DEF(getResponseText);
+			TITANIUM_FUNCTION_DEF(getResponseXML);
+			TITANIUM_FUNCTION_DEF(getSecurityManager);
+			TITANIUM_FUNCTION_DEF(getStatus);
+			TITANIUM_FUNCTION_DEF(getStatusText);
+			TITANIUM_FUNCTION_DEF(getTimeout);
+			TITANIUM_FUNCTION_DEF(getTlsVersion);
+			TITANIUM_FUNCTION_DEF(getUsername);
+			TITANIUM_FUNCTION_DEF(getValidatesSecureCertificate);
+			TITANIUM_FUNCTION_DEF(getWithCredentials);
 			TITANIUM_FUNCTION_DEF(open);
 			TITANIUM_FUNCTION_DEF(send);
+			TITANIUM_FUNCTION_DEF(setAutoEncodeUrl);
+			TITANIUM_FUNCTION_DEF(setAutoRedirect);
+			TITANIUM_FUNCTION_DEF(setCache);
+			TITANIUM_FUNCTION_DEF(setDomain);
+			TITANIUM_FUNCTION_DEF(setEnableKeepAlive);
+			TITANIUM_FUNCTION_DEF(setFile);
+			TITANIUM_FUNCTION_DEF(setOndatastream);
+			TITANIUM_FUNCTION_DEF(setOnerror);
+			TITANIUM_FUNCTION_DEF(setOnload);
+			TITANIUM_FUNCTION_DEF(setOnreadystatechange);
+			TITANIUM_FUNCTION_DEF(setOnsendstream);
+			TITANIUM_FUNCTION_DEF(setPassword);
 			TITANIUM_FUNCTION_DEF(setRequestHeader);
+			TITANIUM_FUNCTION_DEF(setSecurityManager);
+			TITANIUM_FUNCTION_DEF(setTimeout);
+			TITANIUM_FUNCTION_DEF(setTlsVersion);
+			TITANIUM_FUNCTION_DEF(setUsername);
+			TITANIUM_FUNCTION_DEF(setValidatesSecureCertificate);
+			TITANIUM_FUNCTION_DEF(setWithCredentials);
 
 			/////// slots
 			void ondatastream(const double progress) TITANIUM_NOEXCEPT;
 			void onerror(const std::uint32_t id, const std::string error, const bool success) TITANIUM_NOEXCEPT;
 			void onload(const std::uint32_t id, const std::string error, const bool success) TITANIUM_NOEXCEPT;
-			void onreadystatechange(const std::uint32_t state) TITANIUM_NOEXCEPT;
-		    void onsendstream(const double progress) TITANIUM_NOEXCEPT;
+			void onreadystatechange(const RequestState& state) TITANIUM_NOEXCEPT;
+			void onsendstream(const double progress) TITANIUM_NOEXCEPT;
 			
-			/////// signals
 #pragma warning(push)
 #pragma warning(disable: 4251)
+			/////// signals
 			boost::signals2::signal<void(const double progress)> datastream;
 			boost::signals2::signal<void(const std::uint32_t code, const std::string error, const bool success)> error;
 			boost::signals2::signal<void(const std::uint32_t code, const std::string error, const bool success)> loaded;
-			boost::signals2::signal<void(const std::uint32_t state)> readystatechange;
+			boost::signals2::signal<void(const RequestState& state)> readystatechange;
 			boost::signals2::signal<void(const double progress)> sendstream;
 #pragma warning(pop)
 
-		private:
+		protected:
 #pragma warning(push)
 #pragma warning(disable: 4251)
-			JSObject ondatastream_callback__;
-			JSObject onerror_callback__;
-			JSObject onload_callback__;
-			JSObject onreadystatechange_callback__;
-			JSObject onsendstream_callback__;
+			JSValue ondatastream__;
+			JSValue onerror__;
+			JSValue onload__;
+			JSValue onreadystatechange__;
+			JSValue onsendstream__;
 			std::chrono::milliseconds timeout__;
 
 			std::map<uint32_t, std::string> httpStatusPhrase__;
+
+			JSValue done__;
+			JSValue headers_received__;
+			JSValue loading__;
+			JSValue opened__;
+			JSValue unsent__;
+
+			std::string allResponseHeaders__;
+			bool autoEncodeUrl__;
+			bool autoRedirect__;
+			bool connected__;
+			std::string connectionType__;
+			std::string domain__;
+			bool enableKeepAlive__;
+			std::string file__;
+			std::string location__;
+			std::string password__;
+			RequestState readyState__;
+			std::vector<std::uint8_t> responseData__;
+			JSValue responseXML__;
+			JSValue securityManager__;
+			std::uint32_t status__;
+			std::string statusText__;
+			std::string username__;
+			bool validatesSecureCertificate__;
+			bool withCredentials__;
+			TLS_VERSION tlsVersion__;
+			bool cache__;
 #pragma warning(pop)
 
 			void setHTTPStatusPhrase();

--- a/Source/TitaniumKit/include/Titanium/Network/PushNotificationConfig.hpp
+++ b/Source/TitaniumKit/include/Titanium/Network/PushNotificationConfig.hpp
@@ -1,0 +1,41 @@
+/**
+ * TitaniumKit PushNotificationConfig
+ *
+ * Copyright (c) 2015 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License.
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#ifndef _TITANIUM_NETWORK_PUSHNOTIFICATIONCONFIG_HPP_
+#define _TITANIUM_NETWORK_PUSHNOTIFICATIONCONFIG_HPP_
+
+#include "Titanium/detail/TiBase.hpp"
+#include "Titanium/Network/Constants.hpp"
+#include <vector>
+
+namespace Titanium
+{
+	namespace Network
+	{
+		using namespace HAL;
+
+		/*!
+		  @struct
+		  @discussion Simple object for specifying push notification options to registerForPushNotifications.
+		  This is an abstract type. Any object meeting this description can be used where this type is used.
+		  See http://docs.appcelerator.com/titanium/latest/#!/api/PushNotificationConfig
+		*/
+		struct PushNotificationConfig
+		{
+			JSValue callback;
+			JSValue error;
+			JSValue success;
+			std::vector<Titanium::Network::TYPE> types;
+		};
+		
+		PushNotificationConfig js_to_PushNotificationConfig(const JSObject& object);
+		JSObject PushNotificationConfig_to_js(const JSContext& js_context, const PushNotificationConfig& config);
+		
+	} // namespace Network
+} // namespace Titanium
+#endif // _TITANIUM_NETWORK_PUSHNOTIFICATIONCONFIG_HPP_

--- a/Source/TitaniumKit/include/Titanium/Network/Socket.hpp
+++ b/Source/TitaniumKit/include/Titanium/Network/Socket.hpp
@@ -1,0 +1,76 @@
+/**
+ * TitaniumKit Titanium.Network.Socket
+ *
+ * Copyright (c) 2015 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License.
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#ifndef _TITANIUM_SOCKET_HPP_
+#define _TITANIUM_SOCKET_HPP_
+
+#include "Titanium/Module.hpp"
+
+namespace Titanium
+{
+	namespace Network
+	{
+
+		using namespace HAL;
+
+		namespace Socket {
+			enum class State
+			{
+				Initialized,
+				Connected,
+				Listening,
+				Closed,
+				Error
+			};
+		} // namespace Socket
+
+		/*!
+		  @class
+		  @discussion This is the Titanium Socket Module.
+		  See http://docs.appcelerator.com/titanium/latest/#!/api/Titanium.Network.Socket
+		*/
+		class TITANIUMKIT_EXPORT SocketModule : public Module, public JSExport<SocketModule>
+		{
+
+		public:
+
+			SocketModule(const JSContext&) TITANIUM_NOEXCEPT;
+
+			virtual ~SocketModule() = default;
+			SocketModule(const SocketModule&) = default;
+			SocketModule& operator=(const SocketModule&) = default;
+#ifdef TITANIUM_MOVE_CTOR_AND_ASSIGN_DEFAULT_ENABLE
+			SocketModule(SocketModule&&)                 = default;
+			SocketModule& operator=(SocketModule&&)      = default;
+#endif
+
+			static void JSExportInitialize();
+
+			TITANIUM_PROPERTY_READONLY_DEF(INITIALIZED);
+			TITANIUM_PROPERTY_READONLY_DEF(CONNECTED);
+			TITANIUM_PROPERTY_READONLY_DEF(LISTENING);
+			TITANIUM_PROPERTY_READONLY_DEF(CLOSED);
+			TITANIUM_PROPERTY_READONLY_DEF(ERROR);
+
+			TITANIUM_FUNCTION_DEF(createTCP);
+			TITANIUM_FUNCTION_DEF(createUDP);
+
+		protected:
+#pragma warning(push)
+#pragma warning(disable : 4251)
+			JSValue initialized__;
+			JSValue connected__;
+			JSValue listening__;
+			JSValue closed__;
+			JSValue error__;
+#pragma warning(pop)
+		};
+
+	} // namespace Network
+} // namespace Titanium
+#endif // _TITANIUM_SOCKET_HPP_

--- a/Source/TitaniumKit/include/Titanium/Network/Socket/AcceptDict.hpp
+++ b/Source/TitaniumKit/include/Titanium/Network/Socket/AcceptDict.hpp
@@ -1,0 +1,40 @@
+/**
+ * TitaniumKit AcceptDict
+ *
+ * Copyright (c) 2015 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License.
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#ifndef _TITANIUM_NETWORK_SOCKET_ACCEPTDICT_HPP_
+#define _TITANIUM_NETWORK_SOCKET_ACCEPTDICT_HPP_
+
+#include "Titanium/detail/TiBase.hpp"
+
+namespace Titanium
+{
+	namespace Network
+	{
+		namespace Socket
+		{
+			using namespace HAL;
+
+			/*!
+			  @struct
+			  @discussion Simple object for specifying push notification options to registerForPushNotifications.
+			  This is an abstract type. Any object meeting this description can be used where this type is used.
+			  See http://docs.appcelerator.com/titanium/latest/#!/api/AcceptDict
+			*/
+			struct AcceptDict
+			{
+				JSValue error;
+				std::chrono::milliseconds timeout;
+			};
+			
+			AcceptDict js_to_AcceptDict(const JSObject& object);
+			JSObject AcceptDict_to_js(const JSContext& js_context, const AcceptDict& config);
+
+		} // namespace Socket
+	} // namespace Network
+} // namespace Titanium
+#endif // _TITANIUM_NETWORK_SOCKET_ACCEPTDICT_HPP_

--- a/Source/TitaniumKit/include/Titanium/Network/Socket/TCP.hpp
+++ b/Source/TitaniumKit/include/Titanium/Network/Socket/TCP.hpp
@@ -1,0 +1,156 @@
+/**
+ * TitaniumKit Titanium.Network.Socket.TCP
+ *
+ * Copyright (c) 2015 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License.
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#ifndef _TITANIUM_TCP_HPP_
+#define _TITANIUM_TCP_HPP_
+
+#include "Titanium/Module.hpp"
+#include "Titanium/Network/Socket/AcceptDict.hpp"
+#include "Titanium/Network/Socket.hpp"
+
+namespace Titanium
+{
+	namespace Network
+	{
+		namespace Socket
+		{
+
+			using namespace HAL;
+
+			/*!
+			  @class
+			  @discussion This is the Titanium TCP Module.
+			  See http://docs.appcelerator.com/titanium/latest/#!/api/Titanium.Network.Socket.TCP
+			*/
+			class TITANIUMKIT_EXPORT TCP : public Module, public JSExport<TCP>
+			{
+
+			public:
+
+				/*!
+				  @property
+				  @abstract host
+				  @discussion The host to connect to or listen on.
+				*/
+				TITANIUM_PROPERTY_IMPL_DEF(std::string, host);
+
+				/*!
+				  @property
+				  @abstract port
+				  @discussion The port to connect to or listen on.
+				*/
+				TITANIUM_PROPERTY_IMPL_DEF(std::uint32_t, port);
+
+				/*!
+				  @property
+				  @abstract listenQueueSize
+				  @discussion Max number of pending incoming connections to be allowed when the socket is in the [LISTENING](Titanium.Network.Socket.LISTENING) state.
+				*/
+				TITANIUM_PROPERTY_IMPL_DEF(std::uint32_t, listenQueueSize);
+
+				/*!
+				  @property
+				  @abstract timeout
+				  @discussion Timeout, in milliseconds, for `connect` and all `write` operations.
+				*/
+				TITANIUM_PROPERTY_IMPL_DEF(std::chrono::milliseconds, timeout);
+
+				/*!
+				  @property
+				  @abstract state
+				  @discussion Current state of the socket.
+				*/
+				TITANIUM_PROPERTY_IMPL_READONLY_DEF(State, state);
+
+				/*!
+				  @method
+				  @abstract close
+				  @discussion Closes a socket.
+				*/
+				virtual void close() TITANIUM_NOEXCEPT;
+
+				/*!
+				  @method
+				  @abstract connect
+				  @discussion Attempts to connect the socket to its host/port.
+				*/
+				virtual void connect() TITANIUM_NOEXCEPT;
+
+				/*!
+				  @method
+				  @abstract listen
+				  @discussion Attempts to start listening on the socket's host/port.
+				*/
+				virtual void listen() TITANIUM_NOEXCEPT;
+
+				/*!
+				  @method
+				  @abstract accept
+				  @discussion Tells a [LISTENING](Titanium.Network.Socket.LISTENING) socket to accept a connection request at the top of a listener's request queue when one becomes available.
+				*/
+				virtual void accept(const AcceptDict& options) TITANIUM_NOEXCEPT;
+
+				TCP(const JSContext&) TITANIUM_NOEXCEPT;
+
+				virtual ~TCP() = default;
+				TCP(const TCP&) = default;
+				TCP& operator=(const TCP&) = default;
+	#ifdef TITANIUM_MOVE_CTOR_AND_ASSIGN_DEFAULT_ENABLE
+				TCP(TCP&&)                 = default;
+				TCP& operator=(TCP&&)      = default;
+	#endif
+
+				static void JSExportInitialize();
+
+				TITANIUM_PROPERTY_DEF(host);
+				TITANIUM_PROPERTY_DEF(port);
+				TITANIUM_PROPERTY_DEF(listenQueueSize);
+				TITANIUM_PROPERTY_DEF(timeout);
+				TITANIUM_PROPERTY_DEF(connected);
+				TITANIUM_PROPERTY_DEF(error);
+				TITANIUM_PROPERTY_DEF(accepted);
+				TITANIUM_PROPERTY_READONLY_DEF(state);
+
+				TITANIUM_FUNCTION_DEF(close);
+				TITANIUM_FUNCTION_DEF(connect);
+				TITANIUM_FUNCTION_DEF(listen);
+				TITANIUM_FUNCTION_DEF(accept);
+				TITANIUM_FUNCTION_DEF(getHost);
+				TITANIUM_FUNCTION_DEF(setHost);
+				TITANIUM_FUNCTION_DEF(getPort);
+				TITANIUM_FUNCTION_DEF(setPort);
+				TITANIUM_FUNCTION_DEF(getListenQueueSize);
+				TITANIUM_FUNCTION_DEF(setListenQueueSize);
+				TITANIUM_FUNCTION_DEF(getTimeout);
+				TITANIUM_FUNCTION_DEF(setTimeout);
+				TITANIUM_FUNCTION_DEF(getConnected);
+				TITANIUM_FUNCTION_DEF(setConnected);
+				TITANIUM_FUNCTION_DEF(getError);
+				TITANIUM_FUNCTION_DEF(setError);
+				TITANIUM_FUNCTION_DEF(getAccepted);
+				TITANIUM_FUNCTION_DEF(setAccepted);
+				TITANIUM_FUNCTION_DEF(getState);
+
+			protected:
+#pragma warning(push)
+#pragma warning(disable : 4251)
+				std::string host__;
+				std::uint32_t port__;
+				std::uint32_t listenQueueSize__;
+				std::chrono::milliseconds timeout__;
+				JSValue connected__;
+				JSValue error__;
+				JSValue accepted__;
+				State state__;
+#pragma warning(pop)
+			};
+
+		} // namespace Socket
+	} // namespace Network
+} // namespace Titanium
+#endif // _TITANIUM_TCP_HPP_

--- a/Source/TitaniumKit/include/Titanium/Network/Socket/UDP.hpp
+++ b/Source/TitaniumKit/include/Titanium/Network/Socket/UDP.hpp
@@ -1,0 +1,111 @@
+/**
+ * TitaniumKit Titanium.Network.Socket.UDP
+ *
+ * Copyright (c) 2015 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License.
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#ifndef _TITANIUM_UDP_HPP_
+#define _TITANIUM_UDP_HPP_
+
+#include "Titanium/Module.hpp"
+
+namespace Titanium
+{
+	namespace Network
+	{
+		namespace Socket
+		{
+
+			using namespace HAL;
+
+			/*!
+			  @class
+			  @discussion This is the Titanium UDP Module.
+			  See http://docs.appcelerator.com/titanium/latest/#!/api/Titanium.Network.Socket.UDP
+			*/
+			class TITANIUMKIT_EXPORT UDP : public Module, public JSExport<UDP>
+			{
+
+			public:
+
+				/*!
+				  @property
+				  @abstract port
+				  @discussion The port to connect to or listen on.
+				*/
+				TITANIUM_PROPERTY_IMPL_DEF(std::uint32_t, port);
+
+				/*!
+				  @method
+				  @abstract start
+				  @discussion Will start up the local UDP socket.
+				*/
+				virtual void start(const std::uint32_t& port) TITANIUM_NOEXCEPT;
+
+				/*!
+				  @method
+				  @abstract stop
+				  @discussion Will tear down the local UDP socket.
+				*/
+				virtual void stop() TITANIUM_NOEXCEPT;
+
+				/*!
+				  @method
+				  @abstract sendString
+				  @discussion Will send the string as a UDP packet to designated host and port.
+				*/
+				virtual void sendString(const std::uint32_t& port, const std::string& host, const std::string& data) TITANIUM_NOEXCEPT;
+
+				/*!
+				  @method
+				  @abstract sendBytes
+				  @discussion Will send the bytes as a UDP packet to designated host and port.
+				*/
+				virtual void sendBytes(const std::uint32_t& port, const std::string& host, std::vector<std::uint8_t> data) TITANIUM_NOEXCEPT;
+
+				UDP(const JSContext&) TITANIUM_NOEXCEPT;
+
+				virtual ~UDP() = default;
+				UDP(const UDP&) = default;
+				UDP& operator=(const UDP&) = default;
+	#ifdef TITANIUM_MOVE_CTOR_AND_ASSIGN_DEFAULT_ENABLE
+				UDP(UDP&&)                 = default;
+				UDP& operator=(UDP&&)      = default;
+	#endif
+
+				static void JSExportInitialize();
+
+				TITANIUM_PROPERTY_DEF(port);
+				TITANIUM_PROPERTY_DEF(started);
+				TITANIUM_PROPERTY_DEF(data);
+				TITANIUM_PROPERTY_DEF(error);
+
+				TITANIUM_FUNCTION_DEF(start);
+				TITANIUM_FUNCTION_DEF(stop);
+				TITANIUM_FUNCTION_DEF(sendString);
+				TITANIUM_FUNCTION_DEF(sendBytes);
+				TITANIUM_FUNCTION_DEF(getPort);
+				TITANIUM_FUNCTION_DEF(setPort);
+				TITANIUM_FUNCTION_DEF(getStarted);
+				TITANIUM_FUNCTION_DEF(setStarted);
+				TITANIUM_FUNCTION_DEF(getData);
+				TITANIUM_FUNCTION_DEF(setData);
+				TITANIUM_FUNCTION_DEF(getError);
+				TITANIUM_FUNCTION_DEF(setError);
+
+			protected:
+	#pragma warning(push)
+	#pragma warning(disable : 4251)
+				std::uint32_t port__;
+				JSValue started__;
+				JSValue data__;
+				JSValue error__;
+	#pragma warning(pop)
+			};
+
+		} // namespace Socket
+	} // namespace Network
+} // namespace Titanium
+#endif // _TITANIUM_UDP_HPP_

--- a/Source/TitaniumKit/include/Titanium/NetworkModule.hpp
+++ b/Source/TitaniumKit/include/Titanium/NetworkModule.hpp
@@ -9,7 +9,12 @@
 
 #include "Titanium/Module.hpp"
 #include "Titanium/Network/Constants.hpp"
+#include "Titanium/Network/Cookie.hpp"
 #include "Titanium/Network/HTTPClient.hpp"
+#include "Titanium/Network/Socket.hpp"
+#include "Titanium/Network/Socket/TCP.hpp"
+#include "Titanium/Network/Socket/UDP.hpp"
+#include "Titanium/Network/PushNotificationConfig.hpp"
 
 namespace Titanium
 {
@@ -23,35 +28,139 @@ namespace Titanium
 	class TITANIUMKIT_EXPORT NetworkModule : public Module, public JSExport<NetworkModule>
 	{
 	public:
-		/*!
-		  @method
-		  @abstract createHTTPClient 
-		  @discussion Returns a HTTP object allowing users to make http request and query the HTTP object.
-		*/
-		virtual JSObject createHTTPClient(const JSObject& parameters, JSObject& this_object) TITANIUM_NOEXCEPT;
 
 		/*!
-		  @method
-		  @abstract networkType : Number
+		  @property
+		  @abstract allHTTPCookies
+		  @discussion A list of all cookies in the cookie storage.
+		*/
+		TITANIUM_PROPERTY_IMPL_READONLY_DEF(std::vector<std::shared_ptr<Network::Cookie>>, allHTTPCookies);
+
+		/*!
+		  @property
+		  @abstract networkType
 		  @discussion Network type value as a constant.
-
-		  One of the NETWORK constants defined in Titanium.Network.
 		*/
-		virtual Titanium::Network::TYPE get_networkType() const TITANIUM_NOEXCEPT;
+		TITANIUM_PROPERTY_IMPL_READONLY_DEF(Network::TYPE, networkType);
 
 		/*!
-		  @method
-		  @abstract networkTypeName : String
-		  @discussion Network type as a String. Returns one of NONE, WIFI, LAN, MOBILE, or UNKNOWN.
+		  @property
+		  @abstract networkTypeName
+		  @discussion Network type as a String. Returns one of `NONE`, `WIFI`, `LAN`, `MOBILE`, or `UNKNOWN`.
 		*/
-		virtual std::string get_networkTypeName() const TITANIUM_NOEXCEPT final;
+		TITANIUM_PROPERTY_IMPL_READONLY_DEF(std::string, networkTypeName);
 
 		/*!
-		  @method
-		  @abstract online : Boolean
+		  @property
+		  @abstract online
 		  @discussion Boolean value indicating if the device can reach the Internet.
 		*/
-		virtual bool get_online() const TITANIUM_NOEXCEPT;
+		TITANIUM_PROPERTY_IMPL_READONLY_DEF(bool, online);
+
+		/*!
+		  @property
+		  @abstract remoteDeviceUUID
+		  @discussion Remote device UUID if the device is registered with the Apple Push NotificationService, or null if it is not registered.
+		*/
+		TITANIUM_PROPERTY_IMPL_READONLY_DEF(std::string, remoteDeviceUUID);
+
+		/*!
+		  @property
+		  @abstract remoteNotificationTypes
+		  @discussion Array of push notification type constants enabled for the application.
+		*/
+		TITANIUM_PROPERTY_IMPL_READONLY_DEF(std::vector<Network::NOTIFICATION_TYPE>, remoteNotificationTypes);
+
+		/*!
+		  @property
+		  @abstract remoteNotificationsEnabled
+		  @discussion Indicates whether push  notifications have been enabled using [registerForPushNotifications](Titanium.Network.registerForPushNotifications).
+		*/
+		TITANIUM_PROPERTY_IMPL_READONLY_DEF(bool, remoteNotificationsEnabled);
+
+		/*!
+		  @method
+		  @abstract addHTTPCookie
+		  @discussion Adds a cookie to the HTTP client cookie store.
+		*/
+		virtual void addHTTPCookie(std::shared_ptr<Network::Cookie> cookie) TITANIUM_NOEXCEPT;
+
+		/*!
+		  @method
+		  @abstract addSystemCookie
+		  @discussion Adds a cookie to the system cookie store.
+		*/
+		virtual void addSystemCookie(std::shared_ptr<Network::Cookie> cookie) TITANIUM_NOEXCEPT;
+
+		/*!
+		  @method
+		  @abstract getHTTPCookies
+		  @discussion Gets all the cookies with the domain, path and name matched with the given values from the HTTP client cookie store.
+		*/
+		virtual std::vector<std::shared_ptr<Network::Cookie>> getHTTPCookies(const std::string& domain, const std::string& path, const std::string& name) TITANIUM_NOEXCEPT;
+
+		/*!
+		  @method
+		  @abstract getHTTPCookiesForDomain
+		  @discussion Gets all the cookies with the domain matched with the given values from the HTTP client cookie store.
+		*/
+		virtual std::vector<std::shared_ptr<Network::Cookie>> getHTTPCookiesForDomain(const std::string& domain) TITANIUM_NOEXCEPT;
+
+		/*!
+		  @method
+		  @abstract getSystemCookies
+		  @discussion Gets all the cookies with the domain, path and name matched with the given values from the system cookie store.
+		*/
+		virtual std::vector<std::shared_ptr<Network::Cookie>> getSystemCookies(const std::string& domain, const std::string& path, const std::string& name) TITANIUM_NOEXCEPT;
+
+		/*!
+		  @method
+		  @abstract removeAllHTTPCookies
+		  @discussion Removes all the cookies from the HTTP client cookie store.
+		*/
+		virtual void removeAllHTTPCookies() TITANIUM_NOEXCEPT;
+
+		/*!
+		  @method
+		  @abstract removeAllSystemCookies
+		  @discussion Removes all the cookie from the system client cookie store.
+		*/
+		virtual void removeAllSystemCookies() TITANIUM_NOEXCEPT;
+
+		/*!
+		  @method
+		  @abstract removeHTTPCookie
+		  @discussion Removes the cookie with the domain, path and name exactly the same as the given values from the HTTP client cookie store.
+		*/
+		virtual void removeHTTPCookie(const std::string& domain, const std::string& path, const std::string& name) TITANIUM_NOEXCEPT;
+
+		/*!
+		  @method
+		  @abstract removeHTTPCookiesForDomain
+		  @discussion Removes the cookies with the domain matched with the given values from the HTTP client cookie store.
+		*/
+		virtual void removeHTTPCookiesForDomain(const std::string& domain) TITANIUM_NOEXCEPT;
+
+		/*!
+		  @method
+		  @abstract removeSystemCookie
+		  @discussion Removes the cookie with the domain, path and name exactly the same as the given values from the system cookie store.
+		*/
+		virtual void removeSystemCookie(const std::string& domain, const std::string& path, const std::string& name) TITANIUM_NOEXCEPT;
+
+		/*!
+		  @method
+		  @abstract registerForPushNotifications
+		  @discussion Registers for push notifications with the Apple Push Notification Service.
+		*/
+		virtual void registerForPushNotifications(const Network::PushNotificationConfig& config) TITANIUM_NOEXCEPT;
+
+		/*!
+		  @method
+		  @abstract unregisterForPushNotifications
+		  @discussion Unregisters the application for push notifications.
+		*/
+		virtual void unregisterForPushNotifications() TITANIUM_NOEXCEPT;
 
 		TITANIUM_PROPERTY_READONLY_DEF(NETWORK_LAN);
 		TITANIUM_PROPERTY_READONLY_DEF(NETWORK_MOBILE);
@@ -60,12 +169,46 @@ namespace Titanium
 		TITANIUM_PROPERTY_READONLY_DEF(NETWORK_WIFI);
 		TITANIUM_PROPERTY_READONLY_DEF(NOTIFICATION_TYPE_ALERT);
 		TITANIUM_PROPERTY_READONLY_DEF(NOTIFICATION_TYPE_BADGE);
-		TITANIUM_PROPERTY_READONLY_DEF(NOTIFICATION_TYPE_NEWSSTAND);
 		TITANIUM_PROPERTY_READONLY_DEF(NOTIFICATION_TYPE_SOUND);
-		TITANIUM_PROPERTY_READONLY_DEF(PROGRESS_UNKNOWN);
+		TITANIUM_PROPERTY_READONLY_DEF(NOTIFICATION_TYPE_NEWSSTAND);
 		TITANIUM_PROPERTY_READONLY_DEF(TLS_VERSION_1_0);
 		TITANIUM_PROPERTY_READONLY_DEF(TLS_VERSION_1_1);
 		TITANIUM_PROPERTY_READONLY_DEF(TLS_VERSION_1_2);
+		TITANIUM_PROPERTY_READONLY_DEF(PROGRESS_UNKNOWN);
+		TITANIUM_PROPERTY_READONLY_DEF(allHTTPCookies);
+		TITANIUM_PROPERTY_READONLY_DEF(networkType);
+		TITANIUM_PROPERTY_READONLY_DEF(networkTypeName);
+		TITANIUM_PROPERTY_READONLY_DEF(online);
+		TITANIUM_PROPERTY_READONLY_DEF(remoteDeviceUUID);
+		TITANIUM_PROPERTY_READONLY_DEF(remoteNotificationTypes);
+		TITANIUM_PROPERTY_READONLY_DEF(remoteNotificationsEnabled);
+		TITANIUM_PROPERTY_DEF(httpURLFormatter);
+
+		TITANIUM_FUNCTION_DEF(addHTTPCookie);
+		TITANIUM_FUNCTION_DEF(addSystemCookie);
+		TITANIUM_FUNCTION_DEF(createBonjourBrowser);
+		TITANIUM_FUNCTION_DEF(createBonjourService);
+		TITANIUM_FUNCTION_DEF(getHTTPCookies);
+		TITANIUM_FUNCTION_DEF(getHTTPCookiesForDomain);
+		TITANIUM_FUNCTION_DEF(getSystemCookies);
+		TITANIUM_FUNCTION_DEF(removeAllHTTPCookies);
+		TITANIUM_FUNCTION_DEF(removeAllSystemCookies);
+		TITANIUM_FUNCTION_DEF(removeHTTPCookie);
+		TITANIUM_FUNCTION_DEF(removeHTTPCookiesForDomain);
+		TITANIUM_FUNCTION_DEF(removeSystemCookie);
+		TITANIUM_FUNCTION_DEF(registerForPushNotifications);
+		TITANIUM_FUNCTION_DEF(unregisterForPushNotifications);
+		TITANIUM_FUNCTION_DEF(createCookie);
+		TITANIUM_FUNCTION_DEF(createHTTPClient);
+		TITANIUM_FUNCTION_DEF(getAllHTTPCookies);
+		TITANIUM_FUNCTION_DEF(getNetworkType);
+		TITANIUM_FUNCTION_DEF(getNetworkTypeName);
+		TITANIUM_FUNCTION_DEF(getOnline);
+		TITANIUM_FUNCTION_DEF(getRemoteDeviceUUID);
+		TITANIUM_FUNCTION_DEF(getRemoteNotificationTypes);
+		TITANIUM_FUNCTION_DEF(getRemoteNotificationsEnabled);
+		TITANIUM_FUNCTION_DEF(getHttpURLFormatter);
+		TITANIUM_FUNCTION_DEF(setHttpURLFormatter);
 
 		NetworkModule(const JSContext&) TITANIUM_NOEXCEPT;
 
@@ -79,12 +222,9 @@ namespace Titanium
 
 		static void JSExportInitialize();
 
-		TITANIUM_FUNCTION_DEF(createHTTPClient);
-		TITANIUM_PROPERTY_READONLY_DEF(networkType);
-		TITANIUM_PROPERTY_READONLY_DEF(networkTypeName);
-		TITANIUM_PROPERTY_READONLY_DEF(online);
-
 	private:
+#pragma warning(push)
+#pragma warning(disable : 4251)
 		JSValue network_lan__;
 		JSValue network_mobile__;
 		JSValue network_none__;
@@ -92,12 +232,32 @@ namespace Titanium
 		JSValue network_wifi__;
 		JSValue notification_type_alert__;
 		JSValue notification_type_badge__;
-		JSValue notification_type_newsstand__;
 		JSValue notification_type_sound__;
-		JSValue progress_unknown__;
+		JSValue notification_type_newsstand__;
+		JSValue read_mode__;
+		JSValue read_write_mode__;
+		JSValue write_mode__;
+		JSValue socket_closed__;
+		JSValue socket_connected__;
+		JSValue socket_error__;
+		JSValue socket_initialized__;
+		JSValue socket_listening__;
 		JSValue tls_version_1_0__;
 		JSValue tls_version_1_1__;
 		JSValue tls_version_1_2__;
+		JSValue progress_unknown__;
+		
+		Network::TYPE networkType__;
+		std::string networkTypeName__;
+		bool online__;
+		std::string remoteDeviceUUID__;
+		std::vector<Network::NOTIFICATION_TYPE> remoteNotificationTypes__;
+		bool remoteNotificationsEnabled__;
+		
+		// User-defined function that is called everytime HTTPClient connects to a remote resource.
+		JSValue httpURLFormatter__;
+#pragma warning(pop)
+
 	};
 } // namespace Titanium
 

--- a/Source/TitaniumKit/include/Titanium/detail/TiBase.hpp
+++ b/Source/TitaniumKit/include/Titanium/detail/TiBase.hpp
@@ -272,6 +272,16 @@ TITANIUM_PROPERTY_SETTER(MODULE, NAME) { \
 	return true; \
 }
 
+#define TITANIUM_PROPERTY_GETTER_ENUM(MODULE, NAME) \
+  TITANIUM_PROPERTY_GETTER_TYPE(MODULE, NAME, std::uint32_t, Number)
+
+#define TITANIUM_PROPERTY_SETTER_ENUM(MODULE, NAME, ENUM_NAME) \
+TITANIUM_PROPERTY_SETTER(MODULE, NAME) { \
+  TITANIUM_ASSERT(argument.IsNumber()); \
+  set_##NAME(static_cast<ENUM_NAME>(static_cast<std::uint32_t>(argument))); \
+  return true; \
+}
+
 #define TITANIUM_PROPERTY_GETTER_STRUCT(MODULE, NAME, STRUCT_NAME) \
 TITANIUM_PROPERTY_GETTER(MODULE, NAME) { \
 	return STRUCT_NAME##_to_js(get_context(), get_##NAME()); \

--- a/Source/TitaniumKit/src/ApplicationBuilder.cpp
+++ b/Source/TitaniumKit/src/ApplicationBuilder.cpp
@@ -61,7 +61,10 @@ namespace Titanium
 		  database__(js_context__.CreateObject(JSExport<Titanium::DatabaseModule>::Class())),
 		  webview__(js_context__.CreateObject(JSExport<Titanium::UI::WebView>::Class())),
 		  httpclient__(js_context__.CreateObject(JSExport<Titanium::Network::HTTPClient>::Class())),
+		  cookie__(js_context__.CreateObject(JSExport<Titanium::Network::Cookie>::Class())),
 		  network__(js_context__.CreateObject(JSExport<Titanium::NetworkModule>::Class())),
+		  tcp__(js_context__.CreateObject(JSExport<Titanium::Network::Socket::TCP>::Class())),
+		  udp__(js_context__.CreateObject(JSExport<Titanium::Network::Socket::UDP>::Class())),
 		  xml__(js_context__.CreateObject(JSExport<Titanium::XML>::Class())),
 		  map__(js_context__.CreateObject(JSExport<Titanium::MapModule>::Class())),
 		  mapAnnotation__(js_context__.CreateObject(JSExport<Titanium::Map::Annotation>::Class())),
@@ -107,7 +110,13 @@ namespace Titanium
 		ui__.SetProperty("ScrollableView", scrollableView__, { JSPropertyAttribute::ReadOnly, JSPropertyAttribute::DontDelete });
 
 		filesystem__.SetProperty("File", file__);
+
+		JSObject socket__ = js_context__.CreateObject(JSExport<Titanium::Network::SocketModule>::Class());
+		socket__.SetProperty("TCP", tcp__);
+		socket__.SetProperty("UDP", udp__);
+		network__.SetProperty("Socket", socket__);
 		network__.SetProperty("HTTPClient", httpclient__);
+		network__.SetProperty("Cookie", cookie__);
 
 		JSObject titanium = ti__;
 		global_object__.SetProperty("Titanium", titanium, {JSPropertyAttribute::ReadOnly, JSPropertyAttribute::DontDelete});
@@ -517,6 +526,17 @@ namespace Titanium
 		return *this;
 	}
 
+	JSObject ApplicationBuilder::CookieObject() const TITANIUM_NOEXCEPT
+	{
+		return cookie__;
+	}
+
+	ApplicationBuilder& ApplicationBuilder::CookieObject(const JSObject& cookie) TITANIUM_NOEXCEPT
+	{
+		cookie__ = cookie;
+		return *this;
+	}
+
 	JSObject ApplicationBuilder::NetworkObject() const TITANIUM_NOEXCEPT
 	{
 		return network__;
@@ -525,6 +545,28 @@ namespace Titanium
 	ApplicationBuilder& ApplicationBuilder::NetworkObject(const JSObject& network) TITANIUM_NOEXCEPT
 	{
 		network__ = network;
+		return *this;
+	}
+
+	JSObject ApplicationBuilder::TCPObject() const TITANIUM_NOEXCEPT
+	{
+		return tcp__;
+	}
+
+	ApplicationBuilder& ApplicationBuilder::TCPObject(const JSObject& tcp) TITANIUM_NOEXCEPT
+	{
+		tcp__ = tcp;
+		return *this;
+	}
+
+	JSObject ApplicationBuilder::UDPObject() const TITANIUM_NOEXCEPT
+	{
+		return udp__;
+	}
+
+	ApplicationBuilder& ApplicationBuilder::UDPObject(const JSObject& udp) TITANIUM_NOEXCEPT
+	{
+		udp__ = udp;
 		return *this;
 	}
 

--- a/Source/TitaniumKit/src/Network/Constants.cpp
+++ b/Source/TitaniumKit/src/Network/Constants.cpp
@@ -161,9 +161,9 @@ namespace Titanium
 			static std::unordered_map<TLS_VERSION, std::string> map;
 			static std::once_flag of;
 			std::call_once(of, []() {
-				map[TLS_VERSION::ONE_ZERO] = "1_0";
-				map[TLS_VERSION::ONE_ONE]  = "1_1";
-				map[TLS_VERSION::ONE_TWO]  = "1_2";
+				map[TLS_VERSION::_1_0] = "1_0";
+				map[TLS_VERSION::_1_1]  = "1_1";
+				map[TLS_VERSION::_1_2]  = "1_2";
 			});
 
 			std::string string = unknown_string;
@@ -180,12 +180,12 @@ namespace Titanium
 			static std::unordered_map<std::string, TLS_VERSION> map;
 			static std::once_flag of;
 			std::call_once(of, []() {
-				map["1_0"]  = TLS_VERSION::ONE_ZERO;
-				map["1_1"] 	= TLS_VERSION::ONE_ONE;
-				map["1_2"]  = TLS_VERSION::ONE_TWO;
+				map["1_0"]  = TLS_VERSION::_1_0;
+				map["1_1"] 	= TLS_VERSION::_1_1;
+				map["1_2"]  = TLS_VERSION::_1_2;
 			});
 
-			TLS_VERSION version = TLS_VERSION::ONE_ZERO;
+			TLS_VERSION version = TLS_VERSION::_1_0;
 			const auto position = map.find(versionName);
 			if (position != map.end()) {
 				version = position->second;
@@ -201,12 +201,12 @@ namespace Titanium
 			static std::unordered_map<std::underlying_type<TLS_VERSION>::type, TLS_VERSION> map;
 			static std::once_flag of;
 			std::call_once(of, []() {
-				map[static_cast<std::underlying_type<TLS_VERSION>::type>(TLS_VERSION::ONE_ZERO)] = TLS_VERSION::ONE_ZERO;
-				map[static_cast<std::underlying_type<TLS_VERSION>::type>(TLS_VERSION::ONE_ONE)] = TLS_VERSION::ONE_ONE;
-				map[static_cast<std::underlying_type<TLS_VERSION>::type>(TLS_VERSION::ONE_TWO)] = TLS_VERSION::ONE_TWO;
+				map[static_cast<std::underlying_type<TLS_VERSION>::type>(TLS_VERSION::_1_0)] = TLS_VERSION::_1_0;
+				map[static_cast<std::underlying_type<TLS_VERSION>::type>(TLS_VERSION::_1_1)] = TLS_VERSION::_1_1;
+				map[static_cast<std::underlying_type<TLS_VERSION>::type>(TLS_VERSION::_1_2)] = TLS_VERSION::_1_2;
 			});
 
-			TLS_VERSION version = TLS_VERSION::ONE_ZERO;
+			TLS_VERSION version = TLS_VERSION::_1_0;
 			const auto position = map.find(version_underlying_type);
 			if (position != map.end()) {
 				version = position->second;
@@ -221,5 +221,146 @@ namespace Titanium
 		{
 			return static_cast<std::underlying_type<TLS_VERSION>::type>(version);
 		}
+
+		std::string Constants::to_string(const MODE& mode) TITANIUM_NOEXCEPT
+		{
+			static std::string unknown_string = "READ";
+			static std::unordered_map<MODE, std::string> map;
+			static std::once_flag of;
+			std::call_once(of, []() {
+				map[MODE::READ]        = "READ";
+				map[MODE::WRITE]       = "WRITE";
+				map[MODE::READ_WRITE]  = "READ_WRITE";
+			});
+
+			std::string string = unknown_string;
+			const auto position = map.find(mode);
+			if (position != map.end()) {
+				string = position->second;
+			}
+
+			return string;
+		}
+
+		MODE Constants::to_MODE(const std::string& modeName) TITANIUM_NOEXCEPT
+		{
+			static std::unordered_map<std::string, MODE> map;
+			static std::once_flag of;
+			std::call_once(of, []() {
+				map["1_0"]  = MODE::READ;
+				map["1_1"] 	= MODE::WRITE;
+				map["1_2"]  = MODE::READ_WRITE;
+			});
+
+			MODE mode = MODE::READ;
+			const auto position = map.find(modeName);
+			if (position != map.end()) {
+				mode = position->second;
+			} else {
+				TITANIUM_LOG_WARN("Constants::to_MODE: Titanium::Network::MODE with name '", modeName, "' does not exist");
+			}
+
+			return mode;
+		}
+
+		MODE Constants::to_MODE(std::underlying_type<MODE>::type mode_underlying_type) TITANIUM_NOEXCEPT
+		{
+			static std::unordered_map<std::underlying_type<MODE>::type, MODE> map;
+			static std::once_flag of;
+			std::call_once(of, []() {
+				map[static_cast<std::underlying_type<MODE>::type>(MODE::READ)] = MODE::READ;
+				map[static_cast<std::underlying_type<MODE>::type>(MODE::WRITE)] = MODE::WRITE;
+				map[static_cast<std::underlying_type<MODE>::type>(MODE::READ_WRITE)] = MODE::READ_WRITE;
+			});
+
+			MODE mode = MODE::READ;
+			const auto position = map.find(mode_underlying_type);
+			if (position != map.end()) {
+				mode = position->second;
+			} else {
+				TITANIUM_LOG_WARN("Constants::to_MODE: Titanium::Network::MODE with value '", mode_underlying_type, "' does not exist");
+			}
+
+			return mode;
+		}
+
+		std::underlying_type<MODE>::type Constants::to_underlying_type(const MODE& mode) TITANIUM_NOEXCEPT
+		{
+			return static_cast<std::underlying_type<MODE>::type>(mode);
+		}
+
+		std::string Constants::to_string(const SOCKET& socket) TITANIUM_NOEXCEPT
+		{
+			static std::string unknown_string = "ERROR";
+			static std::unordered_map<SOCKET, std::string> map;
+			static std::once_flag of;
+			std::call_once(of, []() {
+				map[SOCKET::INITIALIZED] = "INITIALIZED";
+				map[SOCKET::CONNECTED]   = "CONNECTED";
+				map[SOCKET::LISTENING]   = "LISTENING";
+				map[SOCKET::CLOSED]      = "CLOSED";
+				map[SOCKET::ERROR]       = "ERROR";
+			});
+
+			std::string string = unknown_string;
+			const auto position = map.find(socket);
+			if (position != map.end()) {
+				string = position->second;
+			}
+
+			return string;
+		}
+
+		SOCKET Constants::to_SOCKET(const std::string& socketName) TITANIUM_NOEXCEPT
+		{
+			static std::unordered_map<std::string, SOCKET> map;
+			static std::once_flag of;
+			std::call_once(of, []() {
+				map["INITIALIZED"] = SOCKET::INITIALIZED;
+				map["CONNECTED"]   = SOCKET::CONNECTED;
+				map["LISTENING"]   = SOCKET::LISTENING;
+				map["CLOSED"]      = SOCKET::CLOSED;
+				map["ERROR"]       = SOCKET::ERROR;
+			});
+
+			SOCKET socket = SOCKET::INITIALIZED;
+			const auto position = map.find(socketName);
+			if (position != map.end()) {
+				socket = position->second;
+			} else {
+				TITANIUM_LOG_WARN("Constants::to_SOCKET: Titanium::Network::SOCKET with name '", socketName, "' does not exist");
+			}
+
+			return socket;
+		}
+
+		SOCKET Constants::to_SOCKET(std::underlying_type<SOCKET>::type socket_underlying_type) TITANIUM_NOEXCEPT
+		{
+			static std::unordered_map<std::underlying_type<SOCKET>::type, SOCKET> map;
+			static std::once_flag of;
+			std::call_once(of, []() {
+				map[static_cast<std::underlying_type<SOCKET>::type>(SOCKET::INITIALIZED)] = SOCKET::INITIALIZED;
+				map[static_cast<std::underlying_type<SOCKET>::type>(SOCKET::CONNECTED)] = SOCKET::CONNECTED;
+				map[static_cast<std::underlying_type<SOCKET>::type>(SOCKET::LISTENING)] = SOCKET::LISTENING;
+				map[static_cast<std::underlying_type<SOCKET>::type>(SOCKET::CLOSED)] = SOCKET::CLOSED;
+				map[static_cast<std::underlying_type<SOCKET>::type>(SOCKET::ERROR)] = SOCKET::ERROR;
+			});
+
+			SOCKET socket = SOCKET::ERROR;
+			const auto position = map.find(socket_underlying_type);
+			if (position != map.end()) {
+				socket = position->second;
+			} else {
+				TITANIUM_LOG_WARN("Constants::to_SOCKET: Titanium::Network::SOCKET with value '", socket_underlying_type, "' does not exist");
+			}
+
+			return socket;
+		}
+
+		std::underlying_type<SOCKET>::type Constants::to_underlying_type(const SOCKET& socket) TITANIUM_NOEXCEPT
+		{
+			return static_cast<std::underlying_type<SOCKET>::type>(socket);
+		}
+
 	} // namespace Network
 }  // namespace Titanium

--- a/Source/TitaniumKit/src/Network/Cookie.cpp
+++ b/Source/TitaniumKit/src/Network/Cookie.cpp
@@ -1,0 +1,140 @@
+/**
+ * TitaniumKit Titanium.Network.Cookie
+ *
+ * Copyright (c) 2015 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License.
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#include "Titanium/Network/Cookie.hpp"
+
+namespace Titanium
+{
+	namespace Network
+	{
+
+
+		Cookie::Cookie(const JSContext& js_context) TITANIUM_NOEXCEPT
+			: Module(js_context)
+			, comment__("")
+			, domain__("")
+			, expiryDate__("")
+			, httponly__(false)
+			, name__("")
+			, originalUrl__("")
+			, path__("")
+			, secure__(false)
+			, value__("")
+			, version__(1)
+		{
+		}
+
+		TITANIUM_PROPERTY_READWRITE(Cookie, std::string, comment)
+		TITANIUM_PROPERTY_READWRITE(Cookie, std::string, domain)
+		TITANIUM_PROPERTY_READWRITE(Cookie, std::string, expiryDate)
+		TITANIUM_PROPERTY_READWRITE(Cookie, bool, httponly)
+		TITANIUM_PROPERTY_READ(Cookie, std::string, name)
+		TITANIUM_PROPERTY_READWRITE(Cookie, std::string, originalUrl)
+		TITANIUM_PROPERTY_READWRITE(Cookie, std::string, path)
+		TITANIUM_PROPERTY_READWRITE(Cookie, bool, secure)
+		TITANIUM_PROPERTY_READWRITE(Cookie, std::string, value)
+		TITANIUM_PROPERTY_READWRITE(Cookie, std::uint32_t, version)
+
+		bool Cookie::isValid() TITANIUM_NOEXCEPT
+		{
+			TITANIUM_LOG_WARN("Cookie::isValid: Unimplemented");
+			return false;
+		}
+
+		void Cookie::JSExportInitialize() 
+		{
+			JSExport<Cookie>::SetClassVersion(1);
+			JSExport<Cookie>::SetParent(JSExport<Module>::Class());
+
+			TITANIUM_ADD_PROPERTY(Cookie, comment);
+			TITANIUM_ADD_PROPERTY(Cookie, domain);
+			TITANIUM_ADD_PROPERTY(Cookie, expiryDate);
+			TITANIUM_ADD_PROPERTY(Cookie, httponly);
+			TITANIUM_ADD_PROPERTY_READONLY(Cookie, name);
+			TITANIUM_ADD_PROPERTY(Cookie, originalUrl);
+			TITANIUM_ADD_PROPERTY(Cookie, path);
+			TITANIUM_ADD_PROPERTY(Cookie, secure);
+			TITANIUM_ADD_PROPERTY(Cookie, value);
+			TITANIUM_ADD_PROPERTY(Cookie, version);
+
+			TITANIUM_ADD_FUNCTION(Cookie, isValid);
+			TITANIUM_ADD_FUNCTION(Cookie, getComment);
+			TITANIUM_ADD_FUNCTION(Cookie, setComment);
+			TITANIUM_ADD_FUNCTION(Cookie, getDomain);
+			TITANIUM_ADD_FUNCTION(Cookie, setDomain);
+			TITANIUM_ADD_FUNCTION(Cookie, getExpiryDate);
+			TITANIUM_ADD_FUNCTION(Cookie, setExpiryDate);
+			TITANIUM_ADD_FUNCTION(Cookie, getHttponly);
+			TITANIUM_ADD_FUNCTION(Cookie, setHttponly);
+			TITANIUM_ADD_FUNCTION(Cookie, getName);
+			TITANIUM_ADD_FUNCTION(Cookie, getOriginalUrl);
+			TITANIUM_ADD_FUNCTION(Cookie, setOriginalUrl);
+			TITANIUM_ADD_FUNCTION(Cookie, getPath);
+			TITANIUM_ADD_FUNCTION(Cookie, setPath);
+			TITANIUM_ADD_FUNCTION(Cookie, getSecure);
+			TITANIUM_ADD_FUNCTION(Cookie, setSecure);
+			TITANIUM_ADD_FUNCTION(Cookie, getValue);
+			TITANIUM_ADD_FUNCTION(Cookie, setValue);
+			TITANIUM_ADD_FUNCTION(Cookie, getVersion);
+			TITANIUM_ADD_FUNCTION(Cookie, setVersion);
+		}
+
+		TITANIUM_PROPERTY_GETTER_STRING(Cookie, comment)
+		TITANIUM_PROPERTY_SETTER_STRING(Cookie, comment)
+		TITANIUM_PROPERTY_GETTER_STRING(Cookie, domain)
+		TITANIUM_PROPERTY_SETTER_STRING(Cookie, domain)
+		TITANIUM_PROPERTY_GETTER_STRING(Cookie, expiryDate)
+		TITANIUM_PROPERTY_SETTER_STRING(Cookie, expiryDate)
+
+		TITANIUM_PROPERTY_GETTER_BOOL(Cookie, httponly)
+		TITANIUM_PROPERTY_SETTER_BOOL(Cookie, httponly)
+
+		TITANIUM_PROPERTY_GETTER_STRING(Cookie, name)
+		TITANIUM_PROPERTY_GETTER_STRING(Cookie, originalUrl)
+		TITANIUM_PROPERTY_SETTER_STRING(Cookie, originalUrl)
+
+		TITANIUM_PROPERTY_GETTER_STRING(Cookie, path)
+		TITANIUM_PROPERTY_SETTER_STRING(Cookie, path)
+
+		TITANIUM_PROPERTY_GETTER_BOOL(Cookie, secure)
+		TITANIUM_PROPERTY_SETTER_BOOL(Cookie, secure)
+
+		TITANIUM_PROPERTY_GETTER_STRING(Cookie, value)
+		TITANIUM_PROPERTY_SETTER_STRING(Cookie, value)
+
+		TITANIUM_PROPERTY_GETTER_UINT(Cookie, version)
+		TITANIUM_PROPERTY_SETTER_UINT(Cookie, version)
+
+		TITANIUM_FUNCTION(Cookie, isValid)
+		{
+			isValid();
+			return get_context().CreateUndefined();
+		}
+
+		TITANIUM_FUNCTION_AS_GETTER(Cookie, getComment, comment)
+		TITANIUM_FUNCTION_AS_SETTER(Cookie, setComment, comment)
+		TITANIUM_FUNCTION_AS_GETTER(Cookie, getDomain, domain)
+		TITANIUM_FUNCTION_AS_SETTER(Cookie, setDomain, domain)
+		TITANIUM_FUNCTION_AS_GETTER(Cookie, getExpiryDate, expiryDate)
+		TITANIUM_FUNCTION_AS_SETTER(Cookie, setExpiryDate, expiryDate)
+		TITANIUM_FUNCTION_AS_GETTER(Cookie, getHttponly, httponly)
+		TITANIUM_FUNCTION_AS_SETTER(Cookie, setHttponly, httponly)
+		TITANIUM_FUNCTION_AS_GETTER(Cookie, getName, name)
+		TITANIUM_FUNCTION_AS_GETTER(Cookie, getOriginalUrl, originalUrl)
+		TITANIUM_FUNCTION_AS_SETTER(Cookie, setOriginalUrl, originalUrl)
+		TITANIUM_FUNCTION_AS_GETTER(Cookie, getPath, path)
+		TITANIUM_FUNCTION_AS_SETTER(Cookie, setPath, path)
+		TITANIUM_FUNCTION_AS_GETTER(Cookie, getSecure, secure)
+		TITANIUM_FUNCTION_AS_SETTER(Cookie, setSecure, secure)
+		TITANIUM_FUNCTION_AS_GETTER(Cookie, getValue, value)
+		TITANIUM_FUNCTION_AS_SETTER(Cookie, setValue, value)
+		TITANIUM_FUNCTION_AS_GETTER(Cookie, getVersion, version)
+		TITANIUM_FUNCTION_AS_SETTER(Cookie, setVersion, version)
+
+	} // namespace Network
+} // namespace Titanium

--- a/Source/TitaniumKit/src/Network/HTTPClient.cpp
+++ b/Source/TitaniumKit/src/Network/HTTPClient.cpp
@@ -12,55 +12,52 @@ namespace Titanium
 	namespace Network
 	{
 		HTTPClient::HTTPClient(const JSContext& js_context) TITANIUM_NOEXCEPT
-		    : Module(js_context),
-		      onload_callback__(js_context.CreateObject()),
-		      onerror_callback__(js_context.CreateObject()),
-			  ondatastream_callback__(js_context.CreateObject()),
-		      onsendstream_callback__(js_context.CreateObject()),
-		      onreadystatechange_callback__(js_context.CreateObject())
+			: Module(js_context)
+			, onload__(js_context.CreateNull())
+			, onerror__(js_context.CreateNull())
+			, ondatastream__(js_context.CreateNull())
+			, onsendstream__(js_context.CreateNull())
+			, onreadystatechange__(js_context.CreateNull())
+			, done__(js_context.CreateNumber(static_cast<uint32_t>(RequestState::Done)))
+			, headers_received__(js_context.CreateNumber(static_cast<uint32_t>(RequestState::Headers_Received)))
+			, loading__(js_context.CreateNumber(static_cast<uint32_t>(RequestState::Loading)))
+			, opened__(js_context.CreateNumber(static_cast<uint32_t>(RequestState::Opened)))
+			, unsent__(js_context.CreateNumber(static_cast<uint32_t>(RequestState::Unsent)))
+			, responseXML__(js_context.CreateNull())
+			, securityManager__(js_context.CreateNull())
+			, status__(200)
+			, readyState__(RequestState::Unsent)
 		{
 			setHTTPStatusPhrase();
 		}
 
-		std::chrono::milliseconds HTTPClient::get_timeout() const TITANIUM_NOEXCEPT
-		{
-			return timeout__;
-		}
+		TITANIUM_PROPERTY_READWRITE(HTTPClient, std::chrono::milliseconds, timeout)
+		TITANIUM_PROPERTY_READWRITE(HTTPClient, std::string, file)
+		TITANIUM_PROPERTY_READWRITE(HTTPClient, std::string, username)
+		TITANIUM_PROPERTY_READWRITE(HTTPClient, std::string, password)
+		TITANIUM_PROPERTY_READWRITE(HTTPClient, std::string, domain)
+		TITANIUM_PROPERTY_READ(HTTPClient, std::string, location)
+		TITANIUM_PROPERTY_READWRITE(HTTPClient, bool, cache)
 
-		void HTTPClient::set_timeout(const std::chrono::milliseconds& timeout) TITANIUM_NOEXCEPT
-		{
-			timeout__ = timeout;
-		}
+		TITANIUM_PROPERTY_READWRITE(HTTPClient, bool, autoEncodeUrl)
+		TITANIUM_PROPERTY_READ(HTTPClient, RequestState, readyState)
+		TITANIUM_PROPERTY_READ(HTTPClient, std::string, allResponseHeaders)
+		TITANIUM_PROPERTY_READ(HTTPClient, std::uint32_t, status)
+		TITANIUM_PROPERTY_READWRITE(HTTPClient, TLS_VERSION, tlsVersion)
+		TITANIUM_PROPERTY_READWRITE(HTTPClient, bool, autoRedirect)
+		TITANIUM_PROPERTY_READ(HTTPClient, bool, connected)
+		TITANIUM_PROPERTY_READ(HTTPClient, std::string, connectionType) 
+		TITANIUM_PROPERTY_READWRITE(HTTPClient, bool, enableKeepAlive)
+		TITANIUM_PROPERTY_READWRITE(HTTPClient, bool, validatesSecureCertificate)
+		TITANIUM_PROPERTY_READWRITE(HTTPClient, bool, withCredentials)
+		TITANIUM_PROPERTY_READ(HTTPClient, std::vector<std::uint8_t>, responseData);
 
 		std::string HTTPClient::get_responseText() const TITANIUM_NOEXCEPT
 		{
-			TITANIUM_LOG_WARN("HTTPClient::get_responseText: Unimplemented");
-			return "";
+			auto data = get_responseData();
+			return std::string(data.begin(), data.end());
 		}
 
-		std::vector<std::uint8_t> HTTPClient::get_responseData() const TITANIUM_NOEXCEPT
-		{
-			TITANIUM_LOG_WARN("HTTPClient::get_responseData: Unimplemented");
-			return std::vector<std::uint8_t>();  //empty
-		}
-
-		std::string HTTPClient::get_allResponseHeaders() const TITANIUM_NOEXCEPT
-		{
-			TITANIUM_LOG_WARN("HTTPClient::get_allResponseHeaders: Unimplemented");
-			return "";
-		}
-
-		std::uint32_t HTTPClient::get_readyState() const TITANIUM_NOEXCEPT
-		{
-			TITANIUM_LOG_WARN("HTTPClient::getReadyState: Unimplemented");
-			return N_REQUEST_STATE_UNSENT;
-		}
-
-		std::uint32_t HTTPClient::get_status() const TITANIUM_NOEXCEPT
-		{
-			TITANIUM_LOG_WARN("HTTPClient::getStatus: Unimplemented");
-			return 200;
-		}
 
 		std::string HTTPClient::get_statusText() const TITANIUM_NOEXCEPT
 		{
@@ -72,126 +69,187 @@ namespace Titanium
 			return "HTTP Status Phrase Not Found";
 		}
 
-		// Methods
 		void HTTPClient::abort() TITANIUM_NOEXCEPT
 		{
-			TITANIUM_LOG_WARN("HTTPClient::abort: Unimplemented");
+			TITANIUM_LOG_WARN("HTTPClient::abort: unimplemented");
 		}
 
 		void HTTPClient::clearCookies(const std::string& url) TITANIUM_NOEXCEPT
 		{
-			TITANIUM_LOG_WARN("HTTPClient::clearCookies: Unimplemented");
+			TITANIUM_LOG_WARN("HTTPClient::clearCookies: unimplemented");
 		}
 
 		std::string HTTPClient::getResponseHeader(const std::string& name) TITANIUM_NOEXCEPT
 		{
-			TITANIUM_LOG_WARN("HTTPClient::getResponseHeader: Unimplemented");
+			TITANIUM_LOG_WARN("HTTPClient::getResponseHeader: unimplemented");
 			return "";
 		}
 
 		void HTTPClient::open(const std::string& method, const std::string& url) TITANIUM_NOEXCEPT
 		{
-			TITANIUM_LOG_WARN("HTTPClient::open: Unimplemented");
+			TITANIUM_LOG_WARN("HTTPClient::open: unimplemented");
 		}
 
 		void HTTPClient::send() TITANIUM_NOEXCEPT
 		{
-			TITANIUM_LOG_WARN("HTTPClient::send: Unimplemented");
+			TITANIUM_LOG_WARN("HTTPClient::send: unimplemented");
 		}
 
 		void HTTPClient::send(const std::map<std::string, std::vector<std::uint8_t>>& postDataPairs, const bool& useMultipartForm) TITANIUM_NOEXCEPT
 		{
-			TITANIUM_LOG_WARN("HTTPClient::send<data>: Unimplemented");
+			TITANIUM_LOG_WARN("HTTPClient::send<data>: unimplemented");
 		}
 
 		void HTTPClient::send(const std::string& postDataStr) TITANIUM_NOEXCEPT
 		{
-			TITANIUM_LOG_WARN("HTTPClient::send<data string>: Unimplemented");
+			TITANIUM_LOG_WARN("HTTPClient::send<data string>: unimplemented");
 		}
 		
 		void HTTPClient::setRequestHeader(const std::string& name, const std::string& value) TITANIUM_NOEXCEPT
 		{
-			TITANIUM_LOG_WARN("HTTPClient::setRequestHeader: Unimplemented");
+			TITANIUM_LOG_WARN("HTTPClient::setRequestHeader: unimplemented");
 		}
 
 		void HTTPClient::JSExportInitialize()
 		{
 			JSExport<HTTPClient>::SetClassVersion(1);
 			JSExport<HTTPClient>::SetParent(JSExport<Module>::Class());
-			// constants
-			TITANIUM_ADD_PROPERTY_READONLY(HTTPClient, LOADING);
-			TITANIUM_ADD_PROPERTY_READONLY(HTTPClient, OPENED);
-			TITANIUM_ADD_PROPERTY_READONLY(HTTPClient, DONE);
-			TITANIUM_ADD_PROPERTY_READONLY(HTTPClient, UNSENT);
-			TITANIUM_ADD_PROPERTY_READONLY(HTTPClient, HEADERS_RECEIVED);
-			// properties
-			TITANIUM_ADD_PROPERTY_READONLY(HTTPClient, allResponseHeaders);
+
+			TITANIUM_ADD_PROPERTY(HTTPClient, autoEncodeUrl);
+			TITANIUM_ADD_PROPERTY(HTTPClient, autoRedirect);
+			TITANIUM_ADD_PROPERTY(HTTPClient, cache);
+			TITANIUM_ADD_PROPERTY(HTTPClient, domain);
+			TITANIUM_ADD_PROPERTY(HTTPClient, enableKeepAlive);
+			TITANIUM_ADD_PROPERTY(HTTPClient, file);
 			TITANIUM_ADD_PROPERTY(HTTPClient, ondatastream);
 			TITANIUM_ADD_PROPERTY(HTTPClient, onerror);
 			TITANIUM_ADD_PROPERTY(HTTPClient, onload);
 			TITANIUM_ADD_PROPERTY(HTTPClient, onreadystatechange);
 			TITANIUM_ADD_PROPERTY(HTTPClient, onsendstream);
+			TITANIUM_ADD_PROPERTY(HTTPClient, password);
+			TITANIUM_ADD_PROPERTY(HTTPClient, securityManager);
+			TITANIUM_ADD_PROPERTY(HTTPClient, timeout);
+			TITANIUM_ADD_PROPERTY(HTTPClient, tlsVersion);
+			TITANIUM_ADD_PROPERTY(HTTPClient, username);
+			TITANIUM_ADD_PROPERTY(HTTPClient, validatesSecureCertificate);
+			TITANIUM_ADD_PROPERTY(HTTPClient, withCredentials);
+			TITANIUM_ADD_PROPERTY_READONLY(HTTPClient, DONE);
+			TITANIUM_ADD_PROPERTY_READONLY(HTTPClient, HEADERS_RECEIVED);
+			TITANIUM_ADD_PROPERTY_READONLY(HTTPClient, LOADING);
+			TITANIUM_ADD_PROPERTY_READONLY(HTTPClient, OPENED);
+			TITANIUM_ADD_PROPERTY_READONLY(HTTPClient, UNSENT);
+			TITANIUM_ADD_PROPERTY_READONLY(HTTPClient, allResponseHeaders);
+			TITANIUM_ADD_PROPERTY_READONLY(HTTPClient, connected);
+			TITANIUM_ADD_PROPERTY_READONLY(HTTPClient, connectionType);
+			TITANIUM_ADD_PROPERTY_READONLY(HTTPClient, location);
 			TITANIUM_ADD_PROPERTY_READONLY(HTTPClient, readyState);
 			TITANIUM_ADD_PROPERTY_READONLY(HTTPClient, responseData);
 			TITANIUM_ADD_PROPERTY_READONLY(HTTPClient, responseText);
+			TITANIUM_ADD_PROPERTY_READONLY(HTTPClient, responseXML);
 			TITANIUM_ADD_PROPERTY_READONLY(HTTPClient, status);
 			TITANIUM_ADD_PROPERTY_READONLY(HTTPClient, statusText);
-			TITANIUM_ADD_PROPERTY(HTTPClient, timeout);
-			// methods
-			TITANIUM_ADD_FUNCTION(HTTPClient, open);
-			TITANIUM_ADD_FUNCTION(HTTPClient, send);
-			TITANIUM_ADD_FUNCTION(HTTPClient, abort);
-			TITANIUM_ADD_FUNCTION(HTTPClient, setRequestHeader);
-			TITANIUM_ADD_FUNCTION(HTTPClient, getResponseHeader);
-			TITANIUM_ADD_FUNCTION(HTTPClient, clearCookies);
 
-			// accessors
+			TITANIUM_ADD_FUNCTION(HTTPClient, abort);
+			TITANIUM_ADD_FUNCTION(HTTPClient, addAuthFactory);
+			TITANIUM_ADD_FUNCTION(HTTPClient, addKeyManager);
+			TITANIUM_ADD_FUNCTION(HTTPClient, addTrustManager);
+			TITANIUM_ADD_FUNCTION(HTTPClient, clearCookies);
 			TITANIUM_ADD_FUNCTION(HTTPClient, getAllResponseHeaders);
+			TITANIUM_ADD_FUNCTION(HTTPClient, getAutoEncodeUrl);
+			TITANIUM_ADD_FUNCTION(HTTPClient, getAutoRedirect);
+			TITANIUM_ADD_FUNCTION(HTTPClient, getCache);
+			TITANIUM_ADD_FUNCTION(HTTPClient, getConnected);
+			TITANIUM_ADD_FUNCTION(HTTPClient, getConnectionType);
+			TITANIUM_ADD_FUNCTION(HTTPClient, getDomain);
+			TITANIUM_ADD_FUNCTION(HTTPClient, getEnableKeepAlive);
+			TITANIUM_ADD_FUNCTION(HTTPClient, getFile);
+			TITANIUM_ADD_FUNCTION(HTTPClient, getLocation);
 			TITANIUM_ADD_FUNCTION(HTTPClient, getOndatastream);
-			TITANIUM_ADD_FUNCTION(HTTPClient, setOndatastream);
 			TITANIUM_ADD_FUNCTION(HTTPClient, getOnerror);
-			TITANIUM_ADD_FUNCTION(HTTPClient, setOnerror);
 			TITANIUM_ADD_FUNCTION(HTTPClient, getOnload);
-			TITANIUM_ADD_FUNCTION(HTTPClient, setOnload);
 			TITANIUM_ADD_FUNCTION(HTTPClient, getOnreadystatechange);
-			TITANIUM_ADD_FUNCTION(HTTPClient, setOnreadystatechange);
 			TITANIUM_ADD_FUNCTION(HTTPClient, getOnsendstream);
-			TITANIUM_ADD_FUNCTION(HTTPClient, setOnsendstream);
+			TITANIUM_ADD_FUNCTION(HTTPClient, getPassword);
 			TITANIUM_ADD_FUNCTION(HTTPClient, getReadyState);
 			TITANIUM_ADD_FUNCTION(HTTPClient, getResponseData);
+			TITANIUM_ADD_FUNCTION(HTTPClient, getResponseHeader);
 			TITANIUM_ADD_FUNCTION(HTTPClient, getResponseText);
+			TITANIUM_ADD_FUNCTION(HTTPClient, getResponseXML);
+			TITANIUM_ADD_FUNCTION(HTTPClient, getSecurityManager);
 			TITANIUM_ADD_FUNCTION(HTTPClient, getStatus);
 			TITANIUM_ADD_FUNCTION(HTTPClient, getStatusText);
 			TITANIUM_ADD_FUNCTION(HTTPClient, getTimeout);
+			TITANIUM_ADD_FUNCTION(HTTPClient, getTlsVersion);
+			TITANIUM_ADD_FUNCTION(HTTPClient, getUsername);
+			TITANIUM_ADD_FUNCTION(HTTPClient, getValidatesSecureCertificate);
+			TITANIUM_ADD_FUNCTION(HTTPClient, getWithCredentials);
+			TITANIUM_ADD_FUNCTION(HTTPClient, open);
+			TITANIUM_ADD_FUNCTION(HTTPClient, send);
+			TITANIUM_ADD_FUNCTION(HTTPClient, setAutoEncodeUrl);
+			TITANIUM_ADD_FUNCTION(HTTPClient, setAutoRedirect);
+			TITANIUM_ADD_FUNCTION(HTTPClient, setCache);
+			TITANIUM_ADD_FUNCTION(HTTPClient, setDomain);
+			TITANIUM_ADD_FUNCTION(HTTPClient, setEnableKeepAlive);
+			TITANIUM_ADD_FUNCTION(HTTPClient, setFile);
+			TITANIUM_ADD_FUNCTION(HTTPClient, setOndatastream);
+			TITANIUM_ADD_FUNCTION(HTTPClient, setOnerror);
+			TITANIUM_ADD_FUNCTION(HTTPClient, setOnload);
+			TITANIUM_ADD_FUNCTION(HTTPClient, setOnreadystatechange);
+			TITANIUM_ADD_FUNCTION(HTTPClient, setOnsendstream);
+			TITANIUM_ADD_FUNCTION(HTTPClient, setPassword);
+			TITANIUM_ADD_FUNCTION(HTTPClient, setRequestHeader);
+			TITANIUM_ADD_FUNCTION(HTTPClient, setSecurityManager);
 			TITANIUM_ADD_FUNCTION(HTTPClient, setTimeout);
+			TITANIUM_ADD_FUNCTION(HTTPClient, setTlsVersion);
+			TITANIUM_ADD_FUNCTION(HTTPClient, setUsername);
+			TITANIUM_ADD_FUNCTION(HTTPClient, setValidatesSecureCertificate);
+			TITANIUM_ADD_FUNCTION(HTTPClient, setWithCredentials);
+
 		}
 
 		TITANIUM_PROPERTY_GETTER(HTTPClient, LOADING)
 		{
-			return get_context().CreateNumber(N_REQUEST_STATE_LOADING);
+			return loading__;
 		}
 
 		TITANIUM_PROPERTY_GETTER(HTTPClient, OPENED)
 		{
-			return get_context().CreateNumber(N_REQUEST_STATE_OPENED);
+			return opened__;
 		}
 
 		TITANIUM_PROPERTY_GETTER(HTTPClient, DONE)
 		{
-			return get_context().CreateNumber(N_REQUEST_STATE_DONE);
+			return done__;
 		}
 
 		TITANIUM_PROPERTY_GETTER(HTTPClient, UNSENT)
 		{
-			return get_context().CreateNumber(N_REQUEST_STATE_UNSENT);
+			return unsent__;
 		}
 
 		TITANIUM_PROPERTY_GETTER(HTTPClient, HEADERS_RECEIVED)
 		{
-			return get_context().CreateNumber(N_REQUEST_STATE_HEADERS_RECEIVED);
+			return headers_received__;
 		}
 
-		// Methods
+		TITANIUM_FUNCTION(HTTPClient, addAuthFactory)
+		{
+			TITANIUM_LOG_WARN("HTTPClient::addAuthFactory: unimplemented");
+			return get_context().CreateUndefined();
+		}
+
+		TITANIUM_FUNCTION(HTTPClient, addTrustManager)
+		{
+			TITANIUM_LOG_WARN("HTTPClient::addTrustManager: unimplemented");
+			return get_context().CreateUndefined();
+		}
+
+		TITANIUM_FUNCTION(HTTPClient, addKeyManager)
+		{
+			TITANIUM_LOG_WARN("HTTPClient::addKeyManager: unimplemented");
+			return get_context().CreateUndefined();
+		}
+
 		TITANIUM_FUNCTION(HTTPClient, abort)
 		{
 			abort();
@@ -271,26 +329,10 @@ namespace Titanium
 			return get_context().CreateUndefined();
 		}
 
-		// properties
-		TITANIUM_PROPERTY_GETTER(HTTPClient, allResponseHeaders)
-		{
-			return get_context().CreateString(get_allResponseHeaders());
-		}
-
-		TITANIUM_FUNCTION(HTTPClient, getAllResponseHeaders)
-		{
-			return js_get_allResponseHeaders();
-		}
-
-		TITANIUM_PROPERTY_GETTER(HTTPClient, readyState)
-		{
-			return get_context().CreateNumber(get_readyState());
-		}
-
-		TITANIUM_FUNCTION(HTTPClient, getReadyState)
-		{
-			return js_get_readyState();
-		}
+		TITANIUM_PROPERTY_GETTER_STRING(HTTPClient, allResponseHeaders)
+		TITANIUM_FUNCTION_AS_GETTER(HTTPClient, getAllResponseHeaders, allResponseHeaders)
+		TITANIUM_PROPERTY_GETTER_UINT(HTTPClient, readyState)
+		TITANIUM_FUNCTION_AS_GETTER(HTTPClient, getReadyState, readyState)
 
 		TITANIUM_PROPERTY_GETTER(HTTPClient, responseData)
 		{
@@ -303,196 +345,219 @@ namespace Titanium
 			return blob;
 		}
 
-		TITANIUM_FUNCTION(HTTPClient, getResponseData)
+		TITANIUM_FUNCTION_AS_GETTER(HTTPClient, getResponseData, responseData)
+		TITANIUM_PROPERTY_GETTER_STRING(HTTPClient, responseText)
+		TITANIUM_FUNCTION_AS_GETTER(HTTPClient, getResponseText, responseText)
+
+		TITANIUM_PROPERTY_GETTER(HTTPClient, responseXML)
 		{
-			return js_get_responseData();
+			return responseXML__;
 		}
 
-		TITANIUM_PROPERTY_GETTER(HTTPClient, responseText)
+		TITANIUM_FUNCTION(HTTPClient, getResponseXML)
 		{
-			return get_context().CreateString(get_responseText());
+			return js_get_responseXML();
 		}
 
-		TITANIUM_FUNCTION(HTTPClient, getResponseText)
+		TITANIUM_PROPERTY_GETTER(HTTPClient, securityManager)
 		{
-			return js_get_responseText();
+			return securityManager__;
 		}
 
-		TITANIUM_PROPERTY_GETTER(HTTPClient, status)
+		TITANIUM_PROPERTY_SETTER(HTTPClient, securityManager)
 		{
-			return get_context().CreateNumber(get_status());
-		}
-			
-		TITANIUM_FUNCTION(HTTPClient, getStatus)
-		{
-			return js_get_status();
+			TITANIUM_ASSERT(argument.IsObject());
+			securityManager__ = static_cast<JSObject>(argument);
+			return true;
 		}
 
-		TITANIUM_PROPERTY_GETTER(HTTPClient, statusText)
+		TITANIUM_FUNCTION(HTTPClient, getSecurityManager)
 		{
-			return get_context().CreateString(get_statusText());
+			return js_get_securityManager();
 		}
 
-		TITANIUM_FUNCTION(HTTPClient, getStatusText)
+		TITANIUM_FUNCTION(HTTPClient, setSecurityManager)
 		{
-			return js_get_statusText();
+			ENSURE_OBJECT_AT_INDEX(object, 0);
+			js_set_securityManager(object);
+			return get_context().CreateUndefined();
 		}
+
+		TITANIUM_PROPERTY_GETTER_ENUM(HTTPClient, tlsVersion)
+		TITANIUM_PROPERTY_SETTER_ENUM(HTTPClient, tlsVersion, TLS_VERSION)
+		TITANIUM_FUNCTION_AS_GETTER(HTTPClient, getTlsVersion, tlsVersion)
+		TITANIUM_FUNCTION_AS_SETTER(HTTPClient, setTlsVersion, tlsVersion)
+
+		TITANIUM_PROPERTY_GETTER_BOOL(HTTPClient, autoEncodeUrl)
+		TITANIUM_PROPERTY_SETTER_BOOL(HTTPClient, autoEncodeUrl)
+		TITANIUM_FUNCTION_AS_GETTER(HTTPClient, getAutoEncodeUrl, autoEncodeUrl)
+		TITANIUM_FUNCTION_AS_SETTER(HTTPClient, setAutoEncodeUrl, autoEncodeUrl)
+
+		TITANIUM_PROPERTY_GETTER_BOOL(HTTPClient, autoRedirect)
+		TITANIUM_PROPERTY_SETTER_BOOL(HTTPClient, autoRedirect)
+		TITANIUM_FUNCTION_AS_GETTER(HTTPClient, getAutoRedirect, autoRedirect)
+		TITANIUM_FUNCTION_AS_SETTER(HTTPClient, setAutoRedirect, autoRedirect)
+
+		TITANIUM_PROPERTY_GETTER_BOOL(HTTPClient, connected)
+		TITANIUM_FUNCTION_AS_GETTER(HTTPClient, getConnected, connected)
+
+		TITANIUM_PROPERTY_GETTER_STRING(HTTPClient, connectionType)
+		TITANIUM_FUNCTION_AS_GETTER(HTTPClient, getConnectionType, connectionType)
+
+		TITANIUM_PROPERTY_GETTER_BOOL(HTTPClient, enableKeepAlive)
+		TITANIUM_PROPERTY_SETTER_BOOL(HTTPClient, enableKeepAlive)
+		TITANIUM_FUNCTION_AS_GETTER(HTTPClient, getEnableKeepAlive, enableKeepAlive)
+		TITANIUM_FUNCTION_AS_SETTER(HTTPClient, setEnableKeepAlive, enableKeepAlive)
+
+		TITANIUM_PROPERTY_GETTER_BOOL(HTTPClient, validatesSecureCertificate)
+		TITANIUM_PROPERTY_SETTER_BOOL(HTTPClient, validatesSecureCertificate)
+		TITANIUM_FUNCTION_AS_GETTER(HTTPClient, getValidatesSecureCertificate, validatesSecureCertificate)
+		TITANIUM_FUNCTION_AS_SETTER(HTTPClient, setValidatesSecureCertificate, validatesSecureCertificate)
+
+		TITANIUM_PROPERTY_GETTER_BOOL(HTTPClient, withCredentials)
+		TITANIUM_PROPERTY_SETTER_BOOL(HTTPClient, withCredentials)
+		TITANIUM_FUNCTION_AS_GETTER(HTTPClient, getWithCredentials, withCredentials)
+		TITANIUM_FUNCTION_AS_SETTER(HTTPClient, setWithCredentials, withCredentials)
+
+		TITANIUM_PROPERTY_GETTER_UINT(HTTPClient, status)
+		TITANIUM_FUNCTION_AS_GETTER(HTTPClient, getStatus, status)
+		TITANIUM_PROPERTY_GETTER_STRING(HTTPClient, statusText)
+		TITANIUM_FUNCTION_AS_GETTER(HTTPClient, getStatusText, statusText)
+
+		TITANIUM_PROPERTY_GETTER_STRING(HTTPClient, file)	
+		TITANIUM_PROPERTY_SETTER_STRING(HTTPClient, file)	
+		TITANIUM_FUNCTION_AS_GETTER(HTTPClient, getFile, file)
+		TITANIUM_FUNCTION_AS_SETTER(HTTPClient, setFile, file)
+
+		TITANIUM_PROPERTY_GETTER_BOOL(HTTPClient, cache)	
+		TITANIUM_PROPERTY_SETTER_BOOL(HTTPClient, cache)	
+		TITANIUM_FUNCTION_AS_GETTER(HTTPClient, getCache, cache)
+		TITANIUM_FUNCTION_AS_SETTER(HTTPClient, setCache, cache)
+
+		TITANIUM_PROPERTY_GETTER_STRING(HTTPClient, domain)	
+		TITANIUM_PROPERTY_SETTER_STRING(HTTPClient, domain)	
+		TITANIUM_FUNCTION_AS_GETTER(HTTPClient, getDomain, domain)
+		TITANIUM_FUNCTION_AS_SETTER(HTTPClient, setDomain, domain)
+
+		TITANIUM_PROPERTY_GETTER_STRING(HTTPClient, location)	
+		TITANIUM_FUNCTION_AS_GETTER(HTTPClient, getLocation, location)
+
+		TITANIUM_PROPERTY_GETTER_STRING(HTTPClient, username)	
+		TITANIUM_PROPERTY_SETTER_STRING(HTTPClient, username)	
+		TITANIUM_FUNCTION_AS_GETTER(HTTPClient, getUsername, username)
+		TITANIUM_FUNCTION_AS_SETTER(HTTPClient, setUsername, username)
+
+		TITANIUM_PROPERTY_GETTER_STRING(HTTPClient, password)	
+		TITANIUM_PROPERTY_SETTER_STRING(HTTPClient, password)	
+		TITANIUM_FUNCTION_AS_GETTER(HTTPClient, getPassword, password)
+		TITANIUM_FUNCTION_AS_SETTER(HTTPClient, setPassword, password)
 
 		TITANIUM_PROPERTY_SETTER(HTTPClient, ondatastream)
 		{
 			using namespace std::placeholders;
-			TITANIUM_ASSERT(static_cast<JSObject>(argument).IsFunction());
 
-			// connect the slot
-			datastream.connect(std::bind(&HTTPClient::ondatastream, this, _1));
+			ondatastream__ = argument;
 
-			ondatastream_callback__ = static_cast<JSObject>(argument);
+			if (ondatastream__.IsObject() && static_cast<JSObject>(ondatastream__).IsFunction()) {
+				datastream.connect(std::bind(&HTTPClient::ondatastream, this, _1));
+			}
+
 			return true;
 		}
 
 		TITANIUM_PROPERTY_GETTER(HTTPClient, ondatastream)
 		{
-			return ondatastream_callback__;
+			return ondatastream__;
 		}
 
-		TITANIUM_FUNCTION(HTTPClient, getOndatastream)
-		{
-			return js_get_ondatastream();
-		}
-
-		TITANIUM_FUNCTION(HTTPClient, setOndatastream)
-		{
-			if (arguments.size() >= 1) {
-				js_set_ondatastream(arguments.at(0));
-			}
-			return this_object.get_context().CreateUndefined();
-		}
+		TITANIUM_FUNCTION_AS_GETTER(HTTPClient, getOndatastream, ondatastream)
+		TITANIUM_FUNCTION_AS_SETTER(HTTPClient, setOndatastream, ondatastream);
 
 		TITANIUM_PROPERTY_SETTER(HTTPClient, onerror)
 		{
 			using namespace std::placeholders;
-			TITANIUM_ASSERT(static_cast<JSObject>(argument).IsFunction());
 
-			// connect the slot
-			error.connect(std::bind(&HTTPClient::onerror, this, _1, _2, _3));
+			onerror__ = argument;
 
-			onerror_callback__ = static_cast<JSObject>(argument);
+			if (onerror__.IsObject() && static_cast<JSObject>(onerror__).IsFunction()) {
+				error.connect(std::bind(&HTTPClient::onerror, this, _1, _2, _3));
+			}
+
 			return true;
 		}
 
 		TITANIUM_PROPERTY_GETTER(HTTPClient, onerror)
 		{
-			return onerror_callback__;
+			return onerror__;
 		}
 
-		TITANIUM_FUNCTION(HTTPClient, getOnerror)
-		{
-			return js_get_onerror();
-		}
-
-		TITANIUM_FUNCTION(HTTPClient, setOnerror)
-		{
-			if (arguments.size() >= 1) {
-				js_set_onerror(arguments.at(0));
-			}
-			return this_object.get_context().CreateUndefined();
-		}
+		TITANIUM_FUNCTION_AS_GETTER(HTTPClient, getOnerror, onerror)
+		TITANIUM_FUNCTION_AS_SETTER(HTTPClient, setOnerror, onerror)
 
 		TITANIUM_PROPERTY_SETTER(HTTPClient, onload)
 		{
 			using namespace std::placeholders;
-			TITANIUM_ASSERT(static_cast<JSObject>(argument).IsFunction());
 
-			// connect the slot
-			loaded.connect(std::bind(&HTTPClient::onload, this, _1, _2, _3));
+			onload__ = argument;
 
-			onload_callback__ = static_cast<JSObject>(argument);
+			if (onload__.IsObject() && static_cast<JSObject>(onload__).IsFunction()) {
+				loaded.connect(std::bind(&HTTPClient::onload, this, _1, _2, _3));
+			}
+
 			return true;
 		}
 
 		TITANIUM_PROPERTY_GETTER(HTTPClient, onload)
 		{
-			return onload_callback__;
+			return onload__;
 		}
 
-		TITANIUM_FUNCTION(HTTPClient, getOnload)
-		{
-			return js_get_onload();
-		}
-
-		TITANIUM_FUNCTION(HTTPClient, setOnload)
-		{
-			if (arguments.size() >= 1) {
-				js_set_onload(arguments.at(0));
-			}
-			return this_object.get_context().CreateUndefined();
-		}
+		TITANIUM_FUNCTION_AS_GETTER(HTTPClient, getOnload, onload)
+		TITANIUM_FUNCTION_AS_SETTER(HTTPClient, setOnload, onload)
 
 		TITANIUM_PROPERTY_SETTER(HTTPClient, onreadystatechange)
 		{
 			using namespace std::placeholders;
-			TITANIUM_ASSERT(static_cast<JSObject>(argument).IsFunction());
 
-			// connect the slot
-			readystatechange.connect(std::bind(&HTTPClient::onreadystatechange, this, _1));
+			onreadystatechange__ = argument;
 
-			onreadystatechange_callback__ = static_cast<JSObject>(argument);
+			if (onreadystatechange__.IsObject() && static_cast<JSObject>(onreadystatechange__).IsFunction()) {
+				readystatechange.connect(std::bind(&HTTPClient::onreadystatechange, this, _1));
+			}
+
 			return true;
 		}
 
 		TITANIUM_PROPERTY_GETTER(HTTPClient, onreadystatechange)
 		{
-			return onreadystatechange_callback__;
+			return onreadystatechange__;
 		}
 
-		TITANIUM_FUNCTION(HTTPClient, getOnreadystatechange)
-		{
-			return js_get_onreadystatechange();
-		}
-
-		TITANIUM_FUNCTION(HTTPClient, setOnreadystatechange)
-		{
-			if (arguments.size() >= 1) {
-				js_set_onreadystatechange(arguments.at(0));
-			}
-			return this_object.get_context().CreateUndefined();
-		}
+		TITANIUM_FUNCTION_AS_GETTER(HTTPClient, getOnreadystatechange, onreadystatechange)
+		TITANIUM_FUNCTION_AS_SETTER(HTTPClient, setOnreadystatechange, onreadystatechange)
 
 		TITANIUM_PROPERTY_SETTER(HTTPClient, onsendstream)
 		{
 			using namespace std::placeholders;
-			TITANIUM_ASSERT(static_cast<JSObject>(argument).IsFunction());
 
-			// connect the slot
-			sendstream.connect(std::bind(&HTTPClient::onsendstream, this, _1));
+			onsendstream__ = argument;
 
-			onsendstream_callback__ = static_cast<JSObject>(argument);
+			if (onsendstream__.IsObject() && static_cast<JSObject>(onsendstream__).IsFunction()) {
+				sendstream.connect(std::bind(&HTTPClient::onsendstream, this, _1));
+			}
+
 			return true;
 		}
 
 		TITANIUM_PROPERTY_GETTER(HTTPClient, onsendstream)
 		{
-			return onsendstream_callback__;
+			return onsendstream__;
 		}
 
-		TITANIUM_FUNCTION(HTTPClient, getOnsendstream)
-		{
-			return js_get_onsendstream();
-		}
+		TITANIUM_FUNCTION_AS_GETTER(HTTPClient, getOnsendstream, onsendstream)
+		TITANIUM_FUNCTION_AS_GETTER(HTTPClient, setOnsendstream, onsendstream)
 
-		TITANIUM_FUNCTION(HTTPClient, setOnsendstream)
-		{
-			if (arguments.size() >= 1) {
-				js_set_onsendstream(arguments.at(0));
-			}
-			return this_object.get_context().CreateUndefined();
-		}
-			
-		TITANIUM_PROPERTY_GETTER(HTTPClient, timeout)
-		{
-			return get_context().CreateNumber(static_cast<double>(get_timeout().count()));
-		}
-
+		TITANIUM_PROPERTY_GETTER_TIME(HTTPClient, timeout)
 		TITANIUM_PROPERTY_SETTER(HTTPClient, timeout)
 		{
 			TITANIUM_ASSERT(argument.IsNumber());
@@ -502,10 +567,7 @@ namespace Titanium
 			return true;
 		}
 
-		TITANIUM_FUNCTION(HTTPClient, getTimeout)
-		{
-			return js_get_timeout();
-		}
+		TITANIUM_FUNCTION_AS_GETTER(HTTPClient, getTimeout, timeout)
 
 		TITANIUM_FUNCTION(HTTPClient, setTimeout)
 		{
@@ -518,90 +580,100 @@ namespace Titanium
 		////// slots
 		void HTTPClient::onload(const std::uint32_t code, const std::string error, const bool success) TITANIUM_NOEXCEPT
 		{
-			if (onload_callback__.IsFunction()) {
-				const JSContext ctx = get_context();
+			if (onload__.IsObject()) {
+				auto onload = static_cast<JSObject>(onload__);
+				if (onload.IsFunction()) {
+					const JSContext ctx = get_context();
 
-				JSObject this_object = get_object();
+					JSObject this_object = get_object();
+					JSObject eventArgs = ctx.CreateObject();
+					eventArgs.SetProperty("code", ctx.CreateNumber(code));
+					eventArgs.SetProperty("error", ctx.CreateString(error));
+					eventArgs.SetProperty("success", ctx.CreateBoolean(success));
 
-				JSObject eventArgs = ctx.CreateObject();
-				eventArgs.SetProperty("code", ctx.CreateNumber(code));
-				eventArgs.SetProperty("error", ctx.CreateString(error));
-				eventArgs.SetProperty("success", ctx.CreateBoolean(success));
+					std::vector<JSValue> arguments;
+					arguments.push_back(eventArgs);
 
-				std::vector<JSValue> arguments;
-				arguments.push_back(eventArgs);
-
-				onload_callback__(arguments, this_object);
+					onload(arguments, this_object);
+				}
 			}
 		}
 
 		void HTTPClient::onerror(const std::uint32_t code, const std::string error, const bool success) TITANIUM_NOEXCEPT
 		{
-			if (onerror_callback__.IsFunction()) {
-				const JSContext ctx = get_context();
+			if (onerror__.IsObject()) {
+				auto onerror = static_cast<JSObject>(onerror__);
+				if (onerror.IsFunction()) {
+					const JSContext ctx = get_context();
 
-				JSObject this_object = get_object();
+					JSObject this_object = get_object();
+					JSObject eventArgs = ctx.CreateObject();
+					eventArgs.SetProperty("code", ctx.CreateNumber(code));
+					eventArgs.SetProperty("error", ctx.CreateString(error));
+					eventArgs.SetProperty("success", ctx.CreateBoolean(success));
 
-				JSObject eventArgs = ctx.CreateObject();
-				eventArgs.SetProperty("code", ctx.CreateNumber(code));
-				eventArgs.SetProperty("error", ctx.CreateString(error));
-				eventArgs.SetProperty("success", ctx.CreateBoolean(success));
+					std::vector<JSValue> arguments;
+					arguments.push_back(eventArgs);
 
-				std::vector<JSValue> arguments;
-				arguments.push_back(eventArgs);
-
-				onerror_callback__(arguments, this_object);
+					onerror(arguments, this_object);
+				}
 			}
 		}
 
 		void HTTPClient::ondatastream(const double progress) TITANIUM_NOEXCEPT
 		{
-			if (ondatastream_callback__.IsFunction()) {
-				const JSContext ctx = get_context();
+			if (ondatastream__.IsObject()) {
+				auto ondatastream = static_cast<JSObject>(ondatastream__);
+				if (ondatastream.IsFunction()) {
+					const JSContext ctx = get_context();
 
-				JSObject this_object = get_object();
+					JSObject this_object = get_object();
+					JSObject eventArgs = ctx.CreateObject();
+					eventArgs.SetProperty("progress", ctx.CreateNumber(progress));
 
-				JSObject eventArgs = ctx.CreateObject();
-				eventArgs.SetProperty("progress", ctx.CreateNumber(progress));
+					std::vector<JSValue> arguments;
+					arguments.push_back(eventArgs);
 
-				std::vector<JSValue> arguments;
-				arguments.push_back(eventArgs);
-
-				ondatastream_callback__(arguments, this_object);
+					ondatastream(arguments, this_object);
+				}
 			}
 		}
 
 		void HTTPClient::onsendstream(const double progress) TITANIUM_NOEXCEPT
 		{
-			if (onsendstream_callback__.IsFunction()) {
-				const JSContext ctx = get_context();
+			if (onsendstream__.IsObject()) {
+				auto onsendstream = static_cast<JSObject>(onsendstream__);
+				if (onsendstream.IsFunction()) {
+					const JSContext ctx = get_context();
 
-				JSObject this_object = get_object();
+					JSObject this_object = get_object();
+					JSObject eventArgs = ctx.CreateObject();
+					eventArgs.SetProperty("progress", ctx.CreateNumber(progress));
 
-				JSObject eventArgs = ctx.CreateObject();
-				eventArgs.SetProperty("progress", ctx.CreateNumber(progress));
+					std::vector<JSValue> arguments;
+					arguments.push_back(eventArgs);
 
-				std::vector<JSValue> arguments;
-				arguments.push_back(eventArgs);
-
-				onsendstream_callback__(arguments, this_object);
+					onsendstream(arguments, this_object);
+				}
 			}
 		}
 
-		void HTTPClient::onreadystatechange(const std::uint32_t state) TITANIUM_NOEXCEPT
+		void HTTPClient::onreadystatechange(const RequestState& state) TITANIUM_NOEXCEPT
 		{
-			if (onreadystatechange_callback__.IsFunction()) {
-				const JSContext ctx = get_context();
+			if (onreadystatechange__.IsObject()) {
+				auto onreadystatechange = static_cast<JSObject>(onreadystatechange__);
+				if (onreadystatechange.IsFunction()) {
+					const JSContext ctx = get_context();
 
-				JSObject this_object = get_object();
+					JSObject this_object = get_object();
+					JSObject eventArgs = ctx.CreateObject();
+					eventArgs.SetProperty("readyState", ctx.CreateNumber(static_cast<std::uint32_t>(state)));
 
-				JSObject eventArgs = ctx.CreateObject();
-				eventArgs.SetProperty("readyState", ctx.CreateNumber(state));
+					std::vector<JSValue> arguments;
+					arguments.push_back(eventArgs);
 
-				std::vector<JSValue> arguments;
-				arguments.push_back(eventArgs);
-
-				onreadystatechange_callback__(arguments, this_object);
+					onreadystatechange(arguments, this_object);
+				}
 			}
 		}
 

--- a/Source/TitaniumKit/src/Network/PushNotificationConfig.cpp
+++ b/Source/TitaniumKit/src/Network/PushNotificationConfig.cpp
@@ -1,0 +1,57 @@
+/**
+ * TitaniumKit PushNotificationConfig
+ *
+ * Copyright (c) 2015 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License.
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#include "Titanium/Network/PushNotificationConfig.hpp"
+
+namespace Titanium
+{
+	namespace Network
+	{
+		using namespace HAL;
+
+		PushNotificationConfig js_to_PushNotificationConfig(const JSObject& object)
+		{
+			std::vector<Network::TYPE> types;
+			const auto js_types_property = object.GetProperty("types");
+			if (js_types_property.IsObject()) {
+				const auto js_types_object = static_cast<JSObject>(js_types_property);
+				if (js_types_object.IsArray()) {
+					const auto js_types = static_cast<std::vector<JSValue>>(static_cast<JSArray>(js_types_object));
+					for (const auto t : js_types) {
+						types.push_back(Titanium::Network::Constants::to_TYPE(static_cast<std::underlying_type<Network::TYPE>::type>(t)));
+					}
+				}
+			}
+
+			PushNotificationConfig config {
+				object.GetProperty("callback"),
+				object.GetProperty("error"),
+				object.GetProperty("success"),
+				types
+			};
+			
+			return config;
+		};
+
+		JSObject PushNotificationConfig_to_js(const JSContext& js_context, const PushNotificationConfig& config)
+		{
+			auto object = js_context.CreateObject();
+			object.SetProperty("callback", config.callback);
+			object.SetProperty("error",    config.error);
+			object.SetProperty("success",  config.success);
+
+			std::vector<JSValue> js_types;
+			for (const auto t : config.types) {
+				js_types.push_back(js_context.CreateNumber(Titanium::Network::Constants::to_underlying_type(t)));
+			}
+			object.SetProperty("types", js_context.CreateArray(js_types));
+
+			return object;
+		}
+	} // namespace Network
+} // namespace Titanium

--- a/Source/TitaniumKit/src/Network/Socket.cpp
+++ b/Source/TitaniumKit/src/Network/Socket.cpp
@@ -1,0 +1,122 @@
+/**
+ * TitaniumKit Titanium.Network.Socket
+ *
+ * Copyright (c) 2015 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License.
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#include "Titanium/Network/Socket.hpp"
+
+namespace Titanium
+{
+	namespace Network
+	{
+
+
+		SocketModule::SocketModule(const JSContext& js_context) TITANIUM_NOEXCEPT
+			: Module(js_context)
+			, initialized__(js_context.CreateNumber(static_cast<std::uint32_t>(Socket::State::Initialized)))
+			, connected__(js_context.CreateNumber(static_cast<std::uint32_t>(Socket::State::Connected)))
+			, listening__(js_context.CreateNumber(static_cast<std::uint32_t>(Socket::State::Listening)))
+			, closed__(js_context.CreateNumber(static_cast<std::uint32_t>(Socket::State::Closed)))
+			, error__(js_context.CreateNumber(static_cast<std::uint32_t>(Socket::State::Error)))
+		{
+		}
+
+		void SocketModule::JSExportInitialize() 
+		{
+			JSExport<SocketModule>::SetClassVersion(1);
+			JSExport<SocketModule>::SetParent(JSExport<Module>::Class());
+
+			TITANIUM_ADD_PROPERTY_READONLY(SocketModule, INITIALIZED);
+			TITANIUM_ADD_PROPERTY_READONLY(SocketModule, CONNECTED);
+			TITANIUM_ADD_PROPERTY_READONLY(SocketModule, LISTENING);
+			TITANIUM_ADD_PROPERTY_READONLY(SocketModule, CLOSED);
+			TITANIUM_ADD_PROPERTY_READONLY(SocketModule, ERROR);
+
+			TITANIUM_ADD_FUNCTION(SocketModule, createTCP);
+			TITANIUM_ADD_FUNCTION(SocketModule, createUDP);
+		}
+
+		TITANIUM_PROPERTY_GETTER(SocketModule, INITIALIZED)
+		{
+			return initialized__;
+		}
+
+		TITANIUM_PROPERTY_GETTER(SocketModule, CONNECTED)
+		{
+			return connected__;
+		}
+
+		TITANIUM_PROPERTY_GETTER(SocketModule, LISTENING)
+		{
+			return listening__;
+		}
+
+		TITANIUM_PROPERTY_GETTER(SocketModule, CLOSED)
+		{
+			return closed__;
+		}
+
+		TITANIUM_PROPERTY_GETTER(SocketModule, ERROR)
+		{
+			return error__;
+		}
+
+		TITANIUM_FUNCTION(SocketModule, createTCP)
+		{
+			TITANIUM_LOG_DEBUG("SocketModule::createTCP: ");
+
+			ENSURE_OPTIONAL_OBJECT_AT_INDEX(parameters, 0);
+
+			JSValue Titanium_property = get_context().get_global_object().GetProperty("Titanium");
+			TITANIUM_ASSERT(Titanium_property.IsObject());  // precondition
+			JSObject Titanium = static_cast<JSObject>(Titanium_property);
+
+			JSValue Network_property = Titanium.GetProperty("Network");
+			TITANIUM_ASSERT(Network_property.IsObject());  // precondition
+			JSObject Network = static_cast<JSObject>(Network_property);
+
+			JSValue Socket_property = Network.GetProperty("Socket");
+			TITANIUM_ASSERT(Socket_property.IsObject());  // precondition
+			JSObject Socket = static_cast<JSObject>(Socket_property);
+
+			JSValue TCP_property = Socket.GetProperty("TCP");
+			TITANIUM_ASSERT(TCP_property.IsObject());  // precondition
+			JSObject TCP = static_cast<JSObject>(TCP_property);
+
+			auto tcp = TCP.CallAsConstructor();
+			applyProperties(parameters, tcp);
+			return tcp;
+		}
+
+		TITANIUM_FUNCTION(SocketModule, createUDP)
+		{
+			TITANIUM_LOG_DEBUG("SocketModule::createUDP: ");
+			
+			ENSURE_OPTIONAL_OBJECT_AT_INDEX(parameters, 0);
+
+			JSValue Titanium_property = get_context().get_global_object().GetProperty("Titanium");
+			TITANIUM_ASSERT(Titanium_property.IsObject());  // precondition
+			JSObject Titanium = static_cast<JSObject>(Titanium_property);
+
+			JSValue Network_property = Titanium.GetProperty("Network");
+			TITANIUM_ASSERT(Network_property.IsObject());  // precondition
+			JSObject Network = static_cast<JSObject>(Network_property);
+
+			JSValue Socket_property = Network.GetProperty("Socket");
+			TITANIUM_ASSERT(Socket_property.IsObject());  // precondition
+			JSObject Socket = static_cast<JSObject>(Socket_property);
+
+			JSValue UDP_property = Socket.GetProperty("UDP");
+			TITANIUM_ASSERT(UDP_property.IsObject());  // precondition
+			JSObject UDP = static_cast<JSObject>(UDP_property);
+
+			auto udp = UDP.CallAsConstructor();
+			applyProperties(parameters, udp);
+			return udp;
+		}
+
+	} // namespace Network
+} // namespace Titanium

--- a/Source/TitaniumKit/src/Network/Socket/AcceptDict.cpp
+++ b/Source/TitaniumKit/src/Network/Socket/AcceptDict.cpp
@@ -1,0 +1,40 @@
+/**
+ * TitaniumKit AcceptDict
+ *
+ * Copyright (c) 2015 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License.
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#include "Titanium/Network/Socket/AcceptDict.hpp"
+
+namespace Titanium
+{
+	namespace Network
+	{
+		namespace Socket
+		{
+			using namespace HAL;
+
+			AcceptDict js_to_AcceptDict(const JSObject& object)
+			{
+				const auto timeout = std::chrono::milliseconds(static_cast<std::chrono::milliseconds::rep>(
+														static_cast<std::uint32_t>(object.GetProperty("timeout"))));
+				AcceptDict config {
+					object.GetProperty("error"),
+					timeout
+				};
+				
+				return config;
+			};
+
+			JSObject AcceptDict_to_js(const JSContext& js_context, const AcceptDict& config)
+			{
+				auto object = js_context.CreateObject();
+				object.SetProperty("error",    config.error);
+				object.SetProperty("timeout",  js_context.CreateNumber(static_cast<double>(config.timeout.count())));
+				return object;
+			}
+		} // namespace Socket
+	} // namespace Network
+} // namespace Titanium

--- a/Source/TitaniumKit/src/Network/Socket/TCP.cpp
+++ b/Source/TitaniumKit/src/Network/Socket/TCP.cpp
@@ -1,0 +1,181 @@
+/**
+ * TitaniumKit Titanium.Network.Socket.TCP
+ *
+ * Copyright (c) 2015 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License.
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#include "Titanium/Network/Socket/TCP.hpp"
+
+namespace Titanium
+{
+	namespace Network
+	{
+		namespace Socket
+		{
+			TCP::TCP(const JSContext& js_context) TITANIUM_NOEXCEPT
+				: Module(js_context)
+				, host__("")
+				, port__(0)
+				, listenQueueSize__(0)
+				, timeout__(0)
+				, state__(State::Closed)
+				, connected__(js_context.CreateNull())
+				, accepted__(js_context.CreateNull())
+				, error__(js_context.CreateNull())
+			{
+			}
+
+			TITANIUM_PROPERTY_READWRITE(TCP, std::string, host)
+
+			TITANIUM_PROPERTY_READWRITE(TCP, std::uint32_t, port)
+			TITANIUM_PROPERTY_READWRITE(TCP, std::uint32_t, listenQueueSize)
+			TITANIUM_PROPERTY_READWRITE(TCP, std::chrono::milliseconds, timeout)
+
+			TITANIUM_PROPERTY_READ(TCP, State, state); 
+
+			void TCP::close() TITANIUM_NOEXCEPT
+			{
+				TITANIUM_LOG_WARN("TCP::close: Unimplemented");
+			}
+
+			void TCP::connect() TITANIUM_NOEXCEPT
+			{
+				TITANIUM_LOG_WARN("TCP::connect: Unimplemented");
+			}
+
+			void TCP::listen() TITANIUM_NOEXCEPT
+			{
+				TITANIUM_LOG_WARN("TCP::listen: Unimplemented");
+			}
+
+			void TCP::accept(const AcceptDict& options) TITANIUM_NOEXCEPT
+			{
+				TITANIUM_LOG_WARN("TCP::accept: Unimplemented");
+			}
+
+			void TCP::JSExportInitialize() 
+			{
+				JSExport<TCP>::SetClassVersion(1);
+				JSExport<TCP>::SetParent(JSExport<Module>::Class());
+
+				TITANIUM_ADD_PROPERTY(TCP, host);
+				TITANIUM_ADD_PROPERTY(TCP, port);
+				TITANIUM_ADD_PROPERTY(TCP, listenQueueSize);
+				TITANIUM_ADD_PROPERTY(TCP, timeout);
+				TITANIUM_ADD_PROPERTY(TCP, connected);
+				TITANIUM_ADD_PROPERTY(TCP, error);
+				TITANIUM_ADD_PROPERTY(TCP, accepted);
+				TITANIUM_ADD_PROPERTY_READONLY(TCP, state);
+
+				TITANIUM_ADD_FUNCTION(TCP, close);
+				TITANIUM_ADD_FUNCTION(TCP, connect);
+				TITANIUM_ADD_FUNCTION(TCP, listen);
+				TITANIUM_ADD_FUNCTION(TCP, accept);
+				TITANIUM_ADD_FUNCTION(TCP, getHost);
+				TITANIUM_ADD_FUNCTION(TCP, setHost);
+				TITANIUM_ADD_FUNCTION(TCP, getPort);
+				TITANIUM_ADD_FUNCTION(TCP, setPort);
+				TITANIUM_ADD_FUNCTION(TCP, getListenQueueSize);
+				TITANIUM_ADD_FUNCTION(TCP, setListenQueueSize);
+				TITANIUM_ADD_FUNCTION(TCP, getTimeout);
+				TITANIUM_ADD_FUNCTION(TCP, setTimeout);
+				TITANIUM_ADD_FUNCTION(TCP, getConnected);
+				TITANIUM_ADD_FUNCTION(TCP, setConnected);
+				TITANIUM_ADD_FUNCTION(TCP, getError);
+				TITANIUM_ADD_FUNCTION(TCP, setError);
+				TITANIUM_ADD_FUNCTION(TCP, getAccepted);
+				TITANIUM_ADD_FUNCTION(TCP, setAccepted);
+				TITANIUM_ADD_FUNCTION(TCP, getState);
+			}
+
+			TITANIUM_PROPERTY_GETTER_STRING(TCP, host)
+			TITANIUM_PROPERTY_SETTER_STRING(TCP, host)
+
+			TITANIUM_PROPERTY_GETTER_UINT(TCP, port)
+			TITANIUM_PROPERTY_SETTER_UINT(TCP, port)
+
+			TITANIUM_PROPERTY_GETTER_UINT(TCP, listenQueueSize)
+			TITANIUM_PROPERTY_SETTER_UINT(TCP, listenQueueSize)
+
+			TITANIUM_PROPERTY_GETTER_TIME(TCP, timeout)
+			TITANIUM_PROPERTY_SETTER_TIME(TCP, timeout)
+
+			TITANIUM_PROPERTY_GETTER_ENUM(TCP, state)
+
+			TITANIUM_PROPERTY_GETTER(TCP, connected)
+			{
+				return connected__;
+			}
+
+			TITANIUM_PROPERTY_SETTER(TCP, connected)
+			{
+				connected__ = argument;
+				return true;
+			}
+
+			TITANIUM_PROPERTY_GETTER(TCP, error)
+			{
+				return error__;
+			}
+
+			TITANIUM_PROPERTY_SETTER(TCP, error)
+			{
+				error__ = argument;
+				return true;
+			}
+
+			TITANIUM_PROPERTY_GETTER(TCP, accepted)
+			{
+				return accepted__;
+			}
+
+			TITANIUM_PROPERTY_SETTER(TCP, accepted)
+			{
+				accepted__ = argument;
+				return true;
+			}
+
+			TITANIUM_FUNCTION(TCP, close)
+			{
+				close();
+				return get_context().CreateUndefined();
+			}
+
+			TITANIUM_FUNCTION(TCP, connect)
+			{
+				connect();
+				return get_context().CreateUndefined();
+			}
+			TITANIUM_FUNCTION(TCP, listen)
+			{
+				listen();
+				return get_context().CreateUndefined();
+			}
+			TITANIUM_FUNCTION(TCP, accept)
+			{
+				ENSURE_OBJECT_AT_INDEX(options, 0);
+				accept(js_to_AcceptDict(options));
+				return get_context().CreateUndefined();
+			}
+
+			TITANIUM_FUNCTION_AS_GETTER(TCP, getHost, host)
+			TITANIUM_FUNCTION_AS_SETTER(TCP, setHost, host)
+			TITANIUM_FUNCTION_AS_GETTER(TCP, getPort, port)
+			TITANIUM_FUNCTION_AS_SETTER(TCP, setPort, port)
+			TITANIUM_FUNCTION_AS_GETTER(TCP, getListenQueueSize, listenQueueSize)
+			TITANIUM_FUNCTION_AS_SETTER(TCP, setListenQueueSize, listenQueueSize)
+			TITANIUM_FUNCTION_AS_GETTER(TCP, getTimeout, timeout)
+			TITANIUM_FUNCTION_AS_SETTER(TCP, setTimeout, timeout)
+			TITANIUM_FUNCTION_AS_GETTER(TCP, getConnected, connected)
+			TITANIUM_FUNCTION_AS_SETTER(TCP, setConnected, connected)
+			TITANIUM_FUNCTION_AS_GETTER(TCP, getError, error)
+			TITANIUM_FUNCTION_AS_SETTER(TCP, setError, error)
+			TITANIUM_FUNCTION_AS_GETTER(TCP, getAccepted, accepted)
+			TITANIUM_FUNCTION_AS_SETTER(TCP, setAccepted, accepted)
+			TITANIUM_FUNCTION_AS_GETTER(TCP, getState, state)
+
+		} // namespace Socket
+	} // namespace Network
+} // namespace Titanium

--- a/Source/TitaniumKit/src/Network/Socket/UDP.cpp
+++ b/Source/TitaniumKit/src/Network/Socket/UDP.cpp
@@ -1,0 +1,159 @@
+/**
+ * TitaniumKit Titanium.Network.Socket.UDP
+ *
+ * Copyright (c) 2015 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License.
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#include "Titanium/Network/Socket/UDP.hpp"
+
+namespace Titanium
+{
+	namespace Network
+	{
+		namespace Socket
+		{
+
+			UDP::UDP(const JSContext& js_context) TITANIUM_NOEXCEPT
+				: Module(js_context)
+				, port__(0)
+				, started__(js_context.CreateNull())
+				, data__(js_context.CreateNull())
+				, error__(js_context.CreateNull())
+			{
+			}
+
+			TITANIUM_PROPERTY_READWRITE(UDP, std::uint32_t, port)
+
+			void UDP::start(const std::uint32_t& port) TITANIUM_NOEXCEPT
+			{
+				TITANIUM_LOG_WARN("UDP::start: Unimplemented");
+			}
+
+			void UDP::stop() TITANIUM_NOEXCEPT
+			{
+				TITANIUM_LOG_WARN("UDP::stop: Unimplemented");
+			}
+
+			void UDP::sendString(const std::uint32_t& port, const std::string& host, const std::string& data) TITANIUM_NOEXCEPT
+			{
+				TITANIUM_LOG_WARN("UDP::sendString: Unimplemented");
+			}
+
+			void UDP::sendBytes(const std::uint32_t& port, const std::string& host, std::vector<std::uint8_t> data) TITANIUM_NOEXCEPT
+			{
+				TITANIUM_LOG_WARN("UDP::sendBytes: Unimplemented");
+			}
+
+			void UDP::JSExportInitialize() 
+			{
+				JSExport<UDP>::SetClassVersion(1);
+				JSExport<UDP>::SetParent(JSExport<Module>::Class());
+
+				TITANIUM_ADD_PROPERTY(UDP, port);
+				TITANIUM_ADD_PROPERTY(UDP, started);
+				TITANIUM_ADD_PROPERTY(UDP, data);
+				TITANIUM_ADD_PROPERTY(UDP, error);
+
+				TITANIUM_ADD_FUNCTION(UDP, start);
+				TITANIUM_ADD_FUNCTION(UDP, stop);
+				TITANIUM_ADD_FUNCTION(UDP, sendString);
+				TITANIUM_ADD_FUNCTION(UDP, sendBytes);
+				TITANIUM_ADD_FUNCTION(UDP, getPort);
+				TITANIUM_ADD_FUNCTION(UDP, setPort);
+				TITANIUM_ADD_FUNCTION(UDP, getStarted);
+				TITANIUM_ADD_FUNCTION(UDP, setStarted);
+				TITANIUM_ADD_FUNCTION(UDP, getData);
+				TITANIUM_ADD_FUNCTION(UDP, setData);
+				TITANIUM_ADD_FUNCTION(UDP, getError);
+				TITANIUM_ADD_FUNCTION(UDP, setError);
+			}
+
+			TITANIUM_PROPERTY_GETTER_UINT(UDP, port)
+			TITANIUM_PROPERTY_SETTER_UINT(UDP, port)
+
+			TITANIUM_PROPERTY_GETTER(UDP, started)
+			{
+				return started__;
+			}
+
+			TITANIUM_PROPERTY_SETTER(UDP, started)
+			{
+				started__ = argument;
+				return true;
+			}
+
+			TITANIUM_PROPERTY_GETTER(UDP, data)
+			{
+				return data__;
+			}
+
+			TITANIUM_PROPERTY_SETTER(UDP, data)
+			{
+				data__ = argument;
+				return true;
+			}
+
+			TITANIUM_PROPERTY_GETTER(UDP, error)
+			{
+				return error__;
+			}
+
+			TITANIUM_PROPERTY_SETTER(UDP, error)
+			{
+				error__ = argument;
+				return true;
+			}
+
+			TITANIUM_FUNCTION(UDP, start)
+			{
+				ENSURE_OPTIONAL_UINT_AT_INDEX(port, 0, 0);
+				start(port);
+				return get_context().CreateUndefined();
+			}
+
+			TITANIUM_FUNCTION(UDP, stop)
+			{
+				stop();
+				return get_context().CreateUndefined();
+			}
+			
+			TITANIUM_FUNCTION(UDP, sendString)
+			{
+				ENSURE_OPTIONAL_UINT_AT_INDEX(port, 0, 0);
+				ENSURE_OPTIONAL_STRING_AT_INDEX(host, 1, "");
+				ENSURE_OPTIONAL_STRING_AT_INDEX(data, 2, "");
+				
+				sendString(port, host, data);
+				return get_context().CreateUndefined();
+			}
+
+			TITANIUM_FUNCTION(UDP, sendBytes)
+			{
+				ENSURE_OPTIONAL_UINT_AT_INDEX(port, 0, 0);
+				ENSURE_OPTIONAL_STRING_AT_INDEX(host, 1, "");
+				ENSURE_OPTIONAL_ARRAY_AT_INDEX(js_data, 2);
+
+				std::vector<std::uint8_t> data;
+				const auto length = js_data.GetLength();
+				for (uint32_t i = 0; i < length; i++) {
+					data.push_back(static_cast<std::uint8_t>(static_cast<std::uint32_t>(js_data.GetProperty(i))));
+				}
+				
+				sendBytes(port, host, data);
+				return get_context().CreateUndefined();
+			}
+
+			TITANIUM_FUNCTION_AS_GETTER(UDP, getPort, port)
+			TITANIUM_FUNCTION_AS_SETTER(UDP, setPort, port)
+			TITANIUM_FUNCTION_AS_GETTER(UDP, getStarted, started)
+			TITANIUM_FUNCTION_AS_SETTER(UDP, setStarted, started)
+			TITANIUM_FUNCTION_AS_GETTER(UDP, getData, data)
+			TITANIUM_FUNCTION_AS_SETTER(UDP, setData, data)
+			TITANIUM_FUNCTION_AS_GETTER(UDP, getError, error)
+			TITANIUM_FUNCTION_AS_SETTER(UDP, setError, error)
+
+		} // namespace Socket
+	} // namespace Network
+} // namespace Titanium

--- a/Source/TitaniumKit/src/NetworkModule.cpp
+++ b/Source/TitaniumKit/src/NetworkModule.cpp
@@ -9,60 +9,112 @@
 namespace Titanium
 {
 	NetworkModule::NetworkModule(const JSContext& js_context) TITANIUM_NOEXCEPT
-	    : Module(js_context),
-		network_lan__(js_context.CreateNumber(Titanium::Network::Constants::to_underlying_type(Titanium::Network::TYPE::LAN))),
-		network_mobile__(js_context.CreateNumber(Titanium::Network::Constants::to_underlying_type(Titanium::Network::TYPE::MOBILE))),
-		network_none__(js_context.CreateNumber(Titanium::Network::Constants::to_underlying_type(Titanium::Network::TYPE::NONE))),
-		network_unknown__(js_context.CreateNumber(Titanium::Network::Constants::to_underlying_type(Titanium::Network::TYPE::UNKNOWN))),
-		network_wifi__(js_context.CreateNumber(Titanium::Network::Constants::to_underlying_type(Titanium::Network::TYPE::WIFI))),
-		notification_type_alert__(js_context.CreateNumber(Titanium::Network::Constants::to_underlying_type(Titanium::Network::NOTIFICATION_TYPE::ALERT))),
-		notification_type_badge__(js_context.CreateNumber(Titanium::Network::Constants::to_underlying_type(Titanium::Network::NOTIFICATION_TYPE::BADGE))),
-		notification_type_newsstand__(js_context.CreateNumber(Titanium::Network::Constants::to_underlying_type(Titanium::Network::NOTIFICATION_TYPE::NEWSSTAND))),
-		notification_type_sound__(js_context.CreateNumber(Titanium::Network::Constants::to_underlying_type(Titanium::Network::NOTIFICATION_TYPE::SOUND))),
-		progress_unknown__(js_context.CreateNumber(Titanium::Network::Constants::PROGRESS_UNKNOWN)),
-		tls_version_1_0__(js_context.CreateNumber(Titanium::Network::Constants::to_underlying_type(Titanium::Network::TLS_VERSION::ONE_ZERO))),
-		tls_version_1_1__(js_context.CreateNumber(Titanium::Network::Constants::to_underlying_type(Titanium::Network::TLS_VERSION::ONE_ONE))),
-		tls_version_1_2__(js_context.CreateNumber(Titanium::Network::Constants::to_underlying_type(Titanium::Network::TLS_VERSION::ONE_TWO)))
+	    : Module(js_context)
+		, network_lan__(js_context.CreateNumber(Titanium::Network::Constants::to_underlying_type(Titanium::Network::TYPE::LAN)))
+		, network_mobile__(js_context.CreateNumber(Titanium::Network::Constants::to_underlying_type(Titanium::Network::TYPE::MOBILE)))
+		, network_none__(js_context.CreateNumber(Titanium::Network::Constants::to_underlying_type(Titanium::Network::TYPE::NONE)))
+		, network_unknown__(js_context.CreateNumber(Titanium::Network::Constants::to_underlying_type(Titanium::Network::TYPE::UNKNOWN)))
+		, network_wifi__(js_context.CreateNumber(Titanium::Network::Constants::to_underlying_type(Titanium::Network::TYPE::WIFI)))
+		, notification_type_alert__(js_context.CreateNumber(Titanium::Network::Constants::to_underlying_type(Titanium::Network::NOTIFICATION_TYPE::ALERT)))
+		, notification_type_badge__(js_context.CreateNumber(Titanium::Network::Constants::to_underlying_type(Titanium::Network::NOTIFICATION_TYPE::BADGE)))
+		, notification_type_sound__(js_context.CreateNumber(Titanium::Network::Constants::to_underlying_type(Titanium::Network::NOTIFICATION_TYPE::SOUND)))
+		, notification_type_newsstand__(js_context.CreateNumber(Titanium::Network::Constants::to_underlying_type(Titanium::Network::NOTIFICATION_TYPE::NEWSSTAND)))
+		, read_mode__(js_context.CreateNumber(Titanium::Network::Constants::to_underlying_type(Titanium::Network::MODE::READ)))
+		, read_write_mode__(js_context.CreateNumber(Titanium::Network::Constants::to_underlying_type(Titanium::Network::MODE::READ_WRITE)))
+		, write_mode__(js_context.CreateNumber(Titanium::Network::Constants::to_underlying_type(Titanium::Network::MODE::WRITE)))
+		, socket_closed__(js_context.CreateNumber(Titanium::Network::Constants::to_underlying_type(Titanium::Network::SOCKET::CLOSED)))
+		, socket_connected__(js_context.CreateNumber(Titanium::Network::Constants::to_underlying_type(Titanium::Network::SOCKET::CONNECTED)))
+		, socket_error__(js_context.CreateNumber(Titanium::Network::Constants::to_underlying_type(Titanium::Network::SOCKET::ERROR)))
+		, socket_initialized__(js_context.CreateNumber(Titanium::Network::Constants::to_underlying_type(Titanium::Network::SOCKET::INITIALIZED)))
+		, socket_listening__(js_context.CreateNumber(Titanium::Network::Constants::to_underlying_type(Titanium::Network::SOCKET::LISTENING)))
+		, tls_version_1_0__(js_context.CreateNumber(Titanium::Network::Constants::to_underlying_type(Titanium::Network::TLS_VERSION::_1_0)))
+		, tls_version_1_1__(js_context.CreateNumber(Titanium::Network::Constants::to_underlying_type(Titanium::Network::TLS_VERSION::_1_1)))
+		, tls_version_1_2__(js_context.CreateNumber(Titanium::Network::Constants::to_underlying_type(Titanium::Network::TLS_VERSION::_1_2)))
+		, progress_unknown__(js_context.CreateNumber(Titanium::Network::Constants::PROGRESS_UNKNOWN))
+		, networkType__(Titanium::Network::TYPE::UNKNOWN)
+		, networkTypeName__(Titanium::Network::Constants::to_string(Titanium::Network::TYPE::UNKNOWN))
+		, online__(false)
+		, remoteDeviceUUID__("")
+		, remoteNotificationsEnabled__(false)
+		, httpURLFormatter__(js_context.CreateNull())
 	{
+
 	}
 
-	Titanium::Network::TYPE NetworkModule::get_networkType() const TITANIUM_NOEXCEPT
+	TITANIUM_PROPERTY_READ(NetworkModule, Network::TYPE, networkType);
+	TITANIUM_PROPERTY_READ(NetworkModule, std::string, networkTypeName);
+	TITANIUM_PROPERTY_READ(NetworkModule, std::string, remoteDeviceUUID);
+	TITANIUM_PROPERTY_READ(NetworkModule, std::vector<Network::NOTIFICATION_TYPE>, remoteNotificationTypes);
+	TITANIUM_PROPERTY_READ(NetworkModule, bool, remoteNotificationsEnabled);
+	TITANIUM_PROPERTY_READ(NetworkModule, bool, online);
+
+	void NetworkModule::addHTTPCookie(std::shared_ptr<Network::Cookie> cookie) TITANIUM_NOEXCEPT
 	{
-		TITANIUM_LOG_WARN("NetworkModule::get_networkType: Unimplemented");
-		return Titanium::Network::TYPE::UNKNOWN;
+		TITANIUM_LOG_WARN("NetworkModule::addHTTPCookie: unimplemented");
 	}
 
-	std::string NetworkModule::get_networkTypeName() const TITANIUM_NOEXCEPT
+	void NetworkModule::addSystemCookie(std::shared_ptr<Network::Cookie> cookie) TITANIUM_NOEXCEPT
 	{
-		TITANIUM_LOG_WARN("NetworkModule::get_networkTypeName: Unimplemented");
-		return Titanium::Network::Constants::to_string(get_networkType());
+		TITANIUM_LOG_WARN("NetworkModule::addSystemCookie: unimplemented");
+	}
+	
+	std::vector<std::shared_ptr<Network::Cookie>> NetworkModule::get_allHTTPCookies() const TITANIUM_NOEXCEPT
+	{
+		TITANIUM_LOG_WARN("NetworkModule::get_allHTTPCookies: unimplemented");
+		return std::vector<std::shared_ptr<Network::Cookie>>();
 	}
 
-	bool NetworkModule::get_online() const TITANIUM_NOEXCEPT
+	std::vector<std::shared_ptr<Network::Cookie>> NetworkModule::getHTTPCookies(const std::string& domain, const std::string& path, const std::string& name) TITANIUM_NOEXCEPT
 	{
-		TITANIUM_LOG_WARN("NetworkModule::get_online: Unimplemented");
-		return false;
+		TITANIUM_LOG_WARN("NetworkModule::getHTTPCookies: unimplemented");
+		return std::vector<std::shared_ptr<Network::Cookie>>();
 	}
 
-	JSObject NetworkModule::createHTTPClient(const JSObject& parameters, JSObject& this_object) TITANIUM_NOEXCEPT
+	std::vector<std::shared_ptr<Network::Cookie>> NetworkModule::getHTTPCookiesForDomain(const std::string& domain) TITANIUM_NOEXCEPT
 	{
-		TITANIUM_LOG_DEBUG("Network::createHTTPClient: ");
+		TITANIUM_LOG_WARN("NetworkModule::getHTTPCookiesForDomain: unimplemented");
+		return std::vector<std::shared_ptr<Network::Cookie>>();
+	}
 
-		JSValue Titanium_property = get_context().get_global_object().GetProperty("Titanium");
-		TITANIUM_ASSERT(Titanium_property.IsObject());  // precondition
-		JSObject Titanium = static_cast<JSObject>(Titanium_property);
+	std::vector<std::shared_ptr<Network::Cookie>> NetworkModule::getSystemCookies(const std::string& domain, const std::string& path, const std::string& name) TITANIUM_NOEXCEPT
+	{
+		TITANIUM_LOG_WARN("NetworkModule::getSystemCookies: unimplemented");
+		return std::vector<std::shared_ptr<Network::Cookie>>();
+	}
 
-		JSValue Network_property = Titanium.GetProperty("Network");
-		TITANIUM_ASSERT(Network_property.IsObject());  // precondition
-		JSObject Network = static_cast<JSObject>(Network_property);
+	void NetworkModule::removeAllHTTPCookies() TITANIUM_NOEXCEPT
+	{
+		TITANIUM_LOG_WARN("NetworkModule::removeAllHTTPCookies: unimplemented");
+	}
 
-		JSValue HTTPClient_property = Network.GetProperty("HTTPClient");
-		TITANIUM_ASSERT(HTTPClient_property.IsObject());  // precondition
-		JSObject HTTPClient = static_cast<JSObject>(HTTPClient_property);
+	void NetworkModule::removeAllSystemCookies() TITANIUM_NOEXCEPT
+	{
+		TITANIUM_LOG_WARN("NetworkModule::removeAllSystemCookies: unimplemented");
+	}
 
-		auto httpClient = HTTPClient.CallAsConstructor();
-		applyProperties(parameters, httpClient);
-		return httpClient;
+	void NetworkModule::removeHTTPCookie(const std::string& domain, const std::string& path, const std::string& name) TITANIUM_NOEXCEPT
+	{
+		TITANIUM_LOG_WARN("NetworkModule::removeHTTPCookie: unimplemented");
+	}
+
+	void NetworkModule::removeHTTPCookiesForDomain(const std::string& domain) TITANIUM_NOEXCEPT
+	{
+		TITANIUM_LOG_WARN("NetworkModule::removeHTTPCookiesForDomain: unimplemented");
+	}
+
+	void NetworkModule::removeSystemCookie(const std::string& domain, const std::string& path, const std::string& name) TITANIUM_NOEXCEPT
+	{
+		TITANIUM_LOG_WARN("NetworkModule::removeSystemCookie: unimplemented");
+	}
+
+	void NetworkModule::registerForPushNotifications(const Network::PushNotificationConfig& config) TITANIUM_NOEXCEPT
+	{
+		TITANIUM_LOG_WARN("NetworkModule::registerForPushNotifications: unimplemented");
+	}
+
+	void NetworkModule::unregisterForPushNotifications() TITANIUM_NOEXCEPT
+	{
+		TITANIUM_LOG_WARN("NetworkModule::unregisterForPushNotifications: unimplemented");
 	}
 
 	TITANIUM_PROPERTY_GETTER(NetworkModule, NETWORK_LAN)
@@ -134,6 +186,7 @@ namespace Titanium
 	{
 		JSExport<NetworkModule>::SetClassVersion(1);
 		JSExport<NetworkModule>::SetParent(JSExport<Module>::Class());
+
 		TITANIUM_ADD_PROPERTY_READONLY(NetworkModule, NETWORK_LAN);
 		TITANIUM_ADD_PROPERTY_READONLY(NetworkModule, NETWORK_MOBILE);
 		TITANIUM_ADD_PROPERTY_READONLY(NetworkModule, NETWORK_NONE);
@@ -141,36 +194,280 @@ namespace Titanium
 		TITANIUM_ADD_PROPERTY_READONLY(NetworkModule, NETWORK_WIFI);
 		TITANIUM_ADD_PROPERTY_READONLY(NetworkModule, NOTIFICATION_TYPE_ALERT);
 		TITANIUM_ADD_PROPERTY_READONLY(NetworkModule, NOTIFICATION_TYPE_BADGE);
-		TITANIUM_ADD_PROPERTY_READONLY(NetworkModule, NOTIFICATION_TYPE_NEWSSTAND);
 		TITANIUM_ADD_PROPERTY_READONLY(NetworkModule, NOTIFICATION_TYPE_SOUND);
-		TITANIUM_ADD_PROPERTY_READONLY(NetworkModule, PROGRESS_UNKNOWN);
+		TITANIUM_ADD_PROPERTY_READONLY(NetworkModule, NOTIFICATION_TYPE_NEWSSTAND);
 		TITANIUM_ADD_PROPERTY_READONLY(NetworkModule, TLS_VERSION_1_0);
 		TITANIUM_ADD_PROPERTY_READONLY(NetworkModule, TLS_VERSION_1_1);
 		TITANIUM_ADD_PROPERTY_READONLY(NetworkModule, TLS_VERSION_1_2);
+		TITANIUM_ADD_PROPERTY_READONLY(NetworkModule, PROGRESS_UNKNOWN);
+		TITANIUM_ADD_PROPERTY_READONLY(NetworkModule, allHTTPCookies);
 		TITANIUM_ADD_PROPERTY_READONLY(NetworkModule, networkType);
 		TITANIUM_ADD_PROPERTY_READONLY(NetworkModule, networkTypeName);
 		TITANIUM_ADD_PROPERTY_READONLY(NetworkModule, online);
+		TITANIUM_ADD_PROPERTY_READONLY(NetworkModule, remoteDeviceUUID);
+		TITANIUM_ADD_PROPERTY_READONLY(NetworkModule, remoteNotificationTypes);
+		TITANIUM_ADD_PROPERTY_READONLY(NetworkModule, remoteNotificationsEnabled);
+		TITANIUM_ADD_PROPERTY(NetworkModule, httpURLFormatter);
+
+		TITANIUM_ADD_FUNCTION(NetworkModule, addHTTPCookie);
+		TITANIUM_ADD_FUNCTION(NetworkModule, addSystemCookie);
+		TITANIUM_ADD_FUNCTION(NetworkModule, createBonjourBrowser);
+		TITANIUM_ADD_FUNCTION(NetworkModule, createBonjourService);
+		TITANIUM_ADD_FUNCTION(NetworkModule, getHTTPCookies);
+		TITANIUM_ADD_FUNCTION(NetworkModule, getHTTPCookiesForDomain);
+		TITANIUM_ADD_FUNCTION(NetworkModule, getSystemCookies);
+		TITANIUM_ADD_FUNCTION(NetworkModule, removeAllHTTPCookies);
+		TITANIUM_ADD_FUNCTION(NetworkModule, removeAllSystemCookies);
+		TITANIUM_ADD_FUNCTION(NetworkModule, removeHTTPCookie);
+		TITANIUM_ADD_FUNCTION(NetworkModule, removeHTTPCookiesForDomain);
+		TITANIUM_ADD_FUNCTION(NetworkModule, removeSystemCookie);
+		TITANIUM_ADD_FUNCTION(NetworkModule, registerForPushNotifications);
+		TITANIUM_ADD_FUNCTION(NetworkModule, unregisterForPushNotifications);
+		TITANIUM_ADD_FUNCTION(NetworkModule, createCookie);
 		TITANIUM_ADD_FUNCTION(NetworkModule, createHTTPClient);
+		TITANIUM_ADD_FUNCTION(NetworkModule, getAllHTTPCookies);
+		TITANIUM_ADD_FUNCTION(NetworkModule, getNetworkType);
+		TITANIUM_ADD_FUNCTION(NetworkModule, getNetworkTypeName);
+		TITANIUM_ADD_FUNCTION(NetworkModule, getOnline);
+		TITANIUM_ADD_FUNCTION(NetworkModule, getRemoteDeviceUUID);
+		TITANIUM_ADD_FUNCTION(NetworkModule, getRemoteNotificationTypes);
+		TITANIUM_ADD_FUNCTION(NetworkModule, getRemoteNotificationsEnabled);
+		TITANIUM_ADD_FUNCTION(NetworkModule, getHttpURLFormatter);
+		TITANIUM_ADD_FUNCTION(NetworkModule, setHttpURLFormatter);
+	}
+
+	TITANIUM_FUNCTION(NetworkModule, createBonjourBrowser)
+	{
+		TITANIUM_LOG_DEBUG("Network::createBonjourBrowser: ");
+
+		ENSURE_OPTIONAL_OBJECT_AT_INDEX(parameters, 0);
+
+		JSValue Titanium_property = get_context().get_global_object().GetProperty("Titanium");
+		TITANIUM_ASSERT(Titanium_property.IsObject());  // precondition
+		JSObject Titanium = static_cast<JSObject>(Titanium_property);
+
+		JSValue Network_property = Titanium.GetProperty("Network");
+		TITANIUM_ASSERT(Network_property.IsObject());  // precondition
+		JSObject Network = static_cast<JSObject>(Network_property);
+
+		JSValue Object_property = Network.GetProperty("BonjourBrowser");
+		TITANIUM_ASSERT(Object_property.IsObject());  // precondition
+		JSObject Obj = static_cast<JSObject>(Object_property);
+
+		auto object = Obj.CallAsConstructor();
+		applyProperties(parameters, object);
+		return object;
+	}
+
+	TITANIUM_FUNCTION(NetworkModule, createBonjourService)
+	{
+		TITANIUM_LOG_DEBUG("Network::createBonjourService: ");
+
+		ENSURE_OPTIONAL_OBJECT_AT_INDEX(parameters, 0);
+
+		JSValue Titanium_property = get_context().get_global_object().GetProperty("Titanium");
+		TITANIUM_ASSERT(Titanium_property.IsObject());  // precondition
+		JSObject Titanium = static_cast<JSObject>(Titanium_property);
+
+		JSValue Network_property = Titanium.GetProperty("Network");
+		TITANIUM_ASSERT(Network_property.IsObject());  // precondition
+		JSObject Network = static_cast<JSObject>(Network_property);
+
+		JSValue Object_property = Network.GetProperty("BonjourService");
+		TITANIUM_ASSERT(Object_property.IsObject());  // precondition
+		JSObject Obj = static_cast<JSObject>(Object_property);
+
+		auto object = Obj.CallAsConstructor();
+		applyProperties(parameters, object);
+		return object;
+	}
+
+	TITANIUM_FUNCTION(NetworkModule, createCookie)
+	{
+		TITANIUM_LOG_DEBUG("Network::createCookie: ");
+
+		ENSURE_OPTIONAL_OBJECT_AT_INDEX(parameters, 0);
+
+		JSValue Titanium_property = get_context().get_global_object().GetProperty("Titanium");
+		TITANIUM_ASSERT(Titanium_property.IsObject());  // precondition
+		JSObject Titanium = static_cast<JSObject>(Titanium_property);
+
+		JSValue Network_property = Titanium.GetProperty("Network");
+		TITANIUM_ASSERT(Network_property.IsObject());  // precondition
+		JSObject Network = static_cast<JSObject>(Network_property);
+
+		JSValue Cookie_property = Network.GetProperty("Cookie");
+		TITANIUM_ASSERT(Cookie_property.IsObject());  // precondition
+		JSObject Cookie = static_cast<JSObject>(Cookie_property);
+
+		auto cookie = Cookie.CallAsConstructor();
+		applyProperties(parameters, cookie);
+		return cookie;
 	}
 
 	TITANIUM_FUNCTION(NetworkModule, createHTTPClient)
 	{
+		TITANIUM_LOG_DEBUG("Network::createHTTPClient: ");
+
 		ENSURE_OPTIONAL_OBJECT_AT_INDEX(parameters, 0);
-		return createHTTPClient(parameters, this_object);
+
+		JSValue Titanium_property = get_context().get_global_object().GetProperty("Titanium");
+		TITANIUM_ASSERT(Titanium_property.IsObject());  // precondition
+		JSObject Titanium = static_cast<JSObject>(Titanium_property);
+
+		JSValue Network_property = Titanium.GetProperty("Network");
+		TITANIUM_ASSERT(Network_property.IsObject());  // precondition
+		JSObject Network = static_cast<JSObject>(Network_property);
+
+		JSValue HTTPClient_property = Network.GetProperty("HTTPClient");
+		TITANIUM_ASSERT(HTTPClient_property.IsObject());  // precondition
+		JSObject HTTPClient = static_cast<JSObject>(HTTPClient_property);
+
+		auto httpClient = HTTPClient.CallAsConstructor();
+		applyProperties(parameters, httpClient);
+		return httpClient;
 	}
+
+	TITANIUM_FUNCTION(NetworkModule, addHTTPCookie)
+	{
+		ENSURE_OBJECT_AT_INDEX(cookie, 0);
+		addHTTPCookie(cookie.GetPrivate<Network::Cookie>());	
+		return get_context().CreateUndefined();
+	}
+	
+	TITANIUM_FUNCTION(NetworkModule, addSystemCookie)
+	{
+		ENSURE_OBJECT_AT_INDEX(cookie, 0);
+		addSystemCookie(cookie.GetPrivate<Network::Cookie>());	
+		return get_context().CreateUndefined();
+	}
+	
+	TITANIUM_FUNCTION(NetworkModule, removeAllHTTPCookies)
+	{
+		removeAllHTTPCookies();
+		return get_context().CreateUndefined();
+	}
+
+	TITANIUM_FUNCTION(NetworkModule, removeAllSystemCookies)
+	{
+		removeAllSystemCookies();
+		return get_context().CreateUndefined();
+	}
+
+	TITANIUM_FUNCTION(NetworkModule, removeHTTPCookie)
+	{
+		ENSURE_STRING_AT_INDEX(domain, 0);
+		ENSURE_STRING_AT_INDEX(path, 1);
+		ENSURE_STRING_AT_INDEX(name, 2);
+		removeHTTPCookie(domain, path, name);
+		return get_context().CreateUndefined();
+	}
+
+	TITANIUM_FUNCTION(NetworkModule, removeHTTPCookiesForDomain)
+	{
+		ENSURE_STRING_AT_INDEX(domain, 0);
+		removeHTTPCookiesForDomain(domain);
+		return get_context().CreateUndefined();
+	}
+
+	TITANIUM_FUNCTION(NetworkModule, removeSystemCookie)
+	{
+		ENSURE_STRING_AT_INDEX(domain, 0);
+		ENSURE_STRING_AT_INDEX(path, 1);
+		ENSURE_STRING_AT_INDEX(name, 2);
+		removeSystemCookie(domain, path, name);
+		return get_context().CreateUndefined();
+	}
+
+	TITANIUM_FUNCTION(NetworkModule, registerForPushNotifications)
+	{
+		ENSURE_OPTIONAL_OBJECT_AT_INDEX(config, 0);
+		registerForPushNotifications(Network::js_to_PushNotificationConfig(config));
+		return get_context().CreateUndefined();
+	}
+
+	TITANIUM_FUNCTION(NetworkModule, unregisterForPushNotifications)
+	{
+		unregisterForPushNotifications();
+		return get_context().CreateUndefined();
+	}
+
+	TITANIUM_FUNCTION(NetworkModule, getHTTPCookies)
+	{
+		ENSURE_STRING_AT_INDEX(domain, 0);
+		ENSURE_STRING_AT_INDEX(path, 1);
+		ENSURE_STRING_AT_INDEX(name, 2);
+
+		std::vector<JSValue> values;
+		for (const auto value : getHTTPCookies(domain, path, name)) {
+			values.push_back(value->get_object());
+		}
+		return get_context().CreateArray(values);
+	}
+
+	TITANIUM_FUNCTION(NetworkModule, getHTTPCookiesForDomain)
+	{
+		ENSURE_STRING_AT_INDEX(domain, 0);
+
+		std::vector<JSValue> values;
+		for (const auto value : getHTTPCookiesForDomain(domain)) {
+			values.push_back(value->get_object());
+		}
+		return get_context().CreateArray(values);
+	}
+
+	TITANIUM_FUNCTION(NetworkModule, getSystemCookies)
+	{
+		ENSURE_STRING_AT_INDEX(domain, 0);
+		ENSURE_STRING_AT_INDEX(path, 1);
+		ENSURE_STRING_AT_INDEX(name, 2);
+
+		std::vector<JSValue> values;
+		for (const auto value : getSystemCookies(domain, path, name)) {
+			values.push_back(value->get_object());
+		}
+		return get_context().CreateArray(values);
+	}
+
+	TITANIUM_FUNCTION_AS_GETTER(NetworkModule, getAllHTTPCookies, allHTTPCookies)
+	TITANIUM_FUNCTION_AS_GETTER(NetworkModule, getNetworkType, networkType)
+	TITANIUM_FUNCTION_AS_GETTER(NetworkModule, getNetworkTypeName, networkTypeName)
+	TITANIUM_FUNCTION_AS_GETTER(NetworkModule, getOnline, online)
+	TITANIUM_FUNCTION_AS_GETTER(NetworkModule, getRemoteDeviceUUID, remoteDeviceUUID)
+	TITANIUM_FUNCTION_AS_GETTER(NetworkModule, getRemoteNotificationTypes, remoteNotificationTypes)
+	TITANIUM_FUNCTION_AS_GETTER(NetworkModule, getRemoteNotificationsEnabled, remoteNotificationsEnabled)
+	TITANIUM_FUNCTION_AS_GETTER(NetworkModule, getHttpURLFormatter, httpURLFormatter)
+	TITANIUM_FUNCTION_AS_SETTER(NetworkModule, setHttpURLFormatter, httpURLFormatter)
+
+	TITANIUM_PROPERTY_GETTER_STRING(NetworkModule, networkTypeName);
+	TITANIUM_PROPERTY_GETTER_BOOL(NetworkModule, online);
+	TITANIUM_PROPERTY_GETTER_STRING(NetworkModule, remoteDeviceUUID);
+	TITANIUM_PROPERTY_GETTER_BOOL(NetworkModule, remoteNotificationsEnabled);
+	TITANIUM_PROPERTY_GETTER_OBJECT_ARRAY(NetworkModule, allHTTPCookies);
 
 	TITANIUM_PROPERTY_GETTER(NetworkModule, networkType)
 	{
 		return get_context().CreateNumber(Titanium::Network::Constants::to_underlying_type(get_networkType()));
 	}
 
-	TITANIUM_PROPERTY_GETTER(NetworkModule, networkTypeName)
+	TITANIUM_PROPERTY_GETTER(NetworkModule, remoteNotificationTypes)
 	{
-		return get_context().CreateString(get_networkTypeName());
+		std::vector<JSValue> types;
+		for (const auto t : get_remoteNotificationTypes()) {
+			types.push_back(get_context().CreateNumber(Titanium::Network::Constants::to_underlying_type(t)));
+		}
+		return get_context().CreateArray(types);
 	}
 
-	TITANIUM_PROPERTY_GETTER(NetworkModule, online)
+	TITANIUM_PROPERTY_GETTER(NetworkModule, httpURLFormatter)
 	{
-		return get_context().CreateBoolean(get_online());
+		return httpURLFormatter__;
+	}
+
+	TITANIUM_PROPERTY_SETTER(NetworkModule, httpURLFormatter)
+	{
+		TITANIUM_ASSERT(argument.IsObject());
+		httpURLFormatter__ = static_cast<JSObject>(argument);
+		return true;
 	}
 }

--- a/Source/TitaniumKit/src/UI/ScrollableView.cpp
+++ b/Source/TitaniumKit/src/UI/ScrollableView.cpp
@@ -78,7 +78,7 @@ namespace Titanium
 		{
 			const auto it = std::find(views__.begin(), views__.end(), view);
 			if (it != views__.end()) {
-				set_currentPage(std::distance(views__.begin(), it));
+				set_currentPage(static_cast<uint32_t>(std::distance(views__.begin(), it)));
 			}
 		}
 

--- a/Source/TitaniumKit/test/NetworkTests.cpp
+++ b/Source/TitaniumKit/test/NetworkTests.cpp
@@ -50,6 +50,213 @@ TEST_F(NetworkTests, BasicFeatures)
 	Titanium.SetProperty("Network", Network, {JSPropertyAttribute::ReadOnly, JSPropertyAttribute::DontDelete});
 	XCTAssertTrue(Titanium.HasProperty("Network"));
 
-	XCTAssertTrue(Network.HasProperty("createHTTPClient"));
+	XCTAssertTrue(Network.HasProperty("NETWORK_LAN"));
+	XCTAssertTrue(Network.HasProperty("NETWORK_MOBILE"));
+	XCTAssertTrue(Network.HasProperty("NETWORK_NONE"));
+	XCTAssertTrue(Network.HasProperty("NETWORK_UNKNOWN"));
+	XCTAssertTrue(Network.HasProperty("NETWORK_WIFI"));
+	XCTAssertTrue(Network.HasProperty("NOTIFICATION_TYPE_ALERT"));
+	XCTAssertTrue(Network.HasProperty("NOTIFICATION_TYPE_BADGE"));
+	XCTAssertTrue(Network.HasProperty("NOTIFICATION_TYPE_SOUND"));
+	XCTAssertTrue(Network.HasProperty("NOTIFICATION_TYPE_NEWSSTAND"));
+	XCTAssertTrue(Network.HasProperty("TLS_VERSION_1_0"));
+	XCTAssertTrue(Network.HasProperty("TLS_VERSION_1_1"));
+	XCTAssertTrue(Network.HasProperty("TLS_VERSION_1_2"));
+	XCTAssertTrue(Network.HasProperty("PROGRESS_UNKNOWN"));
+	XCTAssertTrue(Network.HasProperty("allHTTPCookies"));
+	XCTAssertTrue(Network.HasProperty("networkType"));
+	XCTAssertTrue(Network.HasProperty("networkTypeName"));
+	XCTAssertTrue(Network.HasProperty("online"));
+	XCTAssertTrue(Network.HasProperty("remoteDeviceUUID"));
+	XCTAssertTrue(Network.HasProperty("remoteNotificationTypes"));
+	XCTAssertTrue(Network.HasProperty("remoteNotificationsEnabled"));
+	XCTAssertTrue(Network.HasProperty("httpURLFormatter"));
 
+	XCTAssertTrue(Network.HasProperty("addHTTPCookie"));
+	XCTAssertTrue(Network.HasProperty("addSystemCookie"));
+	XCTAssertTrue(Network.HasProperty("createBonjourBrowser"));
+	XCTAssertTrue(Network.HasProperty("createBonjourService"));
+	XCTAssertTrue(Network.HasProperty("getHTTPCookies"));
+	XCTAssertTrue(Network.HasProperty("getHTTPCookiesForDomain"));
+	XCTAssertTrue(Network.HasProperty("getSystemCookies"));
+	XCTAssertTrue(Network.HasProperty("removeAllHTTPCookies"));
+	XCTAssertTrue(Network.HasProperty("removeAllSystemCookies"));
+	XCTAssertTrue(Network.HasProperty("removeHTTPCookie"));
+	XCTAssertTrue(Network.HasProperty("removeHTTPCookiesForDomain"));
+	XCTAssertTrue(Network.HasProperty("removeSystemCookie"));
+	XCTAssertTrue(Network.HasProperty("registerForPushNotifications"));
+	XCTAssertTrue(Network.HasProperty("unregisterForPushNotifications"));
+	XCTAssertTrue(Network.HasProperty("createCookie"));
+	XCTAssertTrue(Network.HasProperty("createHTTPClient"));
+	XCTAssertTrue(Network.HasProperty("getAllHTTPCookies"));
+	XCTAssertTrue(Network.HasProperty("getNetworkType"));
+	XCTAssertTrue(Network.HasProperty("getNetworkTypeName"));
+	XCTAssertTrue(Network.HasProperty("getOnline"));
+	XCTAssertTrue(Network.HasProperty("getRemoteDeviceUUID"));
+	XCTAssertTrue(Network.HasProperty("getRemoteNotificationTypes"));
+	XCTAssertTrue(Network.HasProperty("getRemoteNotificationsEnabled"));
+	XCTAssertTrue(Network.HasProperty("getHttpURLFormatter"));
+	XCTAssertTrue(Network.HasProperty("setHttpURLFormatter"));
+}
+
+TEST_F(NetworkTests, CookieBasicFeatures)
+{
+	JSContext js_context = js_context_group.CreateContext(JSExport<Titanium::GlobalObject>::Class());
+	auto global_object = js_context.get_global_object();
+
+	XCTAssertFalse(global_object.HasProperty("Titanium"));
+	auto Titanium = js_context.CreateObject();
+	global_object.SetProperty("Titanium", Titanium, {JSPropertyAttribute::ReadOnly, JSPropertyAttribute::DontDelete});
+	XCTAssertTrue(global_object.HasProperty("Titanium"));
+
+	// Make the alias "Ti" for the "Titanium" property.
+	XCTAssertFalse(global_object.HasProperty("Ti"));
+	global_object.SetProperty("Ti", Titanium, {JSPropertyAttribute::ReadOnly, JSPropertyAttribute::DontDelete});
+	XCTAssertTrue(global_object.HasProperty("Ti"));
+
+	XCTAssertFalse(Titanium.HasProperty("Cookie"));
+	auto Cookie = js_context.CreateObject(JSExport<Titanium::Network::Cookie>::Class());
+	Titanium.SetProperty("Cookie", Cookie, {JSPropertyAttribute::ReadOnly, JSPropertyAttribute::DontDelete});
+	XCTAssertTrue(Titanium.HasProperty("Cookie"));
+
+	XCTAssertTrue(Cookie.HasProperty("comment"));
+	XCTAssertTrue(Cookie.HasProperty("domain"));
+	XCTAssertTrue(Cookie.HasProperty("expiryDate"));
+	XCTAssertTrue(Cookie.HasProperty("httponly"));
+	XCTAssertTrue(Cookie.HasProperty("name"));
+	XCTAssertTrue(Cookie.HasProperty("originalUrl"));
+	XCTAssertTrue(Cookie.HasProperty("path"));
+	XCTAssertTrue(Cookie.HasProperty("secure"));
+	XCTAssertTrue(Cookie.HasProperty("value"));
+	XCTAssertTrue(Cookie.HasProperty("version"));
+	XCTAssertTrue(Cookie.HasProperty("isValid"));
+	XCTAssertTrue(Cookie.HasProperty("getComment"));
+	XCTAssertTrue(Cookie.HasProperty("setComment"));
+	XCTAssertTrue(Cookie.HasProperty("getDomain"));
+	XCTAssertTrue(Cookie.HasProperty("setDomain"));
+	XCTAssertTrue(Cookie.HasProperty("getExpiryDate"));
+	XCTAssertTrue(Cookie.HasProperty("setExpiryDate"));
+	XCTAssertTrue(Cookie.HasProperty("getHttponly"));
+	XCTAssertTrue(Cookie.HasProperty("setHttponly"));
+	XCTAssertTrue(Cookie.HasProperty("getName"));
+	XCTAssertTrue(Cookie.HasProperty("getOriginalUrl"));
+	XCTAssertTrue(Cookie.HasProperty("setOriginalUrl"));
+	XCTAssertTrue(Cookie.HasProperty("getPath"));
+	XCTAssertTrue(Cookie.HasProperty("setPath"));
+	XCTAssertTrue(Cookie.HasProperty("getSecure"));
+	XCTAssertTrue(Cookie.HasProperty("setSecure"));
+	XCTAssertTrue(Cookie.HasProperty("getValue"));
+	XCTAssertTrue(Cookie.HasProperty("setValue"));
+	XCTAssertTrue(Cookie.HasProperty("getVersion"));
+	XCTAssertTrue(Cookie.HasProperty("setVersion"));
+}
+
+TEST_F(NetworkTests, HTTPClientBasicFeatures)
+{
+	JSContext js_context = js_context_group.CreateContext(JSExport<Titanium::GlobalObject>::Class());
+	auto global_object = js_context.get_global_object();
+
+	XCTAssertFalse(global_object.HasProperty("Titanium"));
+	auto Titanium = js_context.CreateObject();
+	global_object.SetProperty("Titanium", Titanium, {JSPropertyAttribute::ReadOnly, JSPropertyAttribute::DontDelete});
+	XCTAssertTrue(global_object.HasProperty("Titanium"));
+
+	// Make the alias "Ti" for the "Titanium" property.
+	XCTAssertFalse(global_object.HasProperty("Ti"));
+	global_object.SetProperty("Ti", Titanium, {JSPropertyAttribute::ReadOnly, JSPropertyAttribute::DontDelete});
+	XCTAssertTrue(global_object.HasProperty("Ti"));
+
+	XCTAssertFalse(Titanium.HasProperty("HTTPClient"));
+	auto HTTPClient = js_context.CreateObject(JSExport<Titanium::Network::HTTPClient>::Class());
+	Titanium.SetProperty("HTTPClient", HTTPClient, {JSPropertyAttribute::ReadOnly, JSPropertyAttribute::DontDelete});
+	XCTAssertTrue(Titanium.HasProperty("HTTPClient"));
+
+	XCTAssertTrue(HTTPClient.HasProperty("autoEncodeUrl"));
+	XCTAssertTrue(HTTPClient.HasProperty("autoRedirect"));
+	XCTAssertTrue(HTTPClient.HasProperty("cache"));
+	XCTAssertTrue(HTTPClient.HasProperty("domain"));
+	XCTAssertTrue(HTTPClient.HasProperty("enableKeepAlive"));
+	XCTAssertTrue(HTTPClient.HasProperty("file"));
+	XCTAssertTrue(HTTPClient.HasProperty("ondatastream"));
+	XCTAssertTrue(HTTPClient.HasProperty("onerror"));
+	XCTAssertTrue(HTTPClient.HasProperty("onload"));
+	XCTAssertTrue(HTTPClient.HasProperty("onreadystatechange"));
+	XCTAssertTrue(HTTPClient.HasProperty("onsendstream"));
+	XCTAssertTrue(HTTPClient.HasProperty("password"));
+	XCTAssertTrue(HTTPClient.HasProperty("securityManager"));
+	XCTAssertTrue(HTTPClient.HasProperty("timeout"));
+	XCTAssertTrue(HTTPClient.HasProperty("tlsVersion"));
+	XCTAssertTrue(HTTPClient.HasProperty("username"));
+	XCTAssertTrue(HTTPClient.HasProperty("validatesSecureCertificate"));
+	XCTAssertTrue(HTTPClient.HasProperty("withCredentials"));
+	XCTAssertTrue(HTTPClient.HasProperty("DONE"));
+	XCTAssertTrue(HTTPClient.HasProperty("HEADERS_RECEIVED"));
+	XCTAssertTrue(HTTPClient.HasProperty("LOADING"));
+	XCTAssertTrue(HTTPClient.HasProperty("OPENED"));
+	XCTAssertTrue(HTTPClient.HasProperty("UNSENT"));
+	XCTAssertTrue(HTTPClient.HasProperty("allResponseHeaders"));
+	XCTAssertTrue(HTTPClient.HasProperty("connected"));
+	XCTAssertTrue(HTTPClient.HasProperty("connectionType"));
+	XCTAssertTrue(HTTPClient.HasProperty("location"));
+	XCTAssertTrue(HTTPClient.HasProperty("readyState"));
+	XCTAssertTrue(HTTPClient.HasProperty("responseData"));
+	XCTAssertTrue(HTTPClient.HasProperty("responseText"));
+	XCTAssertTrue(HTTPClient.HasProperty("responseXML"));
+	XCTAssertTrue(HTTPClient.HasProperty("status"));
+	XCTAssertTrue(HTTPClient.HasProperty("statusText"));
+	XCTAssertTrue(HTTPClient.HasProperty("abort"));
+	XCTAssertTrue(HTTPClient.HasProperty("addAuthFactory"));
+	XCTAssertTrue(HTTPClient.HasProperty("addKeyManager"));
+	XCTAssertTrue(HTTPClient.HasProperty("addTrustManager"));
+	XCTAssertTrue(HTTPClient.HasProperty("clearCookies"));
+	XCTAssertTrue(HTTPClient.HasProperty("getAllResponseHeaders"));
+	XCTAssertTrue(HTTPClient.HasProperty("getAutoEncodeUrl"));
+	XCTAssertTrue(HTTPClient.HasProperty("getAutoRedirect"));
+	XCTAssertTrue(HTTPClient.HasProperty("getCache"));
+	XCTAssertTrue(HTTPClient.HasProperty("getConnected"));
+	XCTAssertTrue(HTTPClient.HasProperty("getConnectionType"));
+	XCTAssertTrue(HTTPClient.HasProperty("getDomain"));
+	XCTAssertTrue(HTTPClient.HasProperty("getEnableKeepAlive"));
+	XCTAssertTrue(HTTPClient.HasProperty("getFile"));
+	XCTAssertTrue(HTTPClient.HasProperty("getLocation"));
+	XCTAssertTrue(HTTPClient.HasProperty("getOndatastream"));
+	XCTAssertTrue(HTTPClient.HasProperty("getOnerror"));
+	XCTAssertTrue(HTTPClient.HasProperty("getOnload"));
+	XCTAssertTrue(HTTPClient.HasProperty("getOnreadystatechange"));
+	XCTAssertTrue(HTTPClient.HasProperty("getOnsendstream"));
+	XCTAssertTrue(HTTPClient.HasProperty("getPassword"));
+	XCTAssertTrue(HTTPClient.HasProperty("getReadyState"));
+	XCTAssertTrue(HTTPClient.HasProperty("getResponseData"));
+	XCTAssertTrue(HTTPClient.HasProperty("getResponseHeader"));
+	XCTAssertTrue(HTTPClient.HasProperty("getResponseText"));
+	XCTAssertTrue(HTTPClient.HasProperty("getResponseXML"));
+	XCTAssertTrue(HTTPClient.HasProperty("getSecurityManager"));
+	XCTAssertTrue(HTTPClient.HasProperty("getStatus"));
+	XCTAssertTrue(HTTPClient.HasProperty("getStatusText"));
+	XCTAssertTrue(HTTPClient.HasProperty("getTimeout"));
+	XCTAssertTrue(HTTPClient.HasProperty("getTlsVersion"));
+	XCTAssertTrue(HTTPClient.HasProperty("getUsername"));
+	XCTAssertTrue(HTTPClient.HasProperty("getValidatesSecureCertificate"));
+	XCTAssertTrue(HTTPClient.HasProperty("getWithCredentials"));
+	XCTAssertTrue(HTTPClient.HasProperty("open"));
+	XCTAssertTrue(HTTPClient.HasProperty("send"));
+	XCTAssertTrue(HTTPClient.HasProperty("setAutoEncodeUrl"));
+	XCTAssertTrue(HTTPClient.HasProperty("setAutoRedirect"));
+	XCTAssertTrue(HTTPClient.HasProperty("setCache"));
+	XCTAssertTrue(HTTPClient.HasProperty("setDomain"));
+	XCTAssertTrue(HTTPClient.HasProperty("setEnableKeepAlive"));
+	XCTAssertTrue(HTTPClient.HasProperty("setFile"));
+	XCTAssertTrue(HTTPClient.HasProperty("setOndatastream"));
+	XCTAssertTrue(HTTPClient.HasProperty("setOnerror"));
+	XCTAssertTrue(HTTPClient.HasProperty("setOnload"));
+	XCTAssertTrue(HTTPClient.HasProperty("setOnreadystatechange"));
+	XCTAssertTrue(HTTPClient.HasProperty("setOnsendstream"));
+	XCTAssertTrue(HTTPClient.HasProperty("setPassword"));
+	XCTAssertTrue(HTTPClient.HasProperty("setRequestHeader"));
+	XCTAssertTrue(HTTPClient.HasProperty("setSecurityManager"));
+	XCTAssertTrue(HTTPClient.HasProperty("setTimeout"));
+	XCTAssertTrue(HTTPClient.HasProperty("setTlsVersion"));
+	XCTAssertTrue(HTTPClient.HasProperty("setUsername"));
+	XCTAssertTrue(HTTPClient.HasProperty("setValidatesSecureCertificate"));
+	XCTAssertTrue(HTTPClient.HasProperty("setWithCredentials"));
 }

--- a/Source/TitaniumKit/xcode/TitaniumKit.xcodeproj/project.pbxproj
+++ b/Source/TitaniumKit/xcode/TitaniumKit.xcodeproj/project.pbxproj
@@ -110,6 +110,14 @@
 		F95C3E281AA59C6A006AB8C7 /* Route.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F95C3E261AA59C6A006AB8C7 /* Route.hpp */; };
 		F95C3E2B1AA59C75006AB8C7 /* Camera.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F95C3E291AA59C75006AB8C7 /* Camera.cpp */; };
 		F95C3E2C1AA59C75006AB8C7 /* Route.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F95C3E2A1AA59C75006AB8C7 /* Route.cpp */; };
+		F95F908C1B01BD510002BD1C /* Socket.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F95F908B1B01BD510002BD1C /* Socket.hpp */; };
+		F95F90901B01BD680002BD1C /* TCP.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F95F908E1B01BD680002BD1C /* TCP.hpp */; };
+		F95F90911B01BD680002BD1C /* UDP.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F95F908F1B01BD680002BD1C /* UDP.hpp */; };
+		F95F90931B01BD740002BD1C /* Socket.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F95F90921B01BD740002BD1C /* Socket.cpp */; };
+		F95F90961B01BD800002BD1C /* TCP.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F95F90941B01BD800002BD1C /* TCP.cpp */; };
+		F95F90971B01BD800002BD1C /* UDP.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F95F90951B01BD800002BD1C /* UDP.cpp */; };
+		F95F90991B01EBE90002BD1C /* AcceptDict.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F95F90981B01EBE90002BD1C /* AcceptDict.hpp */; };
+		F95F909B1B01EBF70002BD1C /* AcceptDict.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F95F909A1B01EBF70002BD1C /* AcceptDict.cpp */; };
 		F965FF201AA587F30092ABBA /* MapModule.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F965FF1F1AA587F30092ABBA /* MapModule.hpp */; };
 		F965FF241AA588010092ABBA /* Annotation.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F965FF211AA588010092ABBA /* Annotation.hpp */; };
 		F965FF251AA588010092ABBA /* Constants.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F965FF221AA588010092ABBA /* Constants.hpp */; };
@@ -135,6 +143,12 @@
 		F96BCAC41A25CEB000745C3B /* NativePlatformExample.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F96BCAC21A25CEB000745C3B /* NativePlatformExample.hpp */; };
 		F9901B091AA5A355003FFD52 /* MapRegionTypev2.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F9901B081AA5A355003FFD52 /* MapRegionTypev2.hpp */; };
 		F9901B0B1AA5A366003FFD52 /* MapRegionTypev2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9901B0A1AA5A366003FFD52 /* MapRegionTypev2.cpp */; };
+		F9991D521AFF5A6400C7DDF2 /* Cookie.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9991D511AFF5A6400C7DDF2 /* Cookie.cpp */; };
+		F9991D551AFF5A9200C7DDF2 /* Constants.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F9991D531AFF5A9200C7DDF2 /* Constants.hpp */; };
+		F9991D561AFF5A9200C7DDF2 /* Cookie.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F9991D541AFF5A9200C7DDF2 /* Cookie.hpp */; };
+		F9991D581AFF5A9F00C7DDF2 /* NetworkModule.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F9991D571AFF5A9F00C7DDF2 /* NetworkModule.hpp */; };
+		F9991D5A1AFF7D4100C7DDF2 /* PushNotificationConfig.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9991D591AFF7D4100C7DDF2 /* PushNotificationConfig.cpp */; };
+		F9991D5C1AFF7D4E00C7DDF2 /* PushNotificationConfig.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F9991D5B1AFF7D4E00C7DDF2 /* PushNotificationConfig.hpp */; };
 		F99AE3B41ADFA2F500D0F91E /* ActivityIndicator.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F99AE3B21ADFA2F500D0F91E /* ActivityIndicator.hpp */; };
 		F99AE3B51ADFA2F500D0F91E /* ActivityIndicatorStyle.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F99AE3B31ADFA2F500D0F91E /* ActivityIndicatorStyle.hpp */; };
 		F99AE3B81ADFA30300D0F91E /* ActivityIndicator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F99AE3B61ADFA30300D0F91E /* ActivityIndicator.cpp */; };
@@ -168,7 +182,6 @@
 		F9B1AF5D1A8DB4E100DEF4D6 /* ListSection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9B1AF5C1A8DB4E100DEF4D6 /* ListSection.cpp */; };
 		F9B1AF5F1A8DB4EF00DEF4D6 /* ListSection.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F9B1AF5E1A8DB4EF00DEF4D6 /* ListSection.hpp */; };
 		F9B1AF611A8DC18E00DEF4D6 /* ListViewAnimationProperties.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F9B1AF601A8DC18E00DEF4D6 /* ListViewAnimationProperties.hpp */; };
-		F9B1AF6B1A8E2E9400DEF4D6 /* Network.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F9B1AF6A1A8E2E9400DEF4D6 /* Network.hpp */; };
 		F9B1AF6D1A8E2EA300DEF4D6 /* NetworkModule.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9B1AF6C1A8E2EA300DEF4D6 /* NetworkModule.cpp */; };
 		F9B1AF6F1A8E2EBE00DEF4D6 /* DatabaseModule.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F9B1AF6E1A8E2EBE00DEF4D6 /* DatabaseModule.hpp */; };
 		F9B1AF711A8E2ECF00DEF4D6 /* HTTPClient.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F9B1AF701A8E2ECF00DEF4D6 /* HTTPClient.hpp */; };
@@ -322,6 +335,14 @@
 		F95C3E261AA59C6A006AB8C7 /* Route.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = Route.hpp; path = include/Titanium/Map/Route.hpp; sourceTree = "<group>"; };
 		F95C3E291AA59C75006AB8C7 /* Camera.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Camera.cpp; path = src/Map/Camera.cpp; sourceTree = "<group>"; };
 		F95C3E2A1AA59C75006AB8C7 /* Route.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Route.cpp; path = src/Map/Route.cpp; sourceTree = "<group>"; };
+		F95F908B1B01BD510002BD1C /* Socket.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = Socket.hpp; path = include/Titanium/Network/Socket.hpp; sourceTree = "<group>"; };
+		F95F908E1B01BD680002BD1C /* TCP.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = TCP.hpp; path = include/Titanium/Network/Socket/TCP.hpp; sourceTree = "<group>"; };
+		F95F908F1B01BD680002BD1C /* UDP.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = UDP.hpp; path = include/Titanium/Network/Socket/UDP.hpp; sourceTree = "<group>"; };
+		F95F90921B01BD740002BD1C /* Socket.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Socket.cpp; path = src/Network/Socket.cpp; sourceTree = "<group>"; };
+		F95F90941B01BD800002BD1C /* TCP.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TCP.cpp; path = src/Network/Socket/TCP.cpp; sourceTree = "<group>"; };
+		F95F90951B01BD800002BD1C /* UDP.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = UDP.cpp; path = src/Network/Socket/UDP.cpp; sourceTree = "<group>"; };
+		F95F90981B01EBE90002BD1C /* AcceptDict.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = AcceptDict.hpp; path = include/Titanium/Network/Socket/AcceptDict.hpp; sourceTree = "<group>"; };
+		F95F909A1B01EBF70002BD1C /* AcceptDict.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = AcceptDict.cpp; path = src/Network/Socket/AcceptDict.cpp; sourceTree = "<group>"; };
 		F965FF1F1AA587F30092ABBA /* MapModule.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = MapModule.hpp; path = include/Titanium/MapModule.hpp; sourceTree = "<group>"; };
 		F965FF211AA588010092ABBA /* Annotation.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = Annotation.hpp; path = include/Titanium/Map/Annotation.hpp; sourceTree = "<group>"; };
 		F965FF221AA588010092ABBA /* Constants.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = Constants.hpp; path = include/Titanium/Map/Constants.hpp; sourceTree = "<group>"; };
@@ -347,6 +368,12 @@
 		F96BCAC21A25CEB000745C3B /* NativePlatformExample.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = NativePlatformExample.hpp; sourceTree = "<group>"; };
 		F9901B081AA5A355003FFD52 /* MapRegionTypev2.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = MapRegionTypev2.hpp; path = include/Titanium/Map/MapRegionTypev2.hpp; sourceTree = "<group>"; };
 		F9901B0A1AA5A366003FFD52 /* MapRegionTypev2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = MapRegionTypev2.cpp; path = src/Map/MapRegionTypev2.cpp; sourceTree = "<group>"; };
+		F9991D511AFF5A6400C7DDF2 /* Cookie.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Cookie.cpp; path = src/Network/Cookie.cpp; sourceTree = "<group>"; };
+		F9991D531AFF5A9200C7DDF2 /* Constants.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = Constants.hpp; path = include/Titanium/Network/Constants.hpp; sourceTree = "<group>"; };
+		F9991D541AFF5A9200C7DDF2 /* Cookie.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = Cookie.hpp; path = include/Titanium/Network/Cookie.hpp; sourceTree = "<group>"; };
+		F9991D571AFF5A9F00C7DDF2 /* NetworkModule.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = NetworkModule.hpp; path = include/Titanium/NetworkModule.hpp; sourceTree = "<group>"; };
+		F9991D591AFF7D4100C7DDF2 /* PushNotificationConfig.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = PushNotificationConfig.cpp; path = src/Network/PushNotificationConfig.cpp; sourceTree = "<group>"; };
+		F9991D5B1AFF7D4E00C7DDF2 /* PushNotificationConfig.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = PushNotificationConfig.hpp; path = include/Titanium/Network/PushNotificationConfig.hpp; sourceTree = "<group>"; };
 		F99AE3B21ADFA2F500D0F91E /* ActivityIndicator.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = ActivityIndicator.hpp; path = include/Titanium/UI/ActivityIndicator.hpp; sourceTree = "<group>"; };
 		F99AE3B31ADFA2F500D0F91E /* ActivityIndicatorStyle.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = ActivityIndicatorStyle.hpp; path = include/Titanium/UI/ActivityIndicatorStyle.hpp; sourceTree = "<group>"; };
 		F99AE3B61ADFA30300D0F91E /* ActivityIndicator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ActivityIndicator.cpp; path = src/UI/ActivityIndicator.cpp; sourceTree = "<group>"; };
@@ -380,7 +407,6 @@
 		F9B1AF5C1A8DB4E100DEF4D6 /* ListSection.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ListSection.cpp; path = src/UI/ListSection.cpp; sourceTree = "<group>"; };
 		F9B1AF5E1A8DB4EF00DEF4D6 /* ListSection.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = ListSection.hpp; path = include/Titanium/UI/ListSection.hpp; sourceTree = "<group>"; };
 		F9B1AF601A8DC18E00DEF4D6 /* ListViewAnimationProperties.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = ListViewAnimationProperties.hpp; path = include/Titanium/UI/ListViewAnimationProperties.hpp; sourceTree = "<group>"; };
-		F9B1AF6A1A8E2E9400DEF4D6 /* Network.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = Network.hpp; path = ../Network/include/TitaniumWindows/Network.hpp; sourceTree = "<group>"; };
 		F9B1AF6C1A8E2EA300DEF4D6 /* NetworkModule.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = NetworkModule.cpp; path = src/NetworkModule.cpp; sourceTree = "<group>"; };
 		F9B1AF6E1A8E2EBE00DEF4D6 /* DatabaseModule.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = DatabaseModule.hpp; path = include/Titanium/DatabaseModule.hpp; sourceTree = "<group>"; };
 		F9B1AF701A8E2ECF00DEF4D6 /* HTTPClient.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = HTTPClient.hpp; path = include/Titanium/Network/HTTPClient.hpp; sourceTree = "<group>"; };
@@ -675,6 +701,21 @@
 			name = detail;
 			sourceTree = "<group>";
 		};
+		F95F908D1B01BD560002BD1C /* Socket */ = {
+			isa = PBXGroup;
+			children = (
+				F95F909A1B01EBF70002BD1C /* AcceptDict.cpp */,
+				F95F90981B01EBE90002BD1C /* AcceptDict.hpp */,
+				F95F908E1B01BD680002BD1C /* TCP.hpp */,
+				F95F90941B01BD800002BD1C /* TCP.cpp */,
+				F95F908F1B01BD680002BD1C /* UDP.hpp */,
+				F95F90951B01BD800002BD1C /* UDP.cpp */,
+				F95F908B1B01BD510002BD1C /* Socket.hpp */,
+				F95F90921B01BD740002BD1C /* Socket.cpp */,
+			);
+			name = Socket;
+			sourceTree = "<group>";
+		};
 		F965FF2F1AA5899D0092ABBA /* Map */ = {
 			isa = PBXGroup;
 			children = (
@@ -712,10 +753,16 @@
 		F968A1C91AB9A97900A0D546 /* Network */ = {
 			isa = PBXGroup;
 			children = (
-				F9B1AF701A8E2ECF00DEF4D6 /* HTTPClient.hpp */,
+				F95F908D1B01BD560002BD1C /* Socket */,
+				F9991D5B1AFF7D4E00C7DDF2 /* PushNotificationConfig.hpp */,
+				F9991D591AFF7D4100C7DDF2 /* PushNotificationConfig.cpp */,
+				F9991D541AFF5A9200C7DDF2 /* Cookie.hpp */,
+				F9991D511AFF5A6400C7DDF2 /* Cookie.cpp */,
+				F9991D571AFF5A9F00C7DDF2 /* NetworkModule.hpp */,
 				F9B1AF6C1A8E2EA300DEF4D6 /* NetworkModule.cpp */,
-				F9B1AF6A1A8E2E9400DEF4D6 /* Network.hpp */,
+				F9991D531AFF5A9200C7DDF2 /* Constants.hpp */,
 				F96A53DD1AA5CFEA00AD4011 /* Constants.cpp */,
+				F9B1AF701A8E2ECF00DEF4D6 /* HTTPClient.hpp */,
 				F9B1AF801A8E2F2B00DEF4D6 /* HTTPClient.cpp */,
 			);
 			name = Network;
@@ -778,6 +825,7 @@
 				F9B177951A2C46F100ECE602 /* Accelerometer.hpp in Headers */,
 				C9E6AFB81A13043300FED053 /* Titanium.hpp in Headers */,
 				F93CDC421A96D24C00C42D8C /* Gradient.hpp in Headers */,
+				F9991D5C1AFF7D4E00C7DDF2 /* PushNotificationConfig.hpp in Headers */,
 				F9B1AF771A8E2EDD00DEF4D6 /* ResultSet.hpp in Headers */,
 				F9B549791A402D520051A096 /* NativeTiExample.hpp in Headers */,
 				F9ACB7E91AF9CE01008C2F3C /* TableViewSection.hpp in Headers */,
@@ -812,23 +860,28 @@
 				F9ACB7DF1AF9CE01008C2F3C /* OpenWindowParams.hpp in Headers */,
 				F9ACB7E31AF9CE01008C2F3C /* ProgressBar.hpp in Headers */,
 				F93CDC401A96D24C00C42D8C /* Dimension.hpp in Headers */,
+				F95F90901B01BD680002BD1C /* TCP.hpp in Headers */,
 				C97E14861A4CB0E200C15EDC /* ScrollView.hpp in Headers */,
 				C90B900D1A198370005F3210 /* ApplicationBuilder.hpp in Headers */,
 				F9ACB7DE1AF9CE01008C2F3C /* MatrixCreationDict.hpp in Headers */,
 				C90B90091A19804D005F3210 /* Application.hpp in Headers */,
 				C980919B1A2149A300AE5930 /* TitaniumKit_EXPORT.h in Headers */,
+				F9991D581AFF5A9F00C7DDF2 /* NetworkModule.hpp in Headers */,
 				F9E96F8B1A415D6E001E0EC4 /* DisplayCaps.hpp in Headers */,
 				F93CDC431A96D24C00C42D8C /* Point.hpp in Headers */,
 				C9E6AFEC1A13F95300FED053 /* TiLogger.hpp in Headers */,
 				C9E6AFED1A13F95500FED053 /* TiLoggerPolicyInterface.hpp in Headers */,
 				F966AF7D1AC11AE900351707 /* ViewLayoutDelegate.hpp in Headers */,
+				F95F90991B01EBE90002BD1C /* AcceptDict.hpp in Headers */,
 				F9BE4A7D1A88999400301999 /* NativeWebViewExample.hpp in Headers */,
 				F9B47E731A2EF1440052879A /* FilesystemModule.hpp in Headers */,
 				F9B47E7F1A2EF1860052879A /* NativeFileExample.hpp in Headers */,
+				F95F90911B01BD680002BD1C /* UDP.hpp in Headers */,
 				F95C3E281AA59C6A006AB8C7 /* Route.hpp in Headers */,
 				F96BCAC41A25CEB000745C3B /* NativePlatformExample.hpp in Headers */,
 				C9E6AFEE1A13F95900FED053 /* TiLoggerPolicyConsole.hpp in Headers */,
 				C90B90131A1ADC7D005F3210 /* NativeViewExample.hpp in Headers */,
+				F9991D551AFF5A9200C7DDF2 /* Constants.hpp in Headers */,
 				F965FF241AA588010092ABBA /* Annotation.hpp in Headers */,
 				C9BED2261A28F4CD00CFF800 /* Constants.hpp in Headers */,
 				C90950921A2951A7002133E1 /* Gesture.hpp in Headers */,
@@ -837,6 +890,7 @@
 				F9ACB7DD1AF9CE01008C2F3C /* EmailDialog.hpp in Headers */,
 				F9ACB7E81AF9CE01008C2F3C /* TableViewRow.hpp in Headers */,
 				F9B1AF751A8E2EDD00DEF4D6 /* Constants.hpp in Headers */,
+				F95F908C1B01BD510002BD1C /* Socket.hpp in Headers */,
 				C9E6AFF01A13F96000FED053 /* TiLoggerPimpl.hpp in Headers */,
 				C9E6AFEA1A13F94900FED053 /* TiUtil.hpp in Headers */,
 				F9B1AF5F1A8DB4EF00DEF4D6 /* ListSection.hpp in Headers */,
@@ -846,13 +900,13 @@
 				C950EF8F1A48D8FB000EE5AC /* ImageView.hpp in Headers */,
 				F9ACB7E61AF9CE01008C2F3C /* TableView.hpp in Headers */,
 				C9E6AFE91A13F94500FED053 /* HashUtilities.hpp in Headers */,
+				F9991D561AFF5A9200C7DDF2 /* Cookie.hpp in Headers */,
 				C9BED2211A27B14200CFF800 /* NativeModuleExample.hpp in Headers */,
 				F93CDC411A96D24C00C42D8C /* Font.hpp in Headers */,
 				C90950961A2954B3002133E1 /* TextField.hpp in Headers */,
 				F9901B091AA5A355003FFD52 /* MapRegionTypev2.hpp in Headers */,
 				C90950A21A296802002133E1 /* Picker.hpp in Headers */,
 				F9ACB7E51AF9CE01008C2F3C /* Switch.hpp in Headers */,
-				F9B1AF6B1A8E2E9400DEF4D6 /* Network.hpp in Headers */,
 				F9BD6B9F1A96FA4200D721A9 /* ListViewMarkerProps.hpp in Headers */,
 				F91676F71AA5A92A006A6E44 /* CameraAnimationParams.hpp in Headers */,
 				F965FF201AA587F30092ABBA /* MapModule.hpp in Headers */,
@@ -962,6 +1016,8 @@
 				C90B8F931A16D83F005F3210 /* Window.cpp in Sources */,
 				C950EF931A48D90A000EE5AC /* ImageView.cpp in Sources */,
 				F96A53DC1AA5CFC200AD4011 /* Properties.cpp in Sources */,
+				F95F90961B01BD800002BD1C /* TCP.cpp in Sources */,
+				F95F90971B01BD800002BD1C /* UDP.cpp in Sources */,
 				C90950831A291EB5002133E1 /* Animation.cpp in Sources */,
 				F9ACB7CA1AF9CDCD008C2F3C /* Switch.cpp in Sources */,
 				F96A53DA1AA5CFB700AD4011 /* App.cpp in Sources */,
@@ -970,12 +1026,16 @@
 				F9B1AF5D1A8DB4E100DEF4D6 /* ListSection.cpp in Sources */,
 				F966AF7F1AC11AF700351707 /* ViewLayoutDelegate.cpp in Sources */,
 				C9BED2201A27B14200CFF800 /* NativeModuleExample.cpp in Sources */,
+				F9991D5A1AFF7D4100C7DDF2 /* PushNotificationConfig.cpp in Sources */,
 				C909509F1A2963F3002133E1 /* ListView.cpp in Sources */,
 				F9901B0B1AA5A366003FFD52 /* MapRegionTypev2.cpp in Sources */,
+				F95F909B1B01EBF70002BD1C /* AcceptDict.cpp in Sources */,
 				F968A1C61AB93F6C00A0D546 /* FileStream.cpp in Sources */,
+				F9991D521AFF5A6400C7DDF2 /* Cookie.cpp in Sources */,
 				F9B1AF831A8E2F4400DEF4D6 /* sqlite3.c in Sources */,
 				F9ACB7C81AF9CDCD008C2F3C /* ProgressBar.cpp in Sources */,
 				F9B47E831A2EF94A0052879A /* Constants.cpp in Sources */,
+				F95F90931B01BD740002BD1C /* Socket.cpp in Sources */,
 				F93104261ABBDDAB0067470D /* TableViewRow.cpp in Sources */,
 				C90950931A2951A7002133E1 /* Gesture.cpp in Sources */,
 				F93104251ABBDDAB0067470D /* TableView.cpp in Sources */,


### PR DESCRIPTION
[TIMOB-18759](https://jira.appcelerator.org/browse/TIMOB-18759) Windows: Stub out all properties/methods of Titanium.Network in TitaniumKit

- Ti.Network
- Ti.Network.HTTPClient
- Ti.Network.Cookie
- [AcceptDict](http://docs.appcelerator.com/titanium/3.0/#!/api/AcceptDict)
- [PushNotificationConfig](http://docs.appcelerator.com/titanium/3.0/#!/api/PushNotificationConfig)
- Ti.Network.Socket
- Ti.Network.Socket.TCP
- Ti.Network.Socket.UDP
- Ti.Network related constants
- Ti.Network related enums
- Unit tests (TitaniumKit)

