### PR TITLE
Parallelize Builds

### DIFF
--- a/Source/Ti/src/TiModule.cpp
+++ b/Source/Ti/src/TiModule.cpp
@@ -36,12 +36,12 @@ namespace TitaniumWindows
 
 	std::string TiModule::buildDate() const TITANIUM_NOEXCEPT
 	{
-		return "__TITANIUM_BUILD_DATE__";
+		return "6/22/2015 15:18";
 	}
 
 	std::string TiModule::buildHash() const TITANIUM_NOEXCEPT
 	{
-		return "__TITANIUM_BUILD_HASH__";
+		return "aac7571";
 	}
 
 }  // namespace TitaniumWindows

--- a/Tools/Scripts/build/build.js
+++ b/Tools/Scripts/build/build.js
@@ -11,23 +11,130 @@ var path = require('path'),
 	exec = require('child_process').exec,
 	spawn = require('child_process').spawn,
 	cmakeLocation = path.join(__dirname, '..', '..', '..', 'cli', 'vendor', 'cmake', 'bin', 'cmake.exe'),
-	MSBuildLocation = "C:/Program Files (x86)/MSBuild/12.0/Bin/MSBuild.exe";
+	MSBuildLocation = 'C:/Program Files (x86)/MSBuild/12.0/Bin/MSBuild.exe';
+
+// Now do the builds
+var rootDir = path.join(__dirname, '..', '..', '..'),
+	titaniumWindowsSrc = path.join(rootDir, 'Source', 'Titanium'),
+	buildRoot = path.join(rootDir, 'build'),
+	distRoot = path.join(rootDir, 'dist', 'windows'),
+	distLib = path.join(distRoot, 'lib'),
+	beQuiet = process.argv.indexOf('--quiet') >= 0,
+	beParallel = process.argv.indexOf('--parallel') >= 0,
+	overallTimer = process.hrtime(),
+	timer = process.hrtime();
+
+async.series([
+	function updateBuildValues(next) {
+		updateBuildValuesInTitaniumModule(path.join(rootDir, 'Source', 'Ti', 'src', 'TiModule.cpp'), next);
+	},
+	function buildAndPackageAll(next) {
+		// TODO Maybe we can be more efficient by running the mocha tests here after we have enough of the libs to run the emulator.		
+		// If they pass, keep building, otherwise exit early?
+		(beParallel ? async.each : async.eachSeries)([
+			{target: 'WindowsPhone', architecture: 'x86'},
+			{target: 'WindowsPhone', architecture: 'ARM'},
+			{target: 'WindowsStore', architecture: 'x86'}
+		], function (configuration, next) {
+			buildAndPackage(titaniumWindowsSrc, buildRoot, distLib, 'Release', configuration.target, configuration.architecture, next);
+		}, next);
+	},
+	function measureTimeElapsed(next) {
+		var elapsed = process.hrtime(timer);
+		console.info('Build and Package Time: %ds %dms', elapsed[0], elapsed[1] / 1000000);
+		timer = process.hrtime();
+		next();
+	},
+	function copyIncludedHeaders(next) {
+		console.log('Copying over include headers...');
+		var newDir = path.join(distLib, 'TitaniumKit', 'include', 'Titanium');
+		wrench.mkdirSyncRecursive(newDir);
+
+		var tasks = [
+			copyDir(path.join(rootDir, 'Source', 'HAL', 'include', 'HAL'), path.join(distLib, 'HAL', 'include', 'HAL')),
+			copyDir(path.join(rootDir, 'Source', 'TitaniumKit', 'include', 'Titanium'), path.join(distLib, 'TitaniumKit', 'include', 'Titanium')),
+			copyDir(path.join(process.env.JavaScriptCore_HOME, 'includes', 'JavaScriptCore'), path.join(distLib, 'HAL', 'include', 'JavaScriptCore')),
+
+			copyDir(path.join(rootDir, 'Source', 'Utility', 'include', 'TitaniumWindows'), path.join(distLib, 'TitaniumWindows_Utility', 'include', 'TitaniumWindows')),
+			copyDir(path.join(rootDir, 'Source', 'LayoutEngine', 'include', 'LayoutEngine'), path.join(distLib, 'LayoutEngine', 'include', 'LayoutEngine')),
+			copyDir(path.join(rootDir, 'Source', 'Titanium', 'include', 'TitaniumWindows'), path.join(distLib, 'TitaniumWindows', 'include', 'TitaniumWindows')),
+
+			copyFile(path.join(rootDir, 'package.json'), path.join(distRoot, 'package.json')),
+			copyDir(path.join(rootDir, 'templates'), path.join(distRoot, 'templates')),
+			// FIXME For some reason, locally this isn't copying all of cli/vendor/cmake/share (specifically cmake-3.1 subfolder)
+			copyDir(path.join(rootDir, 'cli'), path.join(distRoot, 'cli'))
+		];
+
+		var include_TitaniumWindows = ['Filesystem', 'Global', 'Map', 'Media', 'Network', 'Sensors', 'Ti', 'UI'];
+		for (var i = 0; i < include_TitaniumWindows.length; i++) {
+			tasks.push(copyDir(path.join(rootDir, 'Source', include_TitaniumWindows[i], 'include', 'TitaniumWindows'), path.join(distLib, 'TitaniumWindows_' + include_TitaniumWindows[i], 'include', 'TitaniumWindows')));
+		}
+
+		async.parallel(tasks, next);
+	},
+	function measureTimeElapsed(next) {
+		var elapsed = process.hrtime(timer);
+		console.info('Header Copy Time: %ds %dms', elapsed[0], elapsed[1] / 1000000);
+		elapsed = process.hrtime(overallTimer);
+		console.info('Total Time: %ds %dms', elapsed[0], elapsed[1] / 1000000);
+		next();
+	}
+	// TODO Generate docs and copy them over! We should start integrating together all these disparate node scripts into a cohesive set!
+], function (err, results) {
+	if (err) {
+		console.error(err.toString().red);
+		process.exit(1);
+	} else {
+		process.exit(0);
+	}
+});
+
+/**
+ * @param sourceDir The original source directory (in Source/)
+ * @param buildDir Where to build the modules temporarily
+ * @param destDir The top-level destination directory where we copy the built libraries
+ * @param buildType 'Release' || 'Debug'
+ * @param platform 'WindowsPhone' || 'WindowsStore'
+ * @param arch 'x86' || 'ARM'
+ * @param callback what to invoke when done/errored
+ */
+function buildAndPackage(sourceDir, buildDir, destDir, buildType, platform, arch, callback) {
+	var platformAbbrev = (platform == 'WindowsPhone') ? 'phone' : 'store';
+	console.log('Building ' + platform + ' 8.1 ' + arch + ': ' + buildType);
+	async.series([
+		function (next) {
+			runCMake(sourceDir, path.join(buildDir, platformAbbrev, arch), buildType, platform, arch, next);
+		},
+		function (next) {
+			runMSBuild(path.join(buildDir, platformAbbrev, arch, 'TitaniumWindows.sln'), buildType, arch, next);
+		},
+		function (next) {
+			copyToDistribution(buildDir, destDir, buildType, platform, arch, next);
+		}
+	], function (err, results) {
+		if (err) {
+			callback(err);
+		} else {
+			// Wipe the build dir if everything went well. Don't remove top-level build root, because previous build steps may have added results we care about there (i.e. CTest)
+			wrench.rmdirSyncRecursive(path.join(buildDir, platformAbbrev, arch));
+			callback();
+		}
+	});
+}
 
 /**
  * @param tiModuleCPP the file to update
- * @param callback what to invoke when done/errored 
+ * @param callback what to invoke when done/errored
  */
