### PR TITLE
[TIMOB-18973] Reduce Clutter of Logs

### DIFF
--- a/cli/commands/_build.js
+++ b/cli/commands/_build.js
@@ -1755,7 +1755,13 @@ WindowsBuilder.prototype.compileApp = function compileApp(next) {
 			'&&', 'MSBuild', '/m', '/t:rebuild', '/p:Platform=' + _t.cmakeArch, '/p:Configuration=' + _t.buildConfiguration, slnFile
 		]);
 		p.stdout.on('data', function (data) {
-  			_t.logger.info(data.toString().trim());
+			var line = data.toString().trim();
+			if (line.indexOf(':\\') === -1) {
+				_t.logger.debug(line);
+			}
+			else {
+				_t.logger.trace(line);
+			}
 		});
 		p.stderr.on('data', function (data) {
   			_t.logger.warn(data.toString().trim());

--- a/cli/commands/_build.js
+++ b/cli/commands/_build.js
@@ -1130,7 +1130,7 @@ WindowsBuilder.prototype.copyResources = function copyResources(next) {
 		fs.existsSync(d) || wrench.mkdirSyncRecursive(d);
 
 		if (fs.existsSync(to)) {
-			_t.logger.warn(__('Overwriting file %s', to.cyan));
+			_t.logger.debug(__('Overwriting file %s', to.cyan));
 		}
 
 		this.logger.debug(__('Copying %s => %s', from.cyan, to.cyan));
@@ -1546,6 +1546,7 @@ WindowsBuilder.prototype.generateI18N = function generateI18N(next) {
 WindowsBuilder.prototype.generateNativeWrappers = function generateNativeWrappers(next) {
 	this.logger.info(__('Generating Native Type Wrappers'));
 
+	nativeTypeGenerator.setLogger(this.logger);
 	nativeTypeGenerator.generate(path.join(this.buildDir, 'Native'), this.seeds, this.modules, next);
 };
 
@@ -1756,7 +1757,13 @@ WindowsBuilder.prototype.compileApp = function compileApp(next) {
 		]);
 		p.stdout.on('data', function (data) {
 			var line = data.toString().trim();
-			if (line.indexOf(':\\') === -1) {
+			if (line.indexOf('error ') >= 0) {
+				_t.logger.warn(line);
+			}
+			else if (line.indexOf('warning ') >= 0) {
+				_t.logger.warn(line);
+			}
+			else if (line.indexOf(':\\') === -1) {
 				_t.logger.debug(line);
 			}
 			else {


### PR DESCRIPTION
If you `--log-level info` you'll get a nice short console; debug will
give you a little more progress, and trace will give you the full amount
we had before. Reduces it to just a couple screens of data when run at
info level.

https://jira.appcelerator.org/browse/TIMOB-18973