### PR TITLE
[TIMOB-18981] Resources are not copied from temp folder to build folder

### DIFF
--- a/cli/commands/_build.js
+++ b/cli/commands/_build.js
@@ -1820,7 +1820,9 @@ WindowsBuilder.prototype.copyResultsToProject = function copyResultsToProject(ne
 		// make sure destination exists
 		fs.existsSync(this.originalBuildDir) || wrench.mkdirSyncRecursive(this.originalBuildDir);
 		// Now copy this.buildDir into this.originalBuildDir
-		wrench.copyDirSyncRecursive(this.buildDir, this.originalBuildDir);
+		wrench.copyDirSyncRecursive(this.buildDir, this.originalBuildDir, {
+			forceDelete: true
+		});
 	}
 	next();
 };


### PR DESCRIPTION
- Force delete any existing folder before copying

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-18981)