### PR TITLE
Fix: Building to Emulator Should Allow Error Dialogs

### DIFF
--- a/Source/TitaniumKit/src/Application.cpp
+++ b/Source/TitaniumKit/src/Application.cpp
@@ -25,7 +25,14 @@ namespace Titanium
  * @param (e) Error or Exception
  */
 function Titanium_RedScreenOfDeath(e) {
+
+    // We don't want to show RSOD in production mode. re-throw.
+    if (Ti.App.deployType == "production") {
+        throw e;
+    }
+
     try {
+
         Ti.API.error("Application Error: "+JSON.stringify(e, null, 2));
 
         var f = e.fileName || "",
@@ -84,15 +91,11 @@ function Titanium_RedScreenOfDeath(e) {
 			os << "}";
 			return js_context__.JSEvaluateScript(os.str());
 		} catch (const std::exception& stdex) {
-#ifdef NDEBUG
-			throw stdex;
-#else
 			const auto what = js_context__.CreateString(stdex.what());
 			const auto rsod = js_context__.get_global_object().GetProperty("Titanium_RedScreenOfDeath");
 			auto rsod_func = static_cast<JSObject>(rsod);
 			const std::vector<JSValue> args = { what };
 			return rsod_func(args, rsod_func);
-#endif
 		}
 		return js_context__.CreateUndefined();
 	}

--- a/Source/TitaniumKit/src/Module.cpp
+++ b/Source/TitaniumKit/src/Module.cpp
@@ -178,14 +178,10 @@ namespace Titanium
 				callback({ static_cast<JSValue>(event_copy) }, this_object);
 			}
 		} catch (const HAL::detail::js_runtime_error& ex) {
-#ifdef NDEBUG
-			throw ex;
-#else
 			std::ostringstream os;
 			os << "Runtime Error during " << name << " event: " << ex.js_message();
 
 			showRedScreenOfDeath(os.str());
-#endif
 		}
 	}
 


### PR DESCRIPTION
Fix for [TIMOB-19034](https://jira.appcelerator.org/browse/TIMOB-19034).

```javascript
var win = Ti.UI.createWindow();
win.add(Ti.UI.createLabel({ text: 'Please Wait...' }));
win.open();
setTimeout(function() {
    throw new Error('oh no!');
}, 2000);
```

And

```javascript
var win = Ti.UI.createWindow();
var button = Ti.UI.createButton({
  title: 'PUSH'
});
button.addEventListener('click', function (e) {
    throw new Error('oh no!');
});
win.add(button);
win.open();
```
