### PR TITLE
TIMOB-18882 Crawl user's app for native requires

### DIFF
--- a/cli/lib/stub.js
+++ b/cli/lib/stub.js
@@ -227,19 +227,20 @@ function getEnumDependencies(type_name, metadata) {
  */
 function initialize(seeds, next) {
 	// If we have no seeds, assume we want everything!
-	if (seeds.length == 0) {
-		for (classname in all_classes) {
-			var classDefinition = all_classes[classname];
+	// FIXME What should be used as "every" and what should be used as "none"?
+	//if (seeds.length == 0) {
+	//	for (classname in all_classes) {
+	//		var classDefinition = all_classes[classname];
 			// skip structs and enums
-			if (classDefinition['extends'] && 
-				(classDefinition['extends'].indexOf("[mscorlib]System.Enum") == 0 ||
-				classDefinition['extends'].indexOf("[mscorlib]System.ValueType") == 0)) {
-				continue;
-			}
+	//		if (classDefinition['extends'] && 
+	//			(classDefinition['extends'].indexOf("[mscorlib]System.Enum") == 0 ||
+	//			classDefinition['extends'].indexOf("[mscorlib]System.ValueType") == 0)) {
+	//			continue;
+	//		}
 
-			seeds.unshift(classname);
-		}
-	}
+	//		seeds.unshift(classname);
+	//	}
+	//}
 
 	// Sort seeds by name and remove duplicates
 	seeds = seeds.sort();


### PR DESCRIPTION
- parse JS files with UglifyJS, look for require calls with a single
  string argument. If string begins with "Windows." treat as native type,
  and add it to list of wrappers to generate.

This is an extremely naive check. Basically, if users want to use native APIs, they need to use static strings in typical require calls. Dynamically building the string won't be picked up. I think if they want to do that we should have some overriding option for them to declare they want _all_ APIs generated, or some way to generate a whitelist of types they need. Assuming we should generate everything when we run into dynamic requires would be horrendous for build time/app size.