### PR TITLE
Fix: crash when triggering eventListener on a table view

### DIFF
--- a/Source/TitaniumKit/src/ApplicationBuilder.cpp
+++ b/Source/TitaniumKit/src/ApplicationBuilder.cpp
@@ -179,7 +179,7 @@ JSString builtin_functions_script = R"js(
 			  alert = function (_msg) {
 				  Ti.UI.createAlertDialog({
 					  title: 'Alert',
-					  message: _msg
+					  message: _msg + ''
 				  }).show();
 			  };
 


### PR DESCRIPTION
Fix for [TIMOB-19013](https://jira.appcelerator.org/browse/TIMOB-19013).

Example: TableView constructed from array of JS object
```javascript
var win = Ti.UI.createWindow();

var tableData = [{ title: 'Apples' }, { title: 'Bananas' }, { title: 'Carrots' }, { title: 'Potatoes' }];

var table = Ti.UI.createTableView({
    data: tableData
});
table.addEventListener('click', function (e) {
    alert(e.rowData);
});
win.add(table);
win.open();
```

Example: TableView constructed from array of TableViewSection
```javascript
var win = Ti.UI.createWindow();

var sectionFruit = Ti.UI.createTableViewSection({ headerTitle: 'Fruit' });
sectionFruit.add(Ti.UI.createTableViewRow({ title: 'Apples' }));
sectionFruit.add(Ti.UI.createTableViewRow({ title: 'Bananas' }));

var sectionVeg = Ti.UI.createTableViewSection({ headerTitle: 'Vegetables' });
sectionVeg.add(Ti.UI.createTableViewRow({ title: 'Carrots' }));
sectionVeg.add(Ti.UI.createTableViewRow({ title: 'Potatoes' }));

var table = Ti.UI.createTableView({
    data: [sectionFruit, sectionVeg]
});

table.addEventListener('click', function (e) {
    alert(e.rowData);
});

win.add(table);
win.open();
```
