### PR TITLE
Package all headers including TitaniumWindows

### DIFF
--- a/Tools/Scripts/build/build.js
+++ b/Tools/Scripts/build/build.js
@@ -222,13 +222,19 @@ async.series([
 	function (next) {
 		console.log("Copying over include headers...");
 		wrench.copyDirSyncRecursive(path.join(rootDir, 'Source', 'HAL', 'include', 'HAL'), path.join(distLib, 'HAL', 'include', 'HAL'));
-		wrench.mkdirSyncRecursive(path.join(distLib, 'TitaniumKit', 'include', 'Titanium'));
-		wrench.copyDirSyncRecursive(path.join(rootDir, 'Source', 'Utility', 'include', 'TitaniumWindows'), path.join(distLib, 'TitaniumWindows_Utility', 'include', 'TitaniumWindows'));
-		wrench.copyDirSyncRecursive(path.join(rootDir, 'Source', 'TitaniumKit', 'include', 'Titanium', 'detail'), path.join(distLib, 'TitaniumKit', 'include', 'Titanium', 'detail'));	
+		wrench.copyDirSyncRecursive(path.join(rootDir, 'Source', 'TitaniumKit', 'include', 'Titanium'), path.join(distLib, 'TitaniumKit', 'include', 'Titanium'));
+
 		// Copy over the JSC headers to HAL!
 		wrench.copyDirSyncRecursive(path.join(process.env.JavaScriptCore_HOME, 'includes', 'JavaScriptCore'), path.join(distLib, 'HAL', 'include', 'JavaScriptCore'));
-		// Copy over TitaniumKit's Titanium/Module.hpp until we fix the wrappers to not use it!
-		fs.writeFileSync(path.join(distLib, 'TitaniumKit', 'include', 'Titanium', 'Module.hpp'), fs.readFileSync(path.join(rootDir, 'Source', 'TitaniumKit', 'include', 'Titanium', 'Module.hpp')));
+
+		wrench.copyDirSyncRecursive(path.join(rootDir, 'Source', 'Utility', 'include', 'TitaniumWindows'), path.join(distLib, 'TitaniumWindows_Utility', 'include', 'TitaniumWindows'));
+		wrench.copyDirSyncRecursive(path.join(rootDir, 'Source', 'LayoutEngine', 'include', 'LayoutEngine'), path.join(distLib, 'LayoutEngine', 'include', 'LayoutEngine'));
+		wrench.copyDirSyncRecursive(path.join(rootDir, 'Source', 'Titanium', 'include', 'TitaniumWindows'), path.join(distLib, 'TitaniumWindows', 'include', 'TitaniumWindows'));
+
+		var include_TitaniumWindows = ['UI', 'Filesystem', 'Global', 'Filesystem', 'Map', 'Media', 'Network', 'Sensors', 'Ti' ];
+		for (var i = 0; i < include_TitaniumWindows.length; i++) {
+			wrench.copyDirSyncRecursive(path.join(rootDir, 'Source', include_TitaniumWindows[i], 'include', 'TitaniumWindows'), path.join(distLib, 'TitaniumWindows_'+include_TitaniumWindows[i], 'include', 'TitaniumWindows'));
+		}
 		
 		next();
 	},

--- a/templates/build/cmake/FindLayoutEngine.cmake
+++ b/templates/build/cmake/FindLayoutEngine.cmake
@@ -62,7 +62,7 @@ if(CMAKE_GENERATOR MATCHES "^Visual Studio .+ ARM$")
 endif()
 
 # Create imported target LayoutEngine
-add_library(LayoutEngine STATIC IMPORTED)
+add_library(LayoutEngine SHARED IMPORTED)
 
 set_target_properties(LayoutEngine PROPERTIES
   COMPATIBLE_INTERFACE_STRING "LayoutEngine_MAJOR_VERSION"


### PR DESCRIPTION
Followup for [TIMOB-18992](https://jira.appcelerator.org/browse/TIMOB-18992).

Package all headers including `TitaniumWindows` for Titanium SDK build, because it may be used by module developers. For example `ti.map` may need access to constants in `TitaniumWindows::UI` as well as `Titanium::UI::View`.