### PR TITLE
Fix TIMOB-19022 Windows: Geolocation never returning data for getCurrentPosition

### DIFF
--- a/Source/Titanium/src/TitaniumWindows.cpp
+++ b/Source/Titanium/src/TitaniumWindows.cpp
@@ -24,6 +24,7 @@
 #include "TitaniumWindows/File.hpp"
 #include "TitaniumWindows/HTTPClient.hpp"
 #include "TitaniumWindows/Media.hpp"
+#include "TitaniumWindows/Geolocation.hpp"
 
 #include <Windows.h>
 #include <collection.h>
@@ -58,6 +59,7 @@ namespace TitaniumWindows
 		                                                            .AppObject(js_context__.CreateObject(JSExport<TitaniumWindows::AppModule>::Class()))
 		                                                            .PlatformObject(js_context__.CreateObject(JSExport<TitaniumWindows::Platform>::Class()))
 		                                                            .GestureObject(js_context__.CreateObject(JSExport<TitaniumWindows::Gesture>::Class()))
+																	.GeolocationObject(js_context__.CreateObject(JSExport<TitaniumWindows::Geolocation>::Class()))
 		                                                            .AccelerometerObject(js_context__.CreateObject(JSExport<TitaniumWindows::Accelerometer>::Class()))
 		                                                            .ViewObject(js_context__.CreateObject(JSExport<TitaniumWindows::UI::View>::Class()))
 		                                                            .NotificationObject(js_context__.CreateObject(JSExport<TitaniumWindows::UI::Notification>::Class()))


### PR DESCRIPTION
We never set up our Windows implementation to "override" the TitaniumKit Geolocation module.