### PR TITLE
[TIMOB-18987] App build fails if GTEST is not present on system

### DIFF
--- a/templates/build/cmake/internal_utils.cmake
+++ b/templates/build/cmake/internal_utils.cmake
@@ -103,7 +103,7 @@ function(cxx_executable name dir libs)
     ${name} "${cxx_default}" "${libs}" "${dir}/${name}.cpp" ${ARGN})
 endfunction()
 
-find_package(GTest REQUIRED)
+find_package(GTest)
 
 # cxx_test_with_flags(name cxx_flags libs srcs...)
 #


### PR DESCRIPTION
- Remove ```GTest``` package requirement

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-18987)