### PR TITLE
[TIMOB-18999] Use actual PPI when populating layout properties

### DIFF
--- a/Examples/NMocha/src/Assets/ti.ui.layout.test.js
+++ b/Examples/NMocha/src/Assets/ti.ui.layout.test.js
@@ -755,8 +755,7 @@ describe("Titanium.UI.Layout", function () {
     });
     
     // Functional Test #1001 #1002 #1003 #1004 #1005 #1006
-    // Not supported in Windows yet
-    it.skip("unitMeasurements", function (finish) {
+    it("unitMeasurements", function (finish) {
         var win = createWindow({}, finish);
         var child = Ti.UI.createView({
             height: "50mm",

--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -785,7 +785,8 @@ namespace TitaniumWindows
 				prop.value = "UI.FILL";
 			}
 
-			Titanium::LayoutEngine::populateLayoutPoperties(prop, &layout_node__->properties, 1);
+			auto ppi = Windows::Graphics::Display::DisplayInformation::GetForCurrentView()->LogicalDpi;
+			Titanium::LayoutEngine::populateLayoutPoperties(prop, &layout_node__->properties, ppi);
 
 			if (isLoaded()) {
 				requestLayout();


### PR DESCRIPTION
- Use actual PPI instead of ```1```
- This allows ```cm, in and dp``` to be calculated correctly

###### EXAMPLE
```Javascript
var win = Titanium.UI.createWindow({
    backgroundColor: '#fff'
});
 
var view = Titanium.UI.createView({
    backgroundColor: 'red',
    width: '1in',
    height: '10dp'
});
win.add(view);
 
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-18999)