### PR TITLE
Fix TIMOB-19023 Windows: HTTPClient GET is failing

### DIFF
--- a/Source/Network/include/TitaniumWindows/Network/HTTPClient.hpp
+++ b/Source/Network/include/TitaniumWindows/Network/HTTPClient.hpp
@@ -88,6 +88,8 @@ namespace TitaniumWindows
 			void SerializeHeaderCollection(Windows::Foundation::Collections::IIterable<Windows::Foundation::Collections::IKeyValuePair<::Platform::String^, ::Platform::String^>^>^ headers);
 			void setRequestHeaders(Windows::Web::Http::HttpRequestMessage^ request);
 			void addCookiesToRequest();
+
+			void send(Windows::Web::Http::IHttpContent^ content);
 		};
 	} // namespace Network
 } // namespace TitaniumWindows


### PR DESCRIPTION
The initial error was because we didn't "skip" setting up a timeout timer when timeout was 0 (or less). Since timeout defaults to 0, we always cancelled the request immediately.

I also took the time to clean up the code so we didn't have three separate "send" implementations. Now they all just gather up the content object they need to send and call the shared send implementation.