### PR TITLE
[TIMOB-18883] Windows: Allow registering event handlers with callback functions

### DIFF
--- a/cli/commands/_build.js
+++ b/cli/commands/_build.js
@@ -1636,8 +1636,17 @@ WindowsBuilder.prototype.generateCmakeList = function generateCmakeList(next) {
 	}
 
 	this.cli.createHook('build.windows.writeCMakeLists', this, function (manifest, cb) {
-		fs.existsSync(this.buildDir) || wrench.mkdirSyncRecursive(this.buildDir);
-		fs.existsSync(this.cmakeListFile) && fs.unlinkSync(this.cmakeListFile);
+		fs.existsSync(this.buildDir) || wrench.mkdirSyncRecursive(this.buildDir)
+
+		if (fs.existsSync(this.cmakeListFile)) {
+			if (manifest == fs.readFileSync(this.cmakeListFile).toString())
+			{
+				this.logger.info("CmakeLists.txt contents unchanged, retaining existing file.");
+				cb();
+				return;
+			}
+			fs.unlinkSync(this.cmakeListFile);
+		}
 		fs.writeFile(this.cmakeListFile, manifest, cb);
 	})(ejs.render(
 		fs.readFileSync(

--- a/cli/lib/stub.js
+++ b/cli/lib/stub.js
@@ -606,6 +606,12 @@ function generateCasting(dest, seeds, next) {
 		// Insert cast block
 		data = data.substring(0, data.indexOf('auto to_cast =')) + cast_block + data.substring(data.indexOf('return result;') + 14);
 		// Replace #include "Platform.Object.hpp" with same includes as native module loader!
+
+		// FIXME We need to hack Platform.Object even more! We need to add a callback_map__ as a JSObject protected field
+		// We stick the callback functions from JS into the map by their id returned by hanging the listener?
+		// See GlobalObject.cpp/hpp in TitaniumKit for how.
+		// We could remove usage of add_* methods and force use of add/removeEventListener method from Titanium::Module. We'd have to change how we generate
+		// the wrappers for event handling
 		
 		fs.writeFile(platform_object_cpp, data, function(err) {
 			next(err);

--- a/cli/lib/templates/Proxy.cpp
+++ b/cli/lib/templates/Proxy.cpp
@@ -22,9 +22,8 @@ if (methods) {
 	for (var i = 0; i < methods.length; i++) {
 		var method = methods[i];
 		var overloads = [];
-
-		if (method.name.indexOf('get_') == 0 || method.name.indexOf('put_') == 0 ||
-			method.name.indexOf('add_') == 0 || method.name.indexOf('remove_') == 0) {
+		// skip property methods
+		if (method.name.indexOf('get_') == 0 || method.name.indexOf('put_') == 0) {
 				continue;
 		}
 		// Skip non-public methods
@@ -214,9 +213,19 @@ if (methods) {
 		if (method.name == '.ctor') {
 				continue;
 		}
+		if (method.name.indexOf('add_') == 0) {
+-%>
+<%- include('add_event_handler.cpp', {full_name: full_name, base_name: base_name, methods: methods}) %>
+<%
+		} else if (method.name.indexOf('remove_') == 0) {
+-%>
+<%- include('remove_event_handler.cpp', {full_name: full_name, base_name: base_name, methods: methods}) %>
+<%
+		} else {
 -%>
 <%- include('function.cpp', {full_name: full_name, base_name: base_name, methods: methods}) %>
 <%
+		}
 	}
 }
 

--- a/cli/lib/templates/Proxy.cpp
+++ b/cli/lib/templates/Proxy.cpp
@@ -185,7 +185,7 @@ for (property_name in properties) {
 // Methods
 if (methods) {
 	for (method_name in unique_methods) {
-		if (method_name == ".ctor") {
+		if (method_name == ".ctor" || method.name.indexOf('add_') == 0 || method.name.indexOf('remove_') == 0) {
 				continue;
 		}
 -%>
@@ -210,25 +210,57 @@ if (methods) {
 	for (method_name in unique_methods) {
 		var methods = unique_methods[method_name];
 		var method = methods[0];
-		if (method.name == '.ctor') {
-				continue;
+		if (method.name == '.ctor' || method.name.indexOf('add_') == 0 || method.name.indexOf('remove_') == 0) {
+			continue;
 		}
+-%>
+<%- include('function.cpp', {full_name: full_name, base_name: base_name, methods: methods}) %>
+<%
+	}
+}
+-%>
+		void <%= base_name %>::enableEvent(const std::string& event_name) TITANIUM_NOEXCEPT
+		{
+			<%- parent_name.to_windows_name() %>::enableEvent(event_name);
+
+			const JSContext context = this->get_context();
+<%
+// Event handlers!
+if (methods) {
+	for (method_name in unique_methods) {
+		var methods = unique_methods[method_name];
+		var method = methods[0];
 		if (method.name.indexOf('add_') == 0) {
 -%>
 <%- include('add_event_handler.cpp', {full_name: full_name, base_name: base_name, methods: methods}) %>
 <%
-		} else if (method.name.indexOf('remove_') == 0) {
+		}
+	}
+}
+-%>
+		}
+
+		void <%= base_name %>::disableEvent(const std::string& event_name) TITANIUM_NOEXCEPT
+		{
+			<%- parent_name.to_windows_name() %>::disableEvent(event_name);
+
+			const JSContext context = this->get_context();
+<%
+// Event handlers!
+if (methods) {
+	for (method_name in unique_methods) {
+		var methods = unique_methods[method_name];
+		var method = methods[0];
+		if (method.name.indexOf('remove_') == 0) {
 -%>
 <%- include('remove_event_handler.cpp', {full_name: full_name, base_name: base_name, methods: methods}) %>
-<%
-		} else {
--%>
-<%- include('function.cpp', {full_name: full_name, base_name: base_name, methods: methods}) %>
 <%
 		}
 	}
 }
-
+-%>
+		}
+<%
 for (var i = namespaces.length - 2; i>= 0; i--) {
 -%>
 <%= Array(i + 1).join('\t') %>} // namespace <%= namespaces[i] %>

--- a/cli/lib/templates/Proxy.cpp
+++ b/cli/lib/templates/Proxy.cpp
@@ -185,7 +185,7 @@ for (property_name in properties) {
 // Methods
 if (methods) {
 	for (method_name in unique_methods) {
-		if (method_name == ".ctor" || method.name.indexOf('add_') == 0 || method.name.indexOf('remove_') == 0) {
+		if (method_name == ".ctor" || method_name.indexOf('add_') == 0 || method_name.indexOf('remove_') == 0) {
 				continue;
 		}
 -%>

--- a/cli/lib/templates/Proxy.hpp
+++ b/cli/lib/templates/Proxy.hpp
@@ -105,6 +105,8 @@ if (methods) {
 			static void JSExportInitialize();
 
 			virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;
+			virtual void enableEvent(const std::string& event_name) TITANIUM_NOEXCEPT override;
+			virtual void disableEvent(const std::string& event_name) TITANIUM_NOEXCEPT override;
 
 			::<%= windows_name %>^ unwrap<%= underscore_name %>() const;
 			void wrap(::<%= windows_name %>^ object);
@@ -118,6 +120,7 @@ if (parent_name == 'Module') { -%>
 
 		private:
 			::<%= windows_name %>^ unwrap() const;
+			// Add fields to hold the event registration tokens for handlers!
 
 		};
 

--- a/cli/lib/templates/Proxy.hpp
+++ b/cli/lib/templates/Proxy.hpp
@@ -73,6 +73,7 @@ if (methods) {
 		var method = methods[i];
 		// Skip if method starts with get_, put_ (properties), constructor
 		if (method.name.indexOf('get_') == 0 || method.name.indexOf('put_') == 0 ||
+			method.name.indexOf('add_') == 0 || method.name.indexOf('remove_') == 0 ||
 			method.name == '.ctor') {
 				continue;
 		}
@@ -120,8 +121,19 @@ if (parent_name == 'Module') { -%>
 
 		private:
 			::<%= windows_name %>^ unwrap() const;
-			// Add fields to hold the event registration tokens for handlers!
-
+<%
+if (methods) {
+	for (var i = 0; i < methods.length; i++) {
+		var method = methods[i];
+		// Add registration tokens for event handlers
+		if (method.name.indexOf('add_') == 0) {
+-%>
+			::Windows::Foundation::EventRegistrationToken <%= method.name.substring(4) %>_token__;
+<%
+		}
+	}
+}
+-%>
 		};
 
 <% for (var i = namespaces.length - 2; i>= 0; i--) { -%>

--- a/cli/lib/templates/Proxy.hpp
+++ b/cli/lib/templates/Proxy.hpp
@@ -71,9 +71,9 @@ for (property_name in properties) {
 if (methods) {
 	for (var i = 0; i < methods.length; i++) {
 		var method = methods[i];
-		// Skip if method starts with get_, put_ (properties), add_ or remove_ (events)
+		// Skip if method starts with get_, put_ (properties), constructor
 		if (method.name.indexOf('get_') == 0 || method.name.indexOf('put_') == 0 ||
-			method.name.indexOf('add_') == 0 || method.name.indexOf('remove_') == 0 || method.name == '.ctor') {
+			method.name == '.ctor') {
 				continue;
 		}
 		// Skip non-public methods

--- a/cli/lib/templates/add_event_handler.cpp
+++ b/cli/lib/templates/add_event_handler.cpp
@@ -1,0 +1,90 @@
+		TITANIUM_FUNCTION(<%= base_name %>, <%= methods[0].name %>)
+		{
+			auto context = this_object.get_context();
+			// TODO Handle no args, just return undefined?
+			ENSURE_OBJECT_AT_INDEX(callback, 0);
+<%
+// TODO We need to assert that there is one argument, that it's an object and a function. It's our callback
+// TODO We then need to hook an event handler like so:
+
+var event_name = methods[0].name.substring(4), // drop "add_"
+	handler_type_name = methods[0].args[0].type,
+	handler_type,
+	invoke_method,
+	parameters = ""; // Build up the list of paremeters that the handler needs!
+if (handler_type_name.indexOf('class ') == 0) {
+	handler_type_name = handler_type_name.substring(6); // strip off leading 'class '
+}
+// handle special common handler types:
+if (handler_type_name.indexOf("Windows.Foundation.EventHandler`1") == 0) {
+	var inner = handler_type_name.substring(34, handler_type_name.length - 1); // grab inner type
+	if (inner == 'object') {
+		inner = 'Platform.Object';
+	}
+	if (inner.indexOf("class ") == 0) {
+		inner = inner.substring(6); // drop off "class "
+	}
+	handler_type_name = "Windows.Foundation.EventHandler<::";
+	handler_type_name += inner;
+	handler_type_name += "^>";
+
+	parameters = "::Platform::Object^ sender, ::" + inner.replace(/\./g, '::') + "^ args";
+} else if (handler_type_name.indexOf("Windows.Foundation.TypedEventHandler`2") == 0) {
+	var inner = handler_type_name.substring(handler_type_name.indexOf('`2<') + 3, handler_type_name.length - 1),
+		sender = inner.substring(0, inner.indexOf(',')),
+		result = inner.substring(inner.indexOf(',') + 1);
+	if (sender.indexOf("class ") == 0) {
+		sender = sender.substring(6); // drop off "class "
+	}
+	if (result.indexOf("class ") == 0) {
+		result = result.substring(6); // drop off "class "
+	}
+	handler_type_name = "Windows.Foundation.TypedEventHandler<::";
+	handler_type_name += sender;
+	handler_type_name += "^, ::";
+	handler_type_name += result;
+	handler_type_name += "^>";
+
+	parameters = "::" + sender.replace(/\./g, '::') + "^ sender, ::" + result.replace(/\./g, '::') + "^ result";
+} else {
+	// Dedicated event handler delegate type
+	handler_type = metadata[handler_type_name]; // grab handler type from metadata
+
+	// Find the Invoke method in handler_type.methods!
+	// FIXME Use nicer JS to find it!
+	for (var i = 0; i < handler_type.methods.length; i++) {
+		var method = handler_type.methods[i];
+		if (method.name == "Invoke") {
+			invoke_method = method;
+			break;
+		}
+	}
+
+	// loop through the arguments and turn them into parameters
+	for (var x = 0; x < invoke_method.args.length; x++) {
+		var arg = invoke_method.args[x],
+			arg_type = arg.type;
+		// Normalize type name FIXME We have code like this all over the place!
+		if (arg_type == 'object') {
+			arg_type = "Platform.Object";
+		}
+		if (arg_type.indexOf("class ") == 0) {
+			arg_type = arg_type.substring(6); // drop off "class "
+		}
+		// FIXME What if arg_type starts with 'valuetype '?
+		parameters += "::" + arg_type.replace(/\./g, '::') + "^ " + arg.name + ", ";
+	}
+	if (parameters.length > 0) {
+		parameters = parameters.substring(0, parameters.length - 2); // Drop trailing ", "
+	}
+
+}
+-%>
+			auto method_result = unwrap()-><%= event_name %> += ref new ::<%- handler_type_name.replace(/\./g, '::') %>([context, &callback](<%- parameters %>) {
+				// TODO Convert the args and pass them to callback!
+				// Takes a const std::vector<JSValue>&  arguments
+				callback(context.get_global_object());
+			});
+			<%- include('native_to_js.cpp', {type: methods[0].returnType, metadata: metadata, to_assign: 'result', argument_name: 'method_result'}) -%>
+			return result; 
+		}

--- a/cli/lib/templates/add_event_handler.cpp
+++ b/cli/lib/templates/add_event_handler.cpp
@@ -1,8 +1,3 @@
-		TITANIUM_FUNCTION(<%= base_name %>, <%= methods[0].name %>)
-		{
-			auto context = this_object.get_context();
-			// TODO Handle no args, just return undefined?
-			ENSURE_OBJECT_AT_INDEX(callback, 0);
 <%
 // TODO We need to assert that there is one argument, that it's an object and a function. It's our callback
 // TODO We then need to hook an event handler like so:
@@ -80,11 +75,11 @@ if (handler_type_name.indexOf("Windows.Foundation.EventHandler`1") == 0) {
 
 }
 -%>
-			auto method_result = unwrap()-><%= event_name %> += ref new ::<%- handler_type_name.replace(/\./g, '::') %>([context, &callback](<%- parameters %>) {
-				// TODO Convert the args and pass them to callback!
-				// Takes a const std::vector<JSValue>&  arguments
-				callback(context.get_global_object());
-			});
-			<%- include('native_to_js.cpp', {type: methods[0].returnType, metadata: metadata, to_assign: 'result', argument_name: 'method_result'}) -%>
-			return result; 
-		}
+			if (event_name == "<%= event_name %>") {
+				auto method_result = unwrap()-><%= event_name %> += ref new ::<%- handler_type_name.replace(/\./g, '::') %>([context, this](<%- parameters %>) {
+					auto eventArgs = context.CreateObject();
+					// TODO Convert the args and pass them to event object we pass to callback!
+					this->fireEvent("<%= event_name %>", eventArgs);
+				});
+				return;
+			}

--- a/cli/lib/templates/add_event_handler.cpp
+++ b/cli/lib/templates/add_event_handler.cpp
@@ -76,7 +76,7 @@ if (handler_type_name.indexOf("Windows.Foundation.EventHandler`1") == 0) {
 }
 -%>
 			if (event_name == "<%= event_name %>") {
-				auto method_result = unwrap()-><%= event_name %> += ref new ::<%- handler_type_name.replace(/\./g, '::') %>([context, this](<%- parameters %>) {
+				<%= event_name %>_token__ = unwrap()-><%= event_name %> += ref new ::<%- handler_type_name.replace(/\./g, '::') %>([context, this](<%- parameters %>) {
 					auto eventArgs = context.CreateObject();
 					// TODO Convert the args and pass them to event object we pass to callback!
 					this->fireEvent("<%= event_name %>", eventArgs);

--- a/cli/lib/templates/function.cpp
+++ b/cli/lib/templates/function.cpp
@@ -1,3 +1,10 @@
+<%
+if (methods[0].api && methods[0].api == 'store') {
+-%>
+#if WINAPI_FAMILY != WINAPI_FAMILY_PHONE_APP
+<%
+}
+-%>
 		TITANIUM_FUNCTION(<%= base_name %>, <%= methods[0].name %>)
 		{
 			auto context = get_context();
@@ -53,7 +60,7 @@ for (var i = 0; i < methods.length; i++) {
 	// Now invoke the method and return the result!
 	if (method.returnType == 'void') {
 -%>
-				<%- receiver %><%= method.name %>(<%= arguments %>);
+				<%- receiver %><%= method.name %>(<%- arguments %>);
 				return context.CreateUndefined(); 
 <%
 	} else {
@@ -91,3 +98,10 @@ for (var i = 0; i < methods.length; i++) {
 			TITANIUM_LOG_DEBUG("No method signature matched <%= base_name %>::<%= methods[0].name %> with # of args: ", arguments.size());
 			return context.CreateUndefined(); 
 		}
+<%
+if (methods[0].api) {
+-%>
+#endif
+<%
+}
+-%>

--- a/cli/lib/templates/js_to_native.cpp
+++ b/cli/lib/templates/js_to_native.cpp
@@ -1,5 +1,5 @@
 <%
-// TODO int64, uint64, single, char16
+// TODO uint64, single, char16
 if (type == 'bool') {
 -%> 
 			TITANIUM_ASSERT_AND_THROW(<%= argument_name %>.IsBoolean(), "Expected boolean");
@@ -19,6 +19,11 @@ if (type == 'bool') {
 -%> 
 			TITANIUM_ASSERT_AND_THROW(<%= argument_name %>.IsNumber(), "Expected Number");
 			auto <%= to_assign %> = static_cast<double>(<%= argument_name %>);
+<%
+} else if (type == 'int64') {
+-%> 
+			TITANIUM_ASSERT_AND_THROW(<%= argument_name %>.IsNumber(), "Expected Number");
+			auto <%= to_assign %> = static_cast<int64>(static_cast<double>(<%= argument_name %>));
 <%
 } else if (type == 'float32' || type == 'float64') {
 -%> 

--- a/cli/lib/templates/js_to_native_class.cpp
+++ b/cli/lib/templates/js_to_native_class.cpp
@@ -1,0 +1,137 @@
+<%
+// This expects:
+// to_assign: the name of the native variable to assign the resulting object to
+// type: the name of the type we're converting
+// metadata: pointer to the full metadata
+// argument_name: the name of the JS variable we're converting from
+
+//	It's a class. Let's wrap the native item in our native wrapper for the defined type
+type = type.trim();
+if (type.indexOf('class ') == 0) {
+	type = type.substring(6);
+}
+
+// TODO How do we handle other possible templated types like the Async stuff?
+
+if (type.indexOf('[]') == type.length - 2) { // 'primitive' array
+	// Strip off the [], then proceed knowing it's an array...
+	type = type.substring(0, type.length - 2);
+-%>
+			TITANIUM_ASSERT_AND_THROW(<%= argument_name %>.IsObject(), "Expected Object");
+			auto object_<%= argument_name %> = static_cast<JSObject>(<%= argument_name %>);
+			TITANIUM_ASSERT(object_<%= argument_name %>.IsArray());
+			const auto array_<%= argument_name %> = static_cast<JSArray>(object_<%= argument_name %>);
+			auto items_<%= argument_name %> = array_<%= argument_name %>.GetPrivateItems<<%= type.replace(/\./g, '::') %>>(); // std::vector<std::shared_ptr<<%= type.replace(/\./g, '::') %>>
+			auto <%= to_assign %> = ref new ::Platform::Array<::<%= type.replace(/\./g, '::') %>^>(items_<%= argument_name %>.size());
+			for (size_t i = 0; i < items_<%= argument_name %>.size(); ++i) {
+				items[i] = items_<%= argument_name %>.at(i)->unwrap<%= type.replace(/\./g, '_') %>();
+			}
+<%
+} else  if (type.indexOf('.IIterator') != -1) { // IIterator
+	// Pull out the internal type!
+	type = type.substring(type.indexOf('`1<') + 3, type.length - 1);
+	// Make a vector and then return an iterator over it!
+	type = 'Windows.Foundation.Collections.IVector`1<' + type + '>';
+-%>
+			<%- include('js_to_native_class.cpp', {type: type, metadata: metadata, to_assign: to_assign + "_vector", argument_name: argument_name }) -%>
+			auto <%= to_assign %> = <%= to_assign %>_vector->First();
+<%
+} else if (type.indexOf('.IVectorView') != -1) { // IVectorView
+	type = type.substring(type.indexOf('`1<') + 3, type.length - 1);
+	// Treat as a Vector, then just return view of it!
+	type = 'Windows.Foundation.Collections.IVector`1<' + type + '>';
+-%>
+			<%- include('js_to_native_class.cpp', {type: type, metadata: metadata, to_assign: to_assign + "_vector", argument_name: argument_name }) -%>
+			auto <%= to_assign %> = <%= to_assign %>_vector->GetView();
+<%
+} else if (type.indexOf('.IVector') != -1 || type.indexOf('.IIterable') != -1) { // IVector/IIterable
+	// Pull out the internal type!
+	type = type.substring(type.indexOf('`1<') + 3, type.length - 1);
+	if (type == 'object') {
+		type = 'Platform.Object';
+	}
+	if (type.indexOf('class ') == 0) {
+		type = type.substring(6);
+	}
+-%>
+			TITANIUM_ASSERT_AND_THROW(<%= argument_name %>.IsObject(), "Expected Object");
+			auto object_<%= argument_name %> = static_cast<JSObject>(<%= argument_name %>);
+			TITANIUM_ASSERT(object_<%= argument_name %>.IsArray());
+			const auto array_<%= argument_name %> = static_cast<JSArray>(object_<%= argument_name %>);
+<%
+
+	if (type == 'string') {
+		type = 'Platform.String'; // FIXME When it's strings, we need to handle them totally differently! We can't do GetPrivateItems
+		// we cast to a vectore of std::string, then convert thos to platform strings
+-%>
+			auto items_<%= argument_name %> = static_cast<std::vector<std::string>>(array_<%= argument_name %>);
+			auto <%= to_assign %> = ref new ::Platform::Collections::Vector<::<%- type.replace(/\./g, '::') %>^>();
+			for (size_t i = 0; i < items_<%= argument_name %>.size(); ++i) {
+				TitaniumWindows::Utility::ConvertUTF8String(static_cast<std::string>(<%= argument_name %>));
+				 <%= to_assign %>->Append(TitaniumWindows::Utility::ConvertUTF8String(items_<%= argument_name %>[i]));
+			}
+<%
+	} else { // Assume typical classes
+-%>
+			auto items_<%= argument_name %> = array_<%= argument_name %>.GetPrivateItems<<%= type.replace(/\./g, '::') %>>(); // std::vector<std::shared_ptr<<%= type.replace(/\./g, '::') %>>
+			auto <%= to_assign %> = ref new ::Platform::Collections::Vector<::<%- type.replace(/\./g, '::') %>^>();
+			for (size_t i = 0; i < items_<%= argument_name %>.size(); ++i) {
+				 <%= to_assign %>->Append(items_<%= argument_name %>[i]->unwrap<%= type.replace(/\./g, '_') %>());
+			}
+<%
+	}
+} else if (type.indexOf('.IMapView') != -1) { // IMapView
+	// Pull out the internal types for key and value!
+	type = type.substring(type.indexOf('`2<') + 3, type.length - 1);
+	// Treat as a map, then just return view of it!
+	type = 'Windows.Foundation.Collections.IMap`2<' + type + '>';
+-%>
+			<%- include('js_to_native_class.cpp', {type: type, metadata: metadata, to_assign: to_assign + "_map", argument_name: argument_name }) -%>
+			auto <%= to_assign %> = <%= to_assign %>_map->GetView();
+<%
+} else if (type.indexOf('.IMap') != -1) { // IMap
+	// Pull out the internal types for key and value!
+	type = type.substring(type.indexOf('`2<') + 3, type.length - 1);
+	// Split the type in two using the comma
+	var commaIndex = type.indexOf(',');
+	var key_type_name = type.substring(0, commaIndex);
+	var value_type_name = type.substring(commaIndex + 1);
+	if (key_type_name == 'string') {
+		key_type_name = 'Platform.String';
+	}
+	if (key_type_name == 'object') {
+		key_type_name = 'Platform.Object';
+	}
+	if (value_type_name == 'string') {
+		value_type_name = 'Platform.String';
+	}
+	if (value_type_name == 'object') {
+		value_type_name = 'Platform.Object';
+	}
+	// TODO normalize the key/value type names!
+	// could be 'string' or 'object'!
+-%>
+			ENSURE_ARRAY(<%= argument_name %>, array_<%= argument_name %>)
+			auto vector_<%= argument_name %> = static_cast<std::vector<JSValue>>(array_<%= argument_name %>);
+			auto <%= to_assign %> = ref new ::Platform::Collections::Map<::<%- key_type_name.replace(/\./g, '::') %>^, ::<%- value_type_name.replace(/\./g, '::') %>^>();
+			for (auto v : vector_<%= argument_name %>) {
+				TITANIUM_ASSERT_AND_THROW(v.IsObject(), "Expected Object");
+				auto tmp = static_cast<JSObject>(v);
+				auto tmp_key = tmp.GetProperty("key");
+				auto tmp_value = tmp.GetProperty("value");
+				<%- include('js_to_native.cpp', {type: key_type_name, metadata: metadata, to_assign: 'key', argument_name: 'tmp_key' }) -%>
+				<%- include('js_to_native.cpp', {type: value_type_name, metadata: metadata, to_assign: 'value', argument_name: 'tmp_value' }) -%>
+				<%= to_assign %>->Insert(key, value);
+			}
+<%
+} else { // normal class
+-%>
+			TITANIUM_ASSERT_AND_THROW(<%= argument_name %>.IsObject(), "Expected Object");
+			auto object_<%= argument_name %> = static_cast<JSObject>(<%= argument_name %>);
+			auto wrapper_<%= to_assign %> = object_<%= argument_name %>.GetPrivate<<%= type.replace(/\./g, '::') %>>();
+			// FIXME What if the type we want here is some parent class of the actual wrapper's class? I think we'll get nullptr here.
+			// We need some way to know the underlying type the JSObject maps to, get that, then cast to the type we want...
+			auto <%= to_assign %> = wrapper_<%= to_assign %>->unwrap<%= type.replace(/\./g, '_') %>();
+<%
+}
+-%>

--- a/cli/lib/templates/js_to_native_enum.cpp
+++ b/cli/lib/templates/js_to_native_enum.cpp
@@ -1,0 +1,8 @@
+<%#
+// This expects:
+// to_assign: the name of the native variable to assign the resulting object to
+// type: the name of the type we're converting
+// argument_name: the name of the JS variable we're converting from
+%>
+			TITANIUM_ASSERT_AND_THROW(<%= argument_name %>.IsNumber(), "Expected Number");
+			auto <%= to_assign %> = static_cast<::<%= type.replace(/\./g, '::') %>>(static_cast<int32_t>(<%= argument_name %>)); // TODO Look up enum in metadata to know what type it's value is? 

--- a/cli/lib/templates/js_to_native_primitive.cpp
+++ b/cli/lib/templates/js_to_native_primitive.cpp
@@ -1,0 +1,48 @@
+<%
+// This expects:
+// to_assign: the name of the native variable to assign the resulting value to
+// argument_name: the name of the JS variable we're converting from
+
+// TODO single, char16
+if (type == 'bool') {
+-%> 
+			TITANIUM_ASSERT_AND_THROW(<%= argument_name %>.IsBoolean(), "Expected boolean");
+			auto <%= to_assign %> = static_cast<bool>(<%= argument_name %>);
+<%
+} else if (type == 'int32' || type == 'int16' || type == 'int') {
+-%> 
+			TITANIUM_ASSERT_AND_THROW(<%= argument_name %>.IsNumber(), "Expected Number");
+			auto <%= to_assign %> = static_cast<int32_t>(<%= argument_name %>);
+<%
+} else if (type == 'uint32' || type == 'uint16' || type == 'uint8') {
+-%> 
+			TITANIUM_ASSERT_AND_THROW(<%= argument_name %>.IsNumber(), "Expected Number");
+			auto <%= to_assign %> = static_cast<uint32_t>(<%= argument_name %>);
+<%
+} else if (type == 'double') {
+-%> 
+			TITANIUM_ASSERT_AND_THROW(<%= argument_name %>.IsNumber(), "Expected Number");
+			auto <%= to_assign %> = static_cast<double>(<%= argument_name %>);
+<%
+} else if (type == 'uint64') {
+-%> 
+			TITANIUM_ASSERT_AND_THROW(<%= argument_name %>.IsNumber(), "Expected Number");
+			auto <%= to_assign %> = static_cast<uint64>(static_cast<double>(<%= argument_name %>));
+<%
+} else if (type == 'int64') {
+-%> 
+			TITANIUM_ASSERT_AND_THROW(<%= argument_name %>.IsNumber(), "Expected Number");
+			auto <%= to_assign %> = static_cast<int64>(static_cast<double>(<%= argument_name %>));
+<%
+} else if (type == 'float32' || type == 'float64') {
+-%> 
+			TITANIUM_ASSERT_AND_THROW(<%= argument_name %>.IsNumber(), "Expected Number");
+			auto <%= to_assign %> = static_cast<float>(static_cast<double>(<%= argument_name %>));
+<%
+} else if (type == 'string' || type == 'Platform.String') {
+-%> 
+			TITANIUM_ASSERT_AND_THROW(<%= argument_name %>.IsString(), "Expected String");
+			auto <%= to_assign %> = TitaniumWindows::Utility::ConvertUTF8String(static_cast<std::string>(<%= argument_name %>));
+<%
+}
+-%>

--- a/cli/lib/templates/js_to_native_struct.cpp
+++ b/cli/lib/templates/js_to_native_struct.cpp
@@ -1,0 +1,38 @@
+<%
+// This expects:
+// to_assign: the name of the native variable to assign the resulting object to
+// type: the _definition_ of the struct type from the metadata! Note that this differs from other partials that expect a type name for this variable!
+// metadata: pointer to the full metadata
+// argument_name: the name of the JS variable we're converting from
+
+
+// here we generate constructor args.
+// FIXME the matadata gives no indication if the struct has a constructor or not, or the arg order. So I don't think this will work properly!
+// Looks like we'll need to improve the metadata generator. But it also appears that for those not having constructors they can only be accessed
+// through read-only getters. So let's just hope this works well enough for now...
+var ctr_args = "";
+for (field_name in type.fields) {
+	var field_type = type.fields[field_name].type;
+	if (field_type == 'string') {
+		ctr_args =+ "\"\", ";
+	} else if (field_type == 'bool') {
+		ctr_args += "false, ";
+	} else {
+		// assume number for any other type.
+		ctr_args += "0, ";
+	}
+}
+ctr_args = ctr_args.substring(0, ctr_args.length - 2); 
+-%>
+			TITANIUM_ASSERT_AND_THROW(<%= argument_name %>.IsObject(), "Expected Object");
+			auto object_<%= to_assign %> = static_cast<JSObject>(<%= argument_name %>);
+			::<%= type.name.to_windows_name() %> <%= to_assign %>;
+			// Assign fields explicitly since we didn't use a constructor
+<%
+for (field_name in type.fields) {
+-%>
+			auto object_<%= to_assign %>_<%= field_name %> = object_<%= to_assign %>.GetProperty("<%= field_name %>");<%- include('js_to_native.cpp', {type:  type.fields[field_name].type, metadata: metadata, to_assign: 'object_' + to_assign + '_' + field_name + '_', argument_name: 'object_' + to_assign + '_' + field_name}) -%>
+			<%= to_assign %>.<%= field_name %> = object_<%= to_assign %>_<%= field_name %>_;
+<%
+}
+-%>

--- a/cli/lib/templates/native_primitive_to_js.cpp
+++ b/cli/lib/templates/native_primitive_to_js.cpp
@@ -3,30 +3,30 @@
 // to_assign: the name of the JS variable to assign the resulting object to
 // argument_name: the name of the native variable we're converting from
 
-// TODO int64, uint64, single, char16
+// TODO single, char16
 if (type == 'bool') {
 -%> 
-			auto <%= to_assign %> = context.CreateBoolean(<%= argument_name %>); 
+			auto <%= to_assign %> = context.CreateBoolean(<%- argument_name %>); 
 <%
 } else if (type == 'int32' || type == 'uint32' || type == 'double') {
 -%> 
-			auto <%= to_assign %> = context.CreateNumber(<%= argument_name %>);
+			auto <%= to_assign %> = context.CreateNumber(<%- argument_name %>);
 <%
 } else if (type == 'uint16' || type == 'uint8') {
 -%>
-			auto <%= to_assign %> = context.CreateNumber(static_cast<uint32_t>(<%= argument_name %>));
+			auto <%= to_assign %> = context.CreateNumber(static_cast<uint32_t>(<%- argument_name %>));
 <%
 } else if (type == 'int16' || type == 'int') {
 -%>
-			auto <%= to_assign %> = context.CreateNumber(static_cast<int32_t>(<%= argument_name %>));
+			auto <%= to_assign %> = context.CreateNumber(static_cast<int32_t>(<%- argument_name %>));
 <%
 } else if (type == 'string') {
 -%> 
-			auto <%= to_assign %> = context.CreateString(TitaniumWindows::Utility::ConvertUTF8String(<%= argument_name %>));
+			auto <%= to_assign %> = context.CreateString(TitaniumWindows::Utility::ConvertUTF8String(<%- argument_name %>));
 <%
-} else if (type == 'float32' || type == 'float64' || type == 'int64') {
+} else if (type == 'float32' || type == 'float64' || type == 'int64' || type == 'uint64') {
 -%>
-			auto <%= to_assign %> = context.CreateNumber(static_cast<double>(<%= argument_name %>));
+			auto <%= to_assign %> = context.CreateNumber(static_cast<double>(<%- argument_name %>));
 <%
 }
 -%>

--- a/cli/lib/templates/native_struct_to_js.cpp
+++ b/cli/lib/templates/native_struct_to_js.cpp
@@ -1,4 +1,4 @@
-<%#
+<%
 // This expects:
 // to_assign: the name of the JS variable to assign the resulting object to
 // type: the _definition_ of the struct type from the metadata! Note that this differs from other partials that expect a type name for this variable!
@@ -6,11 +6,20 @@
 // argument_name: the name of the native variable we're converting from
 
 // TODO Handle arrays of structs!
+
+// We need to hold onto copies of the original values.
+// Recursive structs mean that to_assign, field_name and the temp var we assign to
+// all those values get modifies after the sub-include here and before we get to the next chunk of the template where we use them!
+var orig_to_assign = to_assign,
+	orig_sub_assign = "",
+	orig_field = "";
 %>
 			auto <%= to_assign %> = context.CreateObject();<%
 		for (field_name in type.fields) {
+			orig_sub_assign = argument_name.replace(/\./g, '_') + '_' + field_name + '_';
+			orig_field = field_name;
 -%>
-<%- include('native_to_js.cpp', {type: type.fields[field_name].type, metadata: metadata, to_assign: argument_name + '_' + field_name + '_', argument_name: argument_name + '.' + field_name }) -%>			<%= to_assign %>.SetProperty("<%= field_name %>", <%= argument_name %>_<%= field_name %>_);
+<%- include('native_to_js.cpp', {type: type.fields[field_name].type, metadata: metadata, to_assign: argument_name.replace(/\./g, '_') + '_' + field_name + '_', argument_name: argument_name + '.' + field_name }) -%>			<%= orig_to_assign %>.SetProperty("<%= orig_field %>", <%- orig_sub_assign %>);
 <%
 		}
 -%>

--- a/cli/lib/templates/remove_event_handler.cpp
+++ b/cli/lib/templates/remove_event_handler.cpp
@@ -1,12 +1,8 @@
-		TITANIUM_FUNCTION(<%= base_name %>, <%= methods[0].name %>)
-		{
-			auto context = get_context();
 <%
 var event_name = methods[0].name.substring(7), // drop "remove_"
 	type = methods[0].args[0].type;
 -%>
-			auto _0 = arguments.at(0); // Should be a JSObject representing an EventRegistrationToken
-			<%- include('js_to_native.cpp', {type: type, metadata: metadata, to_assign: 'token', argument_name: '_0'}) -%>
-			unwrap()-><%= event_name %> -= token;
-			return context.CreateUndefined(); 
-		}
+			if (event_name == "<%= event_name %>") {
+				unwrap()-><%= event_name %> -= <%= event_name %>_token__;
+				return;
+			}

--- a/cli/lib/templates/remove_event_handler.cpp
+++ b/cli/lib/templates/remove_event_handler.cpp
@@ -1,0 +1,12 @@
+		TITANIUM_FUNCTION(<%= base_name %>, <%= methods[0].name %>)
+		{
+			auto context = get_context();
+<%
+var event_name = methods[0].name.substring(7), // drop "remove_"
+	type = methods[0].args[0].type;
+-%>
+			auto _0 = arguments.at(0); // Should be a JSObject representing an EventRegistrationToken
+			<%- include('js_to_native.cpp', {type: type, metadata: metadata, to_assign: 'token', argument_name: '_0'}) -%>
+			unwrap()-><%= event_name %> -= token;
+			return context.CreateUndefined(); 
+		}


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-18883

Adding event handlers on native types is done more like Titanium event handling, not hyperloop.
```javascript
var Window = require('Windows.UI.Xaml.Window'),
	TextBlock = require('Windows.UI.Xaml.Controls.TextBlock'),
	window = Window.Current,
	text = new TextBlock();

text.Text = "Click me, please!";
text.TextAlignment = Windows.UI.Xaml.TextAlignment.Center;
text.VerticalAlignment = Windows.UI.Xaml.VerticalAlignment.Center;
text.HorizontalAlignment = Windows.UI.Xaml.HorizontalAlignment.Center;
text.FontSize = 60;

text.addEventListener('Tapped', function() {
	alert('You touched it!');
});

window.Content = text;
window.Activate();
```
