### PR TITLE
[TIMOB-18980] Fix:  Closing an alert crashes the app

### DIFF
--- a/Source/UI/src/AlertDialog.cpp
+++ b/Source/UI/src/AlertDialog.cpp
@@ -51,7 +51,10 @@ namespace TitaniumWindows
 			}
 
 			concurrency::create_task(dialog->ShowAsync()).then([this](IUICommand^ command) {
-				const auto index = dynamic_cast<IPropertyValue^>(command->Id)->GetInt32();
+				std::int32_t index = 0;
+				if (command != nullptr) {
+					index = dynamic_cast<IPropertyValue^>(command->Id)->GetInt32();
+				}
 				const JSContext ctx = get_context();
 				JSObject eventArgs = ctx.CreateObject();
 				eventArgs.SetProperty("index", ctx.CreateNumber(index));


### PR DESCRIPTION
Fix for [TIMOB-18980](https://jira.appcelerator.org/browse/TIMOB-18980).

```javascript
var win = Ti.UI.createWindow({ backgroundColor: 'blue' });

var button = Titanium.UI.createButton({
    top: 60,
    title: 'Hello',
    width: '180',
    height: '80'
});

button.addEventListener('click', function () {
    var dialog = Ti.UI.createAlertDialog({
        title: 'Push OK',
        buttonNames: ['OK']
    });
    dialog.addEventListener('click', function (e) {
        alert('HELLO!');
    });
    dialog.show();
});

win.add(button);
win.open();
```