### PR TITLE
[TIMOB-18989] Unable to build a project if the project name contains a space

### DIFF
--- a/cli/commands/_build.js
+++ b/cli/commands/_build.js
@@ -1645,7 +1645,7 @@ WindowsBuilder.prototype.generateCmakeList = function generateCmakeList(next) {
 			path.resolve(this.platformPath, 'templates', 'build', 'CMakeLists.txt.ejs')
 		).toString(),
 		{
-			projectName: getCMakeProjectName(this.cli.tiapp.name),
+			projectName: sanitizeProjectName(this.cli.tiapp.name),
 			windowsSrcDir: path.resolve(__dirname, '..', '..').replace(/\\/g, '/').replace(' ', '\\ '), // cmake likes unix separators
 			version: this.tiapp.version,
 			assets: assetList.join('\n'),
@@ -1700,7 +1700,7 @@ WindowsBuilder.prototype.runCmake = function runCmake(next) {
 	});
 };
 
-function getCMakeProjectName(str) {
+function sanitizeProjectName(str) {
 	return str.replace(/[^a-zA-Z0-9_]/g, '_').replace(/_+/g, '_').split(/[\W_]/).map(function (s) { return appc.string.capitalize(s); }).join('');
 }
 
@@ -1711,7 +1711,7 @@ function getCMakeProjectName(str) {
  */
 WindowsBuilder.prototype.compileApp = function compileApp(next) {
 	var _t = this;
-		cmakeProjectName = getCMakeProjectName(this.cli.tiapp.name),
+		cmakeProjectName = sanitizeProjectName(this.cli.tiapp.name),
 		slnFile = path.resolve(this.cmakeTargetDir, cmakeProjectName + '.sln'),
 		vcxproj = path.resolve(this.cmakeTargetDir, cmakeProjectName + '.vcxproj'),
 		nativeVcxProj = path.resolve(this.cmakeTargetDir, 'Native', 'TitaniumWindows_Native.vcxproj'),

--- a/cli/commands/_build.js
+++ b/cli/commands/_build.js
@@ -1645,7 +1645,7 @@ WindowsBuilder.prototype.generateCmakeList = function generateCmakeList(next) {
 			path.resolve(this.platformPath, 'templates', 'build', 'CMakeLists.txt.ejs')
 		).toString(),
 		{
-			projectName: this.cli.tiapp.name,
+			projectName: getCMakeProjectName(this.cli.tiapp.name),
 			windowsSrcDir: path.resolve(__dirname, '..', '..').replace(/\\/g, '/').replace(' ', '\\ '), // cmake likes unix separators
 			version: this.tiapp.version,
 			assets: assetList.join('\n'),
@@ -1700,6 +1700,10 @@ WindowsBuilder.prototype.runCmake = function runCmake(next) {
 	});
 };
 
+function getCMakeProjectName(str) {
+	return str.replace(/[^a-zA-Z0-9_]/g, '_').replace(/_+/g, '_').split(/[\W_]/).map(function (s) { return appc.string.capitalize(s); }).join('');
+}
+
 /**
  * Compiles the generated Visual Studio project.
  *
@@ -1707,8 +1711,9 @@ WindowsBuilder.prototype.runCmake = function runCmake(next) {
  */
 WindowsBuilder.prototype.compileApp = function compileApp(next) {
 	var _t = this;
-		slnFile = path.resolve(this.cmakeTargetDir, this.cli.tiapp.name + '.sln'),
-		vcxproj = path.resolve(this.cmakeTargetDir, this.cli.tiapp.name + '.vcxproj'),
+		cmakeProjectName = getCMakeProjectName(this.cli.tiapp.name),
+		slnFile = path.resolve(this.cmakeTargetDir, cmakeProjectName + '.sln'),
+		vcxproj = path.resolve(this.cmakeTargetDir, cmakeProjectName + '.vcxproj'),
 		nativeVcxProj = path.resolve(this.cmakeTargetDir, 'Native', 'TitaniumWindows_Native.vcxproj'),
 	this.logger.info(__('Running MSBuild on solution: %s', slnFile.cyan));
 

--- a/cli/hooks/wp-run.js
+++ b/cli/hooks/wp-run.js
@@ -23,6 +23,10 @@ const
 
 exports.cliVersion = '>=3.2.1';
 
+function sanitizeProjectName(str) {
+	return str.replace(/[^a-zA-Z0-9_]/g, '_').replace(/_+/g, '_').split(/[\W_]/).map(function (s) { return appc.string.capitalize(s); }).join('');
+}
+
 exports.init = function (logger, config, cli) {
 	var emuHandle,
 		emuInstall,
@@ -190,9 +194,9 @@ exports.init = function (logger, config, cli) {
 
 				var tiapp = builder.tiapp,
 					// name of the directory holding appx and dependencies subfolder
-					dirName = tiapp.name + '_1.1.0.0' + ((builder.buildConfiguration == 'Debug') ? '_Debug_Test' : '_Test');
+					dirName = sanitizeProjectName(tiapp.name) + '_1.1.0.0' + ((builder.buildConfiguration == 'Debug') ? '_Debug_Test' : '_Test');
 					// path to folder holding appx
-					appxDir = path.resolve(builder.cmakeTargetDir, 'AppPackages', tiapp.name, dirName),
+					appxDir = path.resolve(builder.cmakeTargetDir, 'AppPackages', sanitizeProjectName(tiapp.name), dirName),
 					// path to folder holding depencies of the app
 					dependenciesDir = path.resolve(appxDir, 'Dependencies', (builder.cmakeArch == 'Win32') ? 'x86' : builder.cmakeArch),
 					// Options for installing app


### PR DESCRIPTION
Fix for [TIMOB-18989](https://jira.appcelerator.org/browse/TIMOB-18989).

Steps To Reproduce

1. Create a project using ti create with a space in the name (i.e. "space app")
2. Build the project for Windows using `ti build p windows -T wp-device`