-function updateBuildValuesInTitaniumModule(tiModuleCPP, callback)
-{
-	var prc = exec('git show --abbrev-commit --no-color', { cwd: path.dirname(tiModuleCPP) }, function (error, stdout, stderr) {
-		var githash;
+function updateBuildValuesInTitaniumModule(tiModuleCPP, callback) {
+	exec('git show --abbrev-commit --no-color', {cwd: path.dirname(tiModuleCPP)}, function (error, stdout, stderr) {
 		if (error) {
 			return callback('Failed to get Git HASH: ' + error);
 		}
 
-		githash = stdout.substring(7, 15).trim(); // drop leading 'commit ', just take 7-character sha
+		var githash = stdout.substring(7, 15).trim(); // drop leading 'commit ', just take 7-character sha
 
-		fs.readFile(tiModuleCPP, function(err, data) {
+		fs.readFile(tiModuleCPP, function (err, data) {
 			var contents,
 				timestamp,
 				date;
@@ -35,7 +142,7 @@ function updateBuildValuesInTitaniumModule(tiModuleCPP, callback)
 				return callback('Failed to get contents of TiModule.cpp to replace hard-coded values: ' + error);
 			}
 			date = new Date();
-			timestamp = (date.getMonth() + 1) + "/" + date.getDate() + "/" + date.getYear() + " " + date.getHours() + ":" + date.getMinutes();
+			timestamp = (date.getMonth() + 1) + "/" + date.getDate() + "/" + date.getFullYear() + " " + date.getHours() + ":" + date.getMinutes();
 
 			contents = data.toString();
 			// FIXME How can we set the version? It doesn't get set until later _after_ we've built! We'll need to pull it in from some file!
@@ -51,11 +158,10 @@ function updateBuildValuesInTitaniumModule(tiModuleCPP, callback)
  * @param buildType 'Release' || 'Debug'
  * @param platform 'WindowsPhone' || 'WindowsStore'
  * @param arch 'x86' || 'ARM'
- * @param callback what to invoke when done/errored 
+ * @param callback what to invoke when done/errored
  */
 function runCMake(sourceDir, buildDir, buildType, platform, arch, callback) {
-	var prc,
-		generator = 'Visual Studio 12 2013';
+	var generator = 'Visual Studio 12 2013';
 
 	// If the buildDir already exists, wipe it
 	if (fs.existsSync(buildDir)) {
@@ -67,73 +173,43 @@ function runCMake(sourceDir, buildDir, buildType, platform, arch, callback) {
 		generator += ' ARM';
 	}
 
-	prc = spawn(cmakeLocation, [
-			'-G', generator,
-			'-DCMAKE_SYSTEM_NAME=' + platform,
-			'-DCMAKE_BUILD_TYPE=' + buildType,
-			'-DCMAKE_SYSTEM_VERSION=8.1', 
-			'-DTitaniumWindows_DISABLE_TESTS=ON',
-			'-DTitaniumWindows_Ti_DISABLE_TESTS=ON',
-			'-DTitaniumWindows_Global_DISABLE_TESTS=ON',
-			'-DTitaniumWindows_Sensors_DISABLE_TESTS=ON',
-			'-DTitaniumWindows_UI_DISABLE_TESTS=ON',
-			'-DTitaniumWindows_Utility_DISABLE_TESTS=ON',
-			'-DTitaniumWindows_Map_DISABLE_TESTS=ON',
-			'-DTitaniumWindows_Media_DISABLE_TESTS=ON',
-			'-DHAL_DISABLE_TESTS=ON',
-			'-DTitaniumKit_DISABLE_TESTS=ON',
-			'-Wno-dev',
-			sourceDir
-		],
-		{
-			cwd: buildDir
-	});
-	prc.stdout.on('data', function (data) {
-		console.log(data.toString().trim());
-	});
-	prc.stderr.on('data', function (data) {
-		console.log(data.toString().trim().red);
-	});
+	var args = [
+		'-G', generator,
+		'-DCMAKE_SYSTEM_NAME=' + platform,
+		'-DCMAKE_BUILD_TYPE=' + buildType,
+		'-DCMAKE_SYSTEM_VERSION=8.1',
+		'-DTitaniumWindows_DISABLE_TESTS=ON',
+		'-DTitaniumWindows_Ti_DISABLE_TESTS=ON',
+		'-DTitaniumWindows_Global_DISABLE_TESTS=ON',
+		'-DTitaniumWindows_Sensors_DISABLE_TESTS=ON',
+		'-DTitaniumWindows_UI_DISABLE_TESTS=ON',
+		'-DTitaniumWindows_Utility_DISABLE_TESTS=ON',
+		'-DTitaniumWindows_Map_DISABLE_TESTS=ON',
+		'-DTitaniumWindows_Media_DISABLE_TESTS=ON',
+		'-DHAL_DISABLE_TESTS=ON',
+		'-DTitaniumKit_DISABLE_TESTS=ON',
+		'-Wno-dev',
+		sourceDir
+	];
 
-	prc.on('close', function (code) {
-		if (code != 0) {
-			callback("Failed to run CMake");
-		} else {
-			callback();
-		}
-	});
+	var options = {cwd: buildDir};
+	spawnWithArgs('CMake', cmakeLocation, args, options, callback);
 }
 
 /**
  * @param slnFile The VS solution file to build.
  * @param buildType 'Release' || 'Debug'
  * @param arch 'x86' || 'ARM'
- * @param callback what to invoke when done/errored 
+ * @param callback what to invoke when done/errored
  */
 function runMSBuild(slnFile, buildType, arch, callback) {
-	var prc,
-		args = ['/p:Configuration=' + buildType];
-
+	var args = ['/p:Configuration=' + buildType];
 	if ('ARM' == arch) {
 		args.unshift('/p:Platform=ARM');
 	}
 	args.unshift(slnFile);
-
-	prc = spawn(MSBuildLocation, args);
-	prc.stdout.on('data', function (data) {
-		console.log(data.toString().trim());
-	});
-	prc.stderr.on('data', function (data) {
-		console.log(data.toString().trim().red);
-	});
-
-	prc.on('close', function (code) {
-		if (code != 0) {
-			callback("Failed to run MSBuild");
-		} else {
-			callback();
-		}
-	});
+	beParallel && args.push('/m');
+	spawnWithArgs('MSBuild', MSBuildLocation, args, {}, callback);
 }
 
 /**
@@ -142,7 +218,7 @@ function runMSBuild(slnFile, buildType, arch, callback) {
  * @param buildType 'Release' || 'Debug'
  * @param platform 'WindowsPhone' || 'WindowsStore'
  * @param arch 'x86' || 'ARM'
- * @param callback what to invoke when done/errored 
+ * @param callback what to invoke when done/errored
  */
 function copyToDistribution(sourceDir, destDir, buildType, platform, arch, callback) {
 	var platformAbbrev = (platform == 'WindowsPhone') ? 'phone' : 'store',
@@ -191,7 +267,7 @@ function copyToDistribution(sourceDir, destDir, buildType, platform, arch, callb
 			forceDelete: true, // Whether to overwrite existing directory or not
 			preserveTimestamps: true, // Preserve the mtime and atime when copying files
 			// FIXME This seems to be copying over everything for TitaniumWindows artifacts, but not sub-libraries
-			include: new RegExp(lib + "\.*") // Include the library's artifacts regardless of file extension
+			include: new RegExp(lib + '\.*') // Include the library's artifacts regardless of file extension
 		});
 		// Copy the export header!
 		header = lib.toLowerCase() + '_export.h';
@@ -201,109 +277,67 @@ function copyToDistribution(sourceDir, destDir, buildType, platform, arch, callb
 	callback();
 }
 
-/**
- * @param sourceDir The original source directory (in Source/)
- * @param buildDir Where to build the modules temporarily
- * @param destDir The top-level destination directory where we copy the built libraries
- * @param buildType 'Release' || 'Debug'
- * @param platform 'WindowsPhone' || 'WindowsStore'
- * @param arch 'x86' || 'ARM'
- * @param callback what to invoke when done/errored 
+/*
+ Utility methods (not used elsewhere).
  */
-function buildAndPackage(sourceDir, buildDir, destDir, buildType, platform, arch, callback) {
-	var platformAbbrev = (platform == 'WindowsPhone') ? 'phone' : 'store';
-	console.log("Building " + platform + " 8.1 " + arch + ": " + buildType);
-	async.series([
-		function (next) {
-			runCMake(sourceDir, path.join(buildDir, platformAbbrev, arch), buildType, platform, arch, next);
-		},
-		function (next) {
-			runMSBuild(path.join(buildDir, platformAbbrev, arch, 'TitaniumWindows.sln'), buildType, arch, next);
-		},
-		function (next) {
-			copyToDistribution(buildDir, destDir, buildType, platform, arch, next);
-		}
-	], function (err, results) {
-		if (err) {
-			callback(err);
+
+/**
+ * Spawns the specified file with its args, logging its output, and executing the callback when it has finished.
+ * @param name
+ * @param file
+ * @param args
+ * @param options
+ * @param callback
+ */
+function spawnWithArgs(name, file, args, options, callback) {
+	var child = spawn(file, args, options);
+	child.stdout.on('data', function (data) {
+		beQuiet || console.log(data.toString().trim());
+	});
+	child.stderr.on('data', function (data) {
+		console.log(data.toString().trim().red);
+	});
+	child.on('close', function (code) {
+		if (code != 0) {
+			callback('Failed to run ' + name);
 		} else {
-			// Wipe the build dir if everything went well. Don't remove top-level build root, because previous build steps may have added results we care about there (i.e. CTest)
-			wrench.rmdirSyncRecursive(path.join(buildDir, platformAbbrev, arch));
 			callback();
 		}
 	});
 }
 
-// Now do the builds
-var rootDir = path.join(__dirname, '..', '..', '..'),
-	titaniumWindowsSrc = path.join(rootDir, 'Source', 'Titanium'),
-	buildRoot = path.join(rootDir, 'build'),
-	distRoot = path.join(rootDir, 'dist', 'windows'),
-	distLib = path.join(distRoot, 'lib');
+/**
+ * Recursively copies a directory.
+ * @param from
+ * @param to
+ */
+function copyDir(from, to) {
+	return function (next) {
+		wrench.copyDirRecursive(from, to, {forceDelete: true}, function (err) {
+			if (err) {
+				next(err);
+			}
+			else {
+				next();
+			}
+		});
+	};
+}
 
-async.series([
-	function (next) {
-		updateBuildValuesInTitaniumModule(path.join(rootDir, 'Source', 'Ti', 'src', 'TiModule.cpp'), next);
-	},
-	function (next) {
-		buildAndPackage(titaniumWindowsSrc, buildRoot, distLib, 'Release', 'WindowsPhone', 'x86', next);
-	},
-	// TODO Maybe we can be more efficient by running the mocha tests here after we have enough of the libs to run the emulator.		
-	// If they pass, keep building, otherwise exit early?
-	function (next) {
-		buildAndPackage(titaniumWindowsSrc, buildRoot, distLib, 'Release', 'WindowsPhone', 'ARM', next);
-	},
-	function (next) {
-		buildAndPackage(titaniumWindowsSrc, buildRoot, distLib, 'Release', 'WindowsStore', 'x86', next);
-	},
-	// TODO Do all these others async. Use async.parallel, and use non-sync versions of file ops!
-	function (next) {
-		console.log("Copying over include headers...");
-		wrench.copyDirSyncRecursive(path.join(rootDir, 'Source', 'HAL', 'include', 'HAL'), path.join(distLib, 'HAL', 'include', 'HAL'));
-		wrench.copyDirSyncRecursive(path.join(rootDir, 'Source', 'TitaniumKit', 'include', 'Titanium'), path.join(distLib, 'TitaniumKit', 'include', 'Titanium'));
-
-		// Copy over the JSC headers to HAL!
-		wrench.copyDirSyncRecursive(path.join(process.env.JavaScriptCore_HOME, 'includes', 'JavaScriptCore'), path.join(distLib, 'HAL', 'include', 'JavaScriptCore'));
-
-		wrench.copyDirSyncRecursive(path.join(rootDir, 'Source', 'Utility', 'include', 'TitaniumWindows'), path.join(distLib, 'TitaniumWindows_Utility', 'include', 'TitaniumWindows'));
-		wrench.copyDirSyncRecursive(path.join(rootDir, 'Source', 'LayoutEngine', 'include', 'LayoutEngine'), path.join(distLib, 'LayoutEngine', 'include', 'LayoutEngine'));
-		wrench.copyDirSyncRecursive(path.join(rootDir, 'Source', 'Titanium', 'include', 'TitaniumWindows'), path.join(distLib, 'TitaniumWindows', 'include', 'TitaniumWindows'));
-
-		var include_TitaniumWindows = ['UI', 'Filesystem', 'Global', 'Filesystem', 'Map', 'Media', 'Network', 'Sensors', 'Ti' ];
-		for (var i = 0; i < include_TitaniumWindows.length; i++) {
-			wrench.copyDirSyncRecursive(path.join(rootDir, 'Source', include_TitaniumWindows[i], 'include', 'TitaniumWindows'), path.join(distLib, 'TitaniumWindows_'+include_TitaniumWindows[i], 'include', 'TitaniumWindows'));
-		}
-		
-		next();
-	},
-	function (next) {
-		console.log("Copying over package.json...");
-		fs.writeFileSync(path.join(distRoot, 'package.json'), fs.readFileSync(path.join(rootDir, 'package.json')));
-		next();
-	},
-	function (next) {
-		console.log("Copying over templates...");
-		if (fs.existsSync(path.join(distRoot, 'templates'))) {
-			wrench.rmdirSyncRecursive(path.join(distRoot, 'templates'));
-		}
-		wrench.copyDirSyncRecursive(path.join(rootDir, 'templates'), path.join(distRoot, 'templates'));
-		next();
-	},
-	function (next) {
-		console.log("Copying over CLI...");
-		if (fs.existsSync(path.join(distRoot, 'cli'))) {
-			wrench.rmdirSyncRecursive(path.join(distRoot, 'cli'));
-		}
-		// FIXME For some reason, locally this isn't copying all of cli/vendor/cmake/share (specifically cmake-3.1 subfolder)
-		wrench.copyDirSyncRecursive(path.join(rootDir, 'cli'), path.join(distRoot, 'cli'));
-		next();
-	},
-	// TODO Generate docs and copy them over! We should start integrating together all these disparate node scripts into a cohesive set!
-], function (err, results) {
-	if (err) {
-		console.error(err.toString().red);
-		process.exit(1);
-	} else {
-		process.exit(0);
-	}
-});
+/**
+ * Copies a file.
+ * @param from
+ * @param to
+ */
+function copyFile(from, to) {
+	return function (next) {
+		fs.createReadStream(from).pipe(fs.createWriteStream(to)).on('finish', function (err) {
+			if (err) {
+				next(err);
+			}
+			else {
+				next();
+			}
+		});
+	};
+}


### PR DESCRIPTION
Build for the various targets and architectures in parallel, and then copy over the various files in parallel. Builds take about 30 minutes for me using this, and they _appear_ to work as normal. (I say _appear_
 because I'm just poking around with an app to test.)