### PR TITLE
Fix: Geolocation module should instantiate Geolocator on-demand

### DIFF
--- a/Source/Sensors/include/TitaniumWindows/Geolocation.hpp
+++ b/Source/Sensors/include/TitaniumWindows/Geolocation.hpp
@@ -46,6 +46,8 @@ namespace TitaniumWindows
 
 		virtual void enableEvent(const std::string& event_name) TITANIUM_NOEXCEPT override final;
 
+		void ensureLoadGeolocator();
+
 	private:
 
 		Windows::Devices::Geolocation::Geolocator^ geolocator_;


### PR DESCRIPTION
Quick fix for [TIMOB-19028](https://jira.appcelerator.org/browse/TIMOB-19028). Developer should take care of the timing when first use of Geolocation, which should be done on UI thread according to the [guideline](https://msdn.microsoft.com/en-us/library/windows/apps/hh465148.aspx).

```javascript
Ti.Geolocation.addEventListener('location', ...); // should be done on the UI thread!
```