### PR TITLE
[TIMOB-18937][TIMOB-18938][TIMOB-18939][TIMOB-18942] Add module support to the CLI - READY

### DIFF
--- a/Tools/Scripts/build/package.json
+++ b/Tools/Scripts/build/package.json
@@ -22,7 +22,7 @@
     "async": "~0.9.0",
     "colors": "~0.6.2",
     "ejs": "~2.2.4",
-  	"wrench": "~1.5.4",
+    "fs-extra": "~0.18.4",
     "titanium": "git://github.com/appcelerator/titanium.git#master"
   },
   "engines": {

--- a/Tools/Scripts/build/test.js
+++ b/Tools/Scripts/build/test.js
@@ -4,10 +4,9 @@
  * Please see the LICENSE included with this distribution for details.
  */
 var path = require('path'),
-	fs = require('fs'),
+	fs = require('fs-extra'),
 	async = require('async'),
 	colors = require('colors'),
-	wrench = require('wrench'),
 	ejs = require('ejs'),
 	spawn = require('child_process').spawn,
 	exec = require('child_process').exec,
@@ -54,10 +53,10 @@ function copyWindowsIntoSDK(sdkPath, next) {
 		dest = path.join(sdkPath, 'windows');
 	if (fs.existsSync(dest)) {
 		hadWindowsSDK = true;
-		wrench.rmdirSyncRecursive(dest);
+		fs.removeSync(dest);
 	}
 	// TODO Be smarter about copying to speed it up? Only copy diff? 
-	wrench.copyDirSyncRecursive(windowsSDKDir, dest);
+	fs.copySync(windowsSDKDir, dest);
 	next();
 }
 
@@ -85,9 +84,7 @@ function generateWindowsProject(next) {
 	var projectDir = path.join(__dirname, 'mocha'),
 		prc;
 	// If the project already exists, wipe it
-	if (fs.existsSync(projectDir)) {
-		wrench.rmdirSyncRecursive(projectDir);
-	}
+	fs.emptyDirSync(projectDir);
 	prc = spawn('node', [titanium, 'create', '-t', 'app', '-p', 'windows', '-n', 'mocha', '--id', 'com.appcelerator.mocha.testing', '-u', 'http://www.appcelerator.com', '-d', '.', '--no-prompt']);
 
 	prc.on('close', function (code) {
@@ -103,9 +100,8 @@ function generateWindowsProject(next) {
 function copyMochaAssets(next) {
 	var mochaAssetsDir = path.join(__dirname, '..', '..', '..', 'Examples', 'NMocha', 'src', 'Assets'),
 		dest = path.join(__dirname, 'mocha', 'Resources');
-	wrench.copyDirSyncRecursive(mochaAssetsDir, dest, {
-		forceDelete: true
-	});
+	fs.emptyDirSync(dest);
+	fs.copySync(mochaAssetsDir, dest);
 	next();
 }
 

--- a/cli/commands/_buildModule.js
+++ b/cli/commands/_buildModule.js
@@ -1,0 +1,248 @@
+/**
+* Windows module build command.
+*
+* @module cli/_buildModule
+*
+* @copyright
+* Copyright (c) 2015 by Appcelerator, Inc. All Rights Reserved.
+*
+* @license
+* Licensed under the terms of the Apache Public License
+* Please see the LICENSE included with this distribution for details.
+*/
+
+var archiver = require('archiver'),
+	async = require('async'),
+	appc = require('node-appc'),
+	Builder = require('titanium-sdk/lib/builder'),
+	fs = require('fs'),
+	wrench = require('wrench'),
+	path = require('path'),
+	windowslib = require('windowslib'),
+	util = require('util'),
+	spawn = require('child_process').spawn,
+
+	types = ['WindowsPhone', 'WindowsStore'],
+	typesMin = ['phone', 'store'],
+	configuration = 'Release';
+
+function WindowsModuleBuilder() {
+	Builder.apply(this, arguments);
+}
+util.inherits(WindowsModuleBuilder, Builder);
+
+WindowsModuleBuilder.prototype.config = function config(logger, config, cli) {
+	Builder.prototype.config.apply(this, arguments);
+};
+
+WindowsModuleBuilder.prototype.validate = function validate(logger, config, cli) {
+	if (cli.argv.platform && cli.argv.platform !== 'windows') {
+		logger.error('Invalid platform');
+		process.exit(1);
+	}
+};
+
+WindowsModuleBuilder.prototype.run = function run(logger, config, cli, finished) {
+	Builder.prototype.run.apply(this, arguments);
+
+	this.cli = cli;
+	this.logger = logger;
+
+	appc.async.series(this, [
+		function (next) {
+			cli.emit('build.pre.construct', this, next);
+		},
+
+		'doAnalytics',
+		'initialize',
+		'loginfo',
+
+		function (next) {
+			cli.emit('build.pre.compile', this, next);
+		},
+
+		'compileModule',
+		'packageZip',
+
+		function (next) {
+			//TODO: FIX THIS
+			//cli.emit('build.post.compile', this, next);
+		}
+	], function (err) {
+		cli.emit('build.finalize', this, function () {
+			finished(err);
+		});
+	});
+};
+
+WindowsModuleBuilder.prototype.doAnalytics = function doAnalytics(next) {
+	var cli = this.cli,
+		manifest = cli.manifest,
+		eventName = 'windows.' + cli.argv.type;
+
+	cli.addAnalyticsEvent(eventName, {
+		dir: cli.argv['project-dir'],
+		name: manifest.name,
+		publisher: manifest.author,
+		appid: manifest.moduleid,
+		description: manifest.description,
+		type: cli.argv.type,
+		guid: manifest.guid,
+		version: manifest.version,
+		copyright: manifest.copyright,
+		date: (new Date()).toDateString()
+	});
+
+	next();
+};
+
+WindowsModuleBuilder.prototype.initialize = function initialize(next) {
+	var _t = this;
+
+	function assertIssue(issues, name) {
+		for (var i = 0, l = issues.length; i < l; i++) {
+			if ((typeof name === 'string' && issues[i].id === name) || (typeof name === 'object' && name.test(issues[i].id))) {
+				issues[i].message.split('\n').forEach(function (line) {
+					logger.error(line.replace(/(__(.+?)__)/g, '$2'.bold));
+				});
+				logger.log();
+				process.exit(1);
+			}
+		}
+	}
+
+	this.projectDir = this.cli.argv['project-dir'];
+	this.manifest = this.cli.manifest;
+	this.buildDir = path.join(this.projectDir, 'build');
+
+	windowslib.detect(function (err, windowsInfo) {
+		assertIssue(windowsInfo.issues, 'WINDOWS_VISUAL_STUDIO_NOT_INSTALLED');
+		assertIssue(windowsInfo.issues, 'WINDOWS_MSBUILD_ERROR');
+		assertIssue(windowsInfo.issues, 'WINDOWS_MSBUILD_TOO_OLD');
+
+		if (!windowsInfo.selectedVisualStudio) {
+			logger.error('Unable to find a supported Visual Studio installation');
+			process.exit(1);
+		}
+
+		_t.windowsInfo = windowsInfo;
+
+		next();
+	});
+};
+
+WindowsModuleBuilder.prototype.loginfo = function loginfo(next) {
+	console.log('--- WindowsModuleBuilder loginfo');
+
+	this.logger.info('Visual Studio version: ' + this.windowsInfo.selectedVisualStudio.version.cyan);
+	this.logger.info('MSBuild version: ' + this.windowsInfo.selectedVisualStudio.msbuildVersion.cyan);
+	this.logger.info('Project directory: ' + this.projectDir.cyan);
+
+	next();
+};
+
+WindowsModuleBuilder.prototype.compileModule = function compileModule(next) {
+	var _t = this;
+
+	function build(sln, config, arch, next) {
+		var p = spawn(_t.windowsInfo.selectedVisualStudio.vcvarsall, [
+			'&&', 'MSBuild', '/m', '/p:Platform=' + arch, '/p:Configuration=' + config, sln
+		]);
+		p.stdout.on('data', function (data) {
+			_t.logger.info(data.toString().trim());
+		});
+		p.stderr.on('data', function (data) {
+			_t.logger.error(data.toString().trim());
+		});
+		p.on('close', function (code) {
+			if (code != 0) {
+				process.exit(code);
+			}
+			next();
+		});
+	}
+
+	// compile module projects
+	var archs = _t.manifest.architectures.split(' ');
+	async.eachSeries(types, function(type, next_type) {
+		async.eachSeries(archs, function(arch, next_arch) {
+			build(path.resolve(_t.projectDir, type+'.'+arch, _t.manifest.name+'.sln'), configuration, arch, next_arch);
+		}, function(err) {
+			if (err) {
+				throw err;
+			}
+			next_type();
+		});
+	}, function(err) {
+		if (err) {
+			throw err;
+		}
+		next();
+	});
+};
+
+WindowsModuleBuilder.prototype.packageZip = function packageZip(next) {
+	var buildDir = path.join(this.projectDir, 'build'),
+		moduleDir = path.join(buildDir, this.manifest.moduleid, this.manifest.version),
+		_t = this;
+
+	// empty any existing module directory
+	if (fs.existsSync(moduleDir)) {
+		wrench.rmdirSyncRecursive(moduleDir);
+	}
+	wrench.mkdirSyncRecursive(moduleDir);
+
+	// copy necesary folders and files
+	wrench.copyDirSyncRecursive(path.join(this.projectDir, '..', 'documentation'), path.join(moduleDir, 'documenation'));
+	wrench.copyDirSyncRecursive(path.join(this.projectDir, '..', 'example'), path.join(moduleDir, 'example'));
+	wrench.copyDirSyncRecursive(path.join(this.projectDir, '..', 'assets'), path.join(moduleDir, 'assets'));
+	wrench.copyDirSyncRecursive(path.join(this.projectDir, 'include'), path.join(moduleDir, 'include'));
+
+	fs.createReadStream(path.join(this.projectDir, '..', 'LICENSE')).pipe(fs.createWriteStream(path.join(moduleDir, 'LICENSE')));
+	fs.createReadStream(path.join(this.projectDir, 'manifest')).pipe(fs.createWriteStream(path.join(moduleDir, 'manifest')));
+
+	// copy compiled libraries
+	types.forEach(function(type, index) {
+		_t.manifest.architectures.split(' ').forEach(function(arch) {
+			var moduleSrc = path.join(_t.projectDir, type+'.'+arch, configuration, _t.manifest.name),
+				moduleDst = path.join(moduleDir, typesMin[index], arch, _t.manifest.name);
+
+			// create module directory
+			wrench.mkdirSyncRecursive(path.join(moduleDir, typesMin[index], arch));
+
+			// Dynamic-Link Library
+			fs.createReadStream(moduleSrc+'.dll').pipe(fs.createWriteStream(moduleDst+'.dll'));
+
+			// Windows Metadata
+			fs.createReadStream(moduleSrc+'.winmd').pipe(fs.createWriteStream(moduleDst+'.winmd'));
+
+			// Library
+			fs.createReadStream(moduleSrc+'.lib').pipe(fs.createWriteStream(moduleDst+'.lib'));
+		});
+	});
+
+	// create zip
+	var zipName = _t.manifest.moduleid + '-windows-' + _t.manifest.version + '.zip';
+	var output = fs.createWriteStream(path.join(_t.projectDir, zipName)),
+		archive = archiver('zip');
+
+	_t.logger.info('Creating zip: '+zipName.cyan);
+
+	archive.on('error', function(err) {
+		throw err;
+	});
+	archive.pipe(output);
+	archive.directory(buildDir, 'modules/windows');
+	archive.finalize();
+
+	output.on('close', function() {
+		_t.logger.info('Done.');
+		next();
+	});
+};
+
+(function (windowsModuleBuilder) {
+	exports.config   = windowsModuleBuilder.config.bind(windowsModuleBuilder);
+	exports.validate = windowsModuleBuilder.validate.bind(windowsModuleBuilder);
+	exports.run      = windowsModuleBuilder.run.bind(windowsModuleBuilder);
+}(new WindowsModuleBuilder(module)));

--- a/templates/build/cmake/FindJavaScriptCore.cmake
+++ b/templates/build/cmake/FindJavaScriptCore.cmake
@@ -1,0 +1,61 @@
+# HAL
+#
+# Copyright (c) 2014 by Appcelerator, Inc. All Rights Reserved.
+# Licensed under the terms of the Apache Public License.
+# Please see the LICENSE included with this distribution for details.
+
+# Author: Matt Langston
+# Created: 2014.09.03
+#
+# Try to find JavaScriptCore. Once done this will define:
+#
+#  JavaScriptCore_FOUND       - system has JavaScriptCore
+#  JavaScriptCore_INCLUDE_DIRS - the include directory
+#  JavaScriptCore_LIBRARY_DIR - the directory containing the library
+#  JavaScriptCore_LIBRARIES   - link these to use JavaScriptCore
+
+find_package(PkgConfig)
+
+pkg_check_modules(PC_JavaScriptCore QUIET JavaScriptCore)
+
+find_path(JavaScriptCore_INCLUDE_DIRS
+  NAMES JavaScriptCore/JavaScript.h
+  HINTS ${PC_JavaScriptCore_INCLUDE_DIRS} ${PC_JavaScriptCore_INCLUDEDIR}
+  PATHS ENV JavaScriptCore_HOME
+  PATH_SUFFIXES includes
+  )
+
+set(JavaScriptCore_ARCH "x86")
+if(CMAKE_GENERATOR MATCHES "^Visual Studio .+ ARM$")
+  set(JavaScriptCore_ARCH "arm")
+endif()
+
+find_library(JavaScriptCore_LIBRARIES
+  NAMES JavaScriptCore JavaScriptCore-Debug JavaScriptCore-Release
+  HINTS ${PC_JavaScriptCore_LIBRARY_DIRS} ${PC_JavaScriptCore_LIBDIR}
+  PATHS ENV JavaScriptCore_HOME
+  PATH_SUFFIXES ${JavaScriptCore_ARCH}
+  )
+
+if(NOT JavaScriptCore_LIBRARIES MATCHES ".+-NOTFOUND")
+  get_filename_component(JavaScriptCore_LIBRARY_DIR ${JavaScriptCore_LIBRARIES} DIRECTORY)
+
+  # If we found the JavaScriptCore library and we're using a Visual
+  # Studio generator and we're targeting either WindowsStore or
+  # WindowsPhone, then allow Visual Studio to use both the
+  # JavaScriptCore-Debug.lib and JavaScriptCore-Release.lib if they
+  # exist.
+  if(CMAKE_GENERATOR MATCHES "^Visual Studio .+" AND CMAKE_SYSTEM_NAME MATCHES "^Windows(Store|Phone)")
+    string(REGEX REPLACE "-(Debug|Release)" "-$(Configuration)" JavaScriptCore_LIBRARIES ${JavaScriptCore_LIBRARIES})
+  endif()
+
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(JavaScriptCore DEFAULT_MSG JavaScriptCore_INCLUDE_DIRS JavaScriptCore_LIBRARIES)
+
+# message(STATUS "MDL: CMAKE_CONFIGURATION_TYPES   = ${CMAKE_CONFIGURATION_TYPES}")
+# message(STATUS "MDL: JAVASCRIPTCORE_FOUND        = ${JAVASCRIPTCORE_FOUND}")
+# message(STATUS "MDL: JavaScriptCore_INCLUDE_DIRS = ${JavaScriptCore_INCLUDE_DIRS}")
+# message(STATUS "MDL: JavaScriptCore_LIBRARY_DIR  = ${JavaScriptCore_LIBRARY_DIR}")
+# message(STATUS "MDL: JavaScriptCore_LIBRARIES    = ${JavaScriptCore_LIBRARIES}")

--- a/templates/module/default/hooks/windows-module.js
+++ b/templates/module/default/hooks/windows-module.js
@@ -1,0 +1,99 @@
+/**
+ * Generates the Windows Native Module Visual Studio project files
+ *
+ * @copyright
+ * Copyright (c) 2015 by Appcelerator, Inc. All Rights Reserved.
+ *
+ * @license
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+const
+	fs = require('fs'),
+	path = require('path'),
+	wrench = require('wrench'),
+	async = require('async'),
+	spawn = require('child_process').spawn;
+
+exports.cliVersion = '>=3.2';
+
+exports.init = function (logger, config, cli) {
+	cli.on('create.post.module.platform.windows', {
+		post: function (data, callback) {
+			var cmakeDir = path.resolve(data.sdk.path, 'windows', 'cli', 'vendor', 'cmake'),
+				cmake = path.join(cmakeDir, 'bin', 'cmake.exe'),
+				projectDir = path.join(data.projectDir, 'windows'),
+				cmakeFinds = ['HAL', 'JavascriptCore', 'TitaniumKit'],
+				cmakeFindDirSrc = path.join(data.sdk.path, 'windows', 'templates', 'build', 'cmake'),
+				cmakeFindDirDst = path.join(projectDir, 'cmake');
+
+			async.series([
+				function(next) {
+					logger.info('Copying CMake package finders');
+					wrench.mkdirSyncRecursive(path.join(cmakeFindDirDst));
+					cmakeFinds.forEach(function(pkg) {
+						logger.info('-- '+pkg);
+						fs.writeFileSync(path.join(cmakeFindDirDst, 'Find'+pkg+'.cmake'), fs.readFileSync(path.join(cmakeFindDirSrc, 'Find'+pkg+'.cmake')));
+					});
+					next();
+				},
+				function(next) {
+					logger.info('Generating WindowsPhone ARM project');
+					runCMake(logger, cmake, projectDir, 'WindowsPhone', 'ARM', next);
+				},
+				function(next) {
+					logger.info('Generating WindowsStore ARM project');
+					runCMake(logger, cmake, projectDir, 'WindowsStore', 'ARM', next);
+				},
+				function(next) {
+					logger.info('Generating WindowsPhone Win32 project');
+					runCMake(logger, cmake, projectDir, 'WindowsPhone', 'Win32', next);
+				},
+				function(next) {
+					logger.info('Generating WindowsStore Win32 project');
+					runCMake(logger, cmake, projectDir, 'WindowsStore', 'Win32', next);
+				}
+			], function(err, result) {
+				if (err) {
+					logger.error(err);
+				}
+				callback();
+			});
+		}
+	});
+};
+
+function runCMake(logger, cmake, projectDir, targetEnv, targetArch, callback){
+	var targetDir = path.join(projectDir, targetEnv+'.'+targetArch),
+		generatorName = 'Visual Studio 12 2013'+(targetArch === 'ARM' ? ' ARM' : ''),
+		p;
+
+	if (!fs.existsSync(targetDir)) {
+		wrench.mkdirSyncRecursive(targetDir);
+	}
+
+	p = spawn(cmake,
+		[
+			'-G', generatorName,
+			'-DCMAKE_SYSTEM_NAME=' + targetEnv,
+			'-DCMAKE_SYSTEM_VERSION=' + '8.1',
+			path.join(projectDir)
+		],
+		{
+			cwd: targetDir
+		});
+
+	p.stdout.on('data', function (data) {
+		logger.info(data.toString().trim());
+	});
+	p.stderr.on('data', function (data) {
+		logger.warn(data.toString().trim());
+	});
+	p.on('close', function (code) {
+		if (code != 0) {
+			process.exit(1);
+		}
+		callback();
+	});
+}

--- a/templates/module/default/template/windows/CMakeLists.txt.ejs
+++ b/templates/module/default/template/windows/CMakeLists.txt.ejs
@@ -1,0 +1,120 @@
+# Titanium Windows Native Module - <%- moduleName %>
+#
+# Copyright (c) 2015 by Appcelerator, Inc. All Rights Reserved.
+# Licensed under the terms of the Apache Public License.
+# Please see the LICENSE included with this distribution for details.
+
+cmake_minimum_required(VERSION 3.0.0)
+
+if(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsPhone")
+  set(PLATFORM wp)
+  add_definitions("-DPHONE")
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsStore")
+  set(PLATFORM store)
+else()
+  message(FATAL_ERROR "This app supports Store / Phone only.")
+endif()
+
+project(<%- moduleName %>)
+
+set(<%- moduleName %>_VERSION 0.1.0)
+
+set(WINDOWS_SOURCE_DIR "<%- tisdkPath.replace(/\\/g,'/') %>/windows")
+
+SET(CMAKE_FIND_LIBRARY_PREFIXES "")
+SET(CMAKE_FIND_LIBRARY_SUFFIXES ".lib" ".dll")
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(CMAKE_INCLUDE_CURRENT_DIR_IN_INTERFACE ON)
+
+option(<%- moduleName %>_DISABLE_TESTS "Disable compiling the tests" OFF)
+
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+
+get_filename_component(APPCELERATOR_CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake ABSOLUTE)
+list(INSERT CMAKE_MODULE_PATH 0 ${APPCELERATOR_CMAKE_MODULE_PATH})
+
+set(Boost_USE_STATIC_LIBS ON )
+set(Boost_USE_MULTITHREADED ON )
+set(Boost_USE_STATIC_RUNTIME OFF)
+find_package(Boost 1.55.0 REQUIRED)
+
+find_package(HAL REQUIRED)
+find_package(TitaniumKit REQUIRED)
+find_package(JavaScriptCore REQUIRED)
+
+enable_testing()
+
+set(SOURCE_<%- moduleName %>
+  include/<%- moduleName %>.hpp
+  src/<%- moduleName %>.cpp
+  )
+
+source_group(<%- moduleName %> FILES ${SOURCE_<%- moduleName %>})
+
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
+
+add_library(<%- moduleName %> SHARED
+  ${SOURCE_<%- moduleName %>}
+  )
+
+include(GenerateExportHeader)
+generate_export_header(<%- moduleName %>)
+target_compile_definitions(<%- moduleName %> PRIVATE <%- moduleName %>_EXPORTS)
+
+target_include_directories(<%- moduleName %> PUBLIC
+  ${PROJECT_SOURCE_DIR}/include
+  $<TARGET_PROPERTY:HAL,INTERFACE_INCLUDE_DIRECTORIES>
+  $<TARGET_PROPERTY:TitaniumKit,INTERFACE_INCLUDE_DIRECTORIES>
+  ${JavaScriptCore_INCLUDE_DIRS}
+  ${Boost_INCLUDE_DIRS}
+  )
+
+target_link_libraries(<%- moduleName %>
+  ${Boost_LIBRARIES}
+  HAL
+  TitaniumKit
+  )
+
+set_target_properties(<%- moduleName %> PROPERTIES VS_WINRT_COMPONENT TRUE)
+
+set_property(TARGET <%- moduleName %> APPEND_STRING PROPERTY LINK_FLAGS_DEBUG "/OPT:NOREF /OPT:NOICF")
+
+if (NOT <%- moduleName %>_DISABLE_TESTS)
+  add_subdirectory(test)
+endif()
+
+set_property(TARGET <%- moduleName %> PROPERTY VERSION ${<%- moduleName %>_VERSION})
+set_property(TARGET <%- moduleName %> PROPERTY SOVERSION 0)
+set_property(TARGET <%- moduleName %> PROPERTY INTERFACE_<%- moduleName %>_MAJOR_VERSION 0)
+set_property(TARGET <%- moduleName %> APPEND PROPERTY
+  COMPATIBLE_INTERFACE_STRING <%- moduleName %>_MAJOR_VERSION
+  )
+
+install(TARGETS <%- moduleName %> EXPORT <%- moduleName %>_Targets
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
+  )
+
+export(EXPORT <%- moduleName %>_Targets
+  FILE "${CMAKE_BINARY_DIR}/<%- moduleName %>_Targets.cmake"
+)
+
+configure_file(cmake/<%- moduleName %>_Config.cmake
+  "${CMAKE_BINARY_DIR}/<%- moduleName %>_Config.cmake"
+  COPYONLY
+  )
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+  "${CMAKE_BINARY_DIR}/<%- moduleName %>_ConfigVersion.cmake"
+  VERSION ${<%- moduleName %>_VERSION}
+  COMPATIBILITY AnyNewerVersion
+  )
+
+set_target_properties(<%- moduleName %> PROPERTIES VS_WINRT_REFERENCES HAL)
+
+export(PACKAGE <%- moduleName %>)

--- a/templates/module/default/template/windows/build_and_test.sh.ejs
+++ b/templates/module/default/template/windows/build_and_test.sh.ejs
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+# Titanium Windows Native Module - <%- moduleName %>
+#
+# Copyright (c) 2015 by Appcelerator, Inc. All Rights Reserved.
+# Licensed under the terms of the Apache Public License.
+# Please see the LICENSE included with this distribution for details.
+
+if ! test -d "${GTEST_ROOT}"; then
+    echo "GTEST_ROOT must point to your Google Test installation."
+    exit 1
+fi
+
+declare -rx VERBOSE=1
+
+declare -r TitaniumWindows_<%- moduleName %>_DISABLE_TESTS="OFF"
+
+#declare -r target_platform="WindowsStore"
+declare -r target_platform="WindowsPhone"
+declare -r target_architecture="Win32"
+declare -r target_version="8.1"
+declare -r cmake_generator_name="Visual Studio 12 2013"
+
+declare -r project_name=$(grep -E '^\s*project[(][^)]+[)]\s*$' CMakeLists.txt | awk 'BEGIN {FS="[()]"} {printf "%s", $2}')
+declare -r solution_file_name="${project_name}.sln"
+declare -r MSBUILD_PATH="c:/Program Files (x86)/MSBuild/12.0/Bin/MSBuild.exe"
+declare -r BUILD_DIR="build"
+
+function echo_and_eval {
+    local -r cmd="${1:?}"
+    echo "${cmd}" && eval "${cmd}"
+}
+
+cmd+="cmake"
+cmd+=" -G \"${cmake_generator_name}\""
+cmd+=" -DCMAKE_SYSTEM_NAME=${target_platform}"
+cmd+=" -DCMAKE_SYSTEM_VERSION=${target_version}"
+cmd+=" -DTitaniumWindows_<%- moduleName %>_DISABLE_TESTS=${TitaniumWindows_<%- moduleName %>_DISABLE_TESTS}"
+cmd+=" -DJavaScriptCoreCPP_DISABLE_TESTS=ON"
+cmd+=" -DTitaniumKit_DISABLE_TESTS=ON"
+cmd+=" ../"
+
+echo_and_eval "rm -rf \"${BUILD_DIR}\""
+echo_and_eval "mkdir -p \"${BUILD_DIR}\""
+echo_and_eval "pushd \"${BUILD_DIR}\""
+echo_and_eval "${cmd}"
+echo_and_eval "\"${MSBUILD_PATH}\" ${solution_file_name}"
+
+if [ "${TitaniumWindows_<%- moduleName %>_DISABLE_TESTS}" != "ON" ]; then
+    echo_and_eval "ctest -VV --output-on-failure"
+fi
+
+echo_and_eval "popd"

--- a/templates/module/default/template/windows/cmake/{{ModuleName}}_Config.cmake
+++ b/templates/module/default/template/windows/cmake/{{ModuleName}}_Config.cmake
@@ -1,0 +1,11 @@
+# Titanium Windows Native Module - <%- name %>
+#
+# Copyright (c) 2015 by Appcelerator, Inc. All Rights Reserved.
+# Licensed under the terms of the Apache Public License.
+# Please see the LICENSE included with this distribution for details.
+
+include(CMakeFindDependencyMacro)
+find_dependency(HAL)
+find_dependency(TitaniumKit)
+
+include("${CMAKE_BINARY_DIR}/TitaniumWindows_<%- name %>_Targets.cmake")

--- a/templates/module/default/template/windows/include/{{ModuleName}}.hpp.ejs
+++ b/templates/module/default/template/windows/include/{{ModuleName}}.hpp.ejs
@@ -1,0 +1,44 @@
+/**
+ * Titanium Windows Native Module - <%- moduleName %>
+ *
+ * Copyright (c) 2015 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License.
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#ifndef _<%- moduleName.toUpperCase() %>_HPP_
+#define _<%- moduleName.toUpperCase() %>_HPP_
+
+#include "<%- moduleName %>_EXPORT.h"
+
+#include "Titanium/detail/TiBase.hpp"
+
+<%  var namespaces = moduleId.split('.'),
+	indent = Array(namespaces.length).join('\t');
+    for(var i = 0; i < namespaces.length; i++) { -%>
+<%- 	Array(i+1).join('\t') %>namespace <%- namespaces[i] %>
+<%- 	Array(i+1).join('\t') %>{
+<%  } -%>
+<%- indent %>	using namespace HAL;
+
+<%- indent %>	class <%- moduleName.toUpperCase() %>_EXPORT <%- moduleName %> : public JSExport<<%- moduleName %>>
+<%- indent %>	{
+<%- indent %>		public:
+<%- indent %>			<%- moduleName %>(const JSContext&, const std::vector<JSValue>& arguments = {}) TITANIUM_NOEXCEPT;
+<%- indent %>			virtual void postInitialize(JSObject& js_object);
+<%- indent %>			virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments);
+
+<%- indent %>			virtual ~<%- moduleName %>()<%= Array(moduleName.length).join(' ') %>           = default;
+<%- indent %>			<%- moduleName %>(const <%- moduleName %>&)            = default;
+<%- indent %>			<%- moduleName %>& operator=(const <%- moduleName %>&) = default;
+#ifdef TITANIUM_MOVE_CTOR_AND_ASSIGN_DEFAULT_ENABLE
+<%- indent %>			<%- moduleName %>(<%- moduleName %>&&)                 = default;
+<%- indent %>			<%- moduleName %>& operator=(<%- moduleName %>&&)      = default;
+#endif
+
+<%- indent %>			static void JSExportInitialize();
+<%- indent %>	};
+<%  for(var i = namespaces.length; i > 0; i--) { -%>
+<%- 	Array(i).join('\t') %>}
+<%  } -%>
+#endif // _<%- moduleName.toUpperCase() %>_HPP_

--- a/templates/module/default/template/windows/manifest.ejs
+++ b/templates/module/default/template/windows/manifest.ejs
@@ -1,0 +1,18 @@
+#
+# this is your module manifest and used by Titanium
+# during compilation, packaging, distribution, etc.
+#
+version: 1.0.0
+apiversion: 2
+architectures: ARM Win32
+description: <%- moduleName %>
+author: <%- author %>
+license: Specify your license
+copyright: Copyright (c) <%- (new Date).getFullYear() %> by <%- publisher %>
+
+# these should not be edited
+name: <%- moduleName %>
+moduleid: <%- moduleId %>
+guid: <%- guid %>
+platform: <%- platform %>
+minsdk: <%- tisdkVersion %>

--- a/templates/module/default/template/windows/src/{{ModuleName}}.cpp.ejs
+++ b/templates/module/default/template/windows/src/{{ModuleName}}.cpp.ejs
@@ -1,0 +1,36 @@
+/**
+ * Titanium Windows Native Module - <%- moduleName %>
+ *
+ * Copyright (c) 2015 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License.
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#include "<%- moduleName %>.hpp"
+
+<%  var namespaces = moduleId.split('.'),
+	indent = Array(namespaces.length).join('\t');
+    for(var i = 0; i < namespaces.length; i++) { -%>
+<%- 	Array(i+1).join('\t') %>namespace <%- namespaces[i] %>
+<%- 	Array(i+1).join('\t') %>{
+<%  } -%>
+<%- indent %>	<%- moduleName %>::<%- moduleName %>(const JSContext& js_context, const std::vector<JSValue>& arguments) TITANIUM_NOEXCEPT
+<%- indent %>	{
+<%- indent %>		TITANIUM_LOG_DEBUG("<%- moduleName %>::ctor Initialize");
+<%- indent %>	}
+
+<%- indent %>	void <%- moduleName %>::postInitialize(JSObject& js_object)
+<%- indent %>	{
+<%- indent %>	}
+
+<%- indent %>	void <%- moduleName %>::postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments)
+<%- indent %>	{
+<%- indent %>	}
+
+<%- indent %>	void <%- moduleName %>::JSExportInitialize()
+<%- indent %>	{
+<%- indent %>		JSExport<<%- moduleName %>>::SetClassVersion(1);
+<%- indent %>	}
+<%  for(var i = namespaces.length; i > 0; i--) { -%>
+<%- 	Array(i).join('\t') %>}
+<%  } -%>

--- a/templates/module/default/template/windows/test/CMakeLists.txt.ejs
+++ b/templates/module/default/template/windows/test/CMakeLists.txt.ejs
@@ -1,0 +1,7 @@
+# Titanium Windows Native Module - <%- moduleName %>
+#
+# Copyright (c) 2015 by Appcelerator, Inc. All Rights Reserved.
+# Licensed under the terms of the Apache Public License.
+# Please see the LICENSE included with this distribution for details.
+
+#cxx_test(<%- moduleName %>Tests . <%- moduleName %>)

--- a/templates/module/default/template/windows/timodule.xml
+++ b/templates/module/default/template/windows/timodule.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ti:module xmlns:ti="http://ti.appcelerator.org" xmlns:android="http://schemas.android.com/apk/res/android">
+	<!--
+		Similar to tiapp.xml, but contains module/platform specific
+		configuration in <iphone>, <android>, and <mobileweb> sections
+	-->
+	<iphone>
+	</iphone>
+	<android xmlns:android="http://schemas.android.com/apk/res/android">
+	</android>
+	<mobileweb>
+	</mobileweb>
+</ti:module>


### PR DESCRIPTION
##### READY FOR REVIEW
- Created project structure for native modules
- Created templates for module project generation
- Implemented a CLI hook to generate the Visual Studio projects using CMake
- Updated build script to copy over necessary header files (HAL and TitaniumKit) into the SDK ```windows/lib/*/include``` directory for successful module compilation
- Added ```WindowsStore``` ```ARM``` to build script

##### DEPENDS ON
[TIMOB-18978](https://jira.appcelerator.org/browse/TIMOB-18978) - https://github.com/appcelerator/titanium_mobile/pull/6892

##### NOTES
- I have updated the ```build.js``` script to use ```fs-extra``` as I was having problems with ```wrench```
- @infosia Do you still need ```classname``` or can you use ```moduleid```?

##### JIRA TICKETS
**EPIC** [TIMOB-17911](https://jira.appcelerator.org/browse/TIMOB-18937)
- [TIMOB-18937](https://jira.appcelerator.org/browse/TIMOB-18937)
- [TIMOB-18938](https://jira.appcelerator.org/browse/TIMOB-18938)
- [TIMOB-18939](https://jira.appcelerator.org/browse/TIMOB-18939)
- [TIMOB-18942](https://jira.appcelerator.org/browse/TIMOB-18942)