### PR TITLE
[TIMOB-18974] Fix: Building a project with the --build-only flag errors out

### DIFF
--- a/cli/commands/_build.js
+++ b/cli/commands/_build.js
@@ -769,15 +769,15 @@ WindowsBuilder.prototype.loginfo = function loginfo(next) {
 	switch (this.target) {
 		// windows phone targets
 		case 'wp-emulator':
-			this.logger.info(this.buildOnly
-				? __('Building for Windows Phone emulator')
-				: __('Building for Windows Phone emulator: %s', this.deviceId.cyan)
+			this.logger.info(this.deviceId
+				? __('Building for Windows Phone emulator: %s', this.deviceId.cyan)
+				: __('Building for Windows Phone emulator')
 			);
 			break;
 		case 'wp-device':
-			this.logger.info(this.buildOnly
+			this.logger.info(this.deviceId
 				? __('Building for Windows Phone device: %s', this.deviceId.cyan)
-				: __('Building for Windows Phone device: %s', this.deviceId.cyan)
+				: __('Building for Windows Phone device')
 			);
 			break;
 		case 'dist-phonestore':


### PR DESCRIPTION
Fix for [TIMOB-18974](https://jira.appcelerator.org/browse/TIMOB-18974).

Steps To Reproduce

1. Create a new application using ti create
2. Run the application using ti build -p windows -T wp-device --build-only