### PR TITLE
Provide ability to set capabilities on appx.manifest in tiapp.xml

### DIFF
--- a/Tools/Scripts/build/test.js
+++ b/Tools/Scripts/build/test.js
@@ -111,6 +111,7 @@ function addTiAppProperties(next) {
 		content.push(line);
 		if (line.indexOf('<guid>') >= 0) {
 			content.push('\t'+publishername);
+			content.push('\t<windows><manifest><Capabilities><Capability Name=\"internetClient\" /></Capabilities></manifest></windows>');
 		}
 	});
 	fs.writeFileSync(tiapp_xml, content.join('\n'));

--- a/cli/commands/_build.js
+++ b/cli/commands/_build.js
@@ -1786,6 +1786,8 @@ WindowsBuilder.prototype.readTiAppManifest = function readTiAppManifest() {
  */
 WindowsBuilder.prototype.generateAppxManifest = function generateAppxManifest(next) {
 
+	this.tiapp.windows = this.tiapp.windows || {};
+
 	this.readTiAppManifest();
 
 	if (!this.tiapp.windows.manifests) {

--- a/cli/commands/_build.js
+++ b/cli/commands/_build.js
@@ -1771,13 +1771,17 @@ WindowsBuilder.prototype.readTiAppManifest = function readTiAppManifest() {
  *
  *  Example:
  *	<windows>
- *		<manifest>
- *			<Capabilities target="phone">
+ *		<manifest target="phone">
+ *			<Capabilities>
  *				<Capability Name="location" />
  *			</Capabilities>
- *			<Capabilities target="store">
+ *		</manifest>
+ *		<manifest target="store">
+ *			<Capabilities>
  *				<Capability Name="optical" />
  *			</Capabilities>
+ *		</manifest>
+ *		<manifest>
  *			<Capabilities>
  *				<Capability Name="internetClient" />
  *			</Capabilities>

--- a/cli/commands/_build.js
+++ b/cli/commands/_build.js
@@ -1791,16 +1791,17 @@ WindowsBuilder.prototype.readTiAppManifest = function readTiAppManifest() {
 WindowsBuilder.prototype.generateAppxManifest = function generateAppxManifest(next) {
 
 	this.tiapp.windows = this.tiapp.windows || {};
-
 	this.readTiAppManifest();
-
-	if (!this.tiapp.windows.manifests) {
-		next();
-		return;
-	}
 
 	var xprops = {phone:{}, store:{}},
 		domParser = new DOMParser();
+
+	if (!this.tiapp.windows.manifests) {
+		this.generateAppxManifestForPlatform("store", xprops.store);
+		this.generateAppxManifestForPlatform("phone", xprops.phone);
+		next();
+		return;
+	}
 
 	// Construct manifest properties
 	for (var i = 0; i < this.tiapp.windows.manifests.length; i++) {

--- a/cli/commands/_build.js
+++ b/cli/commands/_build.js
@@ -1719,7 +1719,7 @@ WindowsBuilder.prototype.generateAppxManifestForPlatform = function generateAppx
 
 	// Supported properties
 	properties.Properties    = properties.Properties    || [];
-	properties.Capabilities  = properties.Capabilities  || [];
+	properties.Capabilities  = properties.Capabilities  || [ '<Capability Name=\"internetClient\" />'];
 	properties.Prerequisites = properties.Prerequisites || [];
 	properties.Resources     = properties.Resources     || [];
 

--- a/templates/build/Package.phone.appxmanifest.in.ejs
+++ b/templates/build/Package.phone.appxmanifest.in.ejs
@@ -1,26 +1,39 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/2010/manifest"
-	 xmlns:m2="http://schemas.microsoft.com/appx/2013/manifest">
-
+	 xmlns:m2="http://schemas.microsoft.com/appx/2013/manifest"
+	 xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest">
+  
   <Identity Name="@PACKAGE_GUID@"
 	    Publisher="CN=appcelerator"
 	    Version="1.1.0.0" />
+  
+  <mp:PhoneIdentity PhoneProductId="@PHONE_PRODUCT_ID@"
+        PhonePublisherId="00000000-0000-0000-0000-000000000000" />
 
   <Properties>
     <DisplayName>@SHORT_NAME@</DisplayName>
     <PublisherDisplayName>Appcelerator</PublisherDisplayName>
     <Logo>StoreLogo.png</Logo>
+<% for(var i = 0; i < manifest.Properties.length; i++) { -%>
+    <%- manifest.Properties[i] %>
+<% } -%>
   </Properties>
-
+  
   <Prerequisites>
-    <OSMinVersion>6.3</OSMinVersion>
-    <OSMaxVersionTested>6.3</OSMaxVersionTested>
+    <OSMinVersion>6.3.1</OSMinVersion>
+    <OSMaxVersionTested>6.3.1</OSMaxVersionTested>
+<% for(var i = 0; i < manifest.Prerequisites.length; i++) { -%>
+    <%- manifest.Prerequisites[i] %>
+<% } -%>
   </Prerequisites>
 
   <Resources>
     <Resource Language="x-generate" />
+<% for(var i = 0; i < manifest.Resources.length; i++) { -%>
+    <%- manifest.Resources[i] %>
+<% } -%>
   </Resources>
-  
+
   <Applications>
     <Application Id="App"
 		 Executable="$targetnametoken$.exe"
@@ -44,7 +57,9 @@
   </Applications>
   
   <Capabilities>
-    <Capability Name="internetClient" />
+<% for(var i = 0; i < manifest.Capabilities.length; i++) { -%>
+    <%- manifest.Capabilities[i] %>
+<% } -%>
   </Capabilities>
   
 </Package>

--- a/templates/build/Package.store.appxmanifest.in.ejs
+++ b/templates/build/Package.store.appxmanifest.in.ejs
@@ -1,30 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/2010/manifest"
-	 xmlns:m2="http://schemas.microsoft.com/appx/2013/manifest"
-	 xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest">
-  
+	 xmlns:m2="http://schemas.microsoft.com/appx/2013/manifest">
+
   <Identity Name="@PACKAGE_GUID@"
 	    Publisher="CN=appcelerator"
 	    Version="1.1.0.0" />
-  
-  <mp:PhoneIdentity PhoneProductId="@PHONE_PRODUCT_ID@"
-        PhonePublisherId="00000000-0000-0000-0000-000000000000" />
 
   <Properties>
     <DisplayName>@SHORT_NAME@</DisplayName>
     <PublisherDisplayName>Appcelerator</PublisherDisplayName>
     <Logo>StoreLogo.png</Logo>
+<% for(var i = 0; i < manifest.Properties.length; i++) { -%>
+    <%- manifest.Properties[i] %>
+<% } -%>
   </Properties>
-  
+
   <Prerequisites>
-    <OSMinVersion>6.3.1</OSMinVersion>
-    <OSMaxVersionTested>6.3.1</OSMaxVersionTested>
+    <OSMinVersion>6.3</OSMinVersion>
+    <OSMaxVersionTested>6.3</OSMaxVersionTested>
+<% for(var i = 0; i < manifest.Prerequisites.length; i++) { -%>
+    <%- manifest.Prerequisites[i] %>
+<% } -%>
   </Prerequisites>
 
   <Resources>
     <Resource Language="x-generate" />
+<% for(var i = 0; i < manifest.Resources.length; i++) { -%>
+    <%- manifest.Resources[i] %>
+<% } -%>
   </Resources>
-
+  
   <Applications>
     <Application Id="App"
 		 Executable="$targetnametoken$.exe"
@@ -48,7 +53,9 @@
   </Applications>
   
   <Capabilities>
-    <Capability Name="internetClient" />
+<% for(var i = 0; i < manifest.Capabilities.length; i++) { -%>
+    <%- manifest.Capabilities[i] %>
+<% } -%>
   </Capabilities>
   
 </Package>


### PR DESCRIPTION
[TIMOB-18995](https://jira.appcelerator.org/browse/TIMOB-18995)

Provide ability to set capabilities on appx.manifest in tiapp.xml. Not only `Capabilities` but also `Properties`, `﻿Prerequisites` and `Resources` are supported.

```xml
<windows>
	<manifest>
		<Capabilities>
			<Capability Name="internetClient" />
		</Capabilities>
	</manifest>
</windows>
```

By providing `target` attribute, you can setup platform-specific properties. Entries with no target means common properties across `phone` and `store`.

Updated: See example at https://github.com/appcelerator/titanium_mobile_windows/pull/278#issuecomment-111519660

In this case this ends up with `location` and `internetClient` capabilities set for `phone` app.

```xml
<Capabilities>
	<Capability Name="location" />
	<Capability Name="internetClient" />
</Capabilities>
```

And `optical` and `internetClient` capabilities set for `store` app.

```xml
<Capabilities>
	<Capability Name="optical" />
	<Capability Name="internetClient" />
</Capabilities>
```