### PR TITLE
Fix to actually set request headers before making the request.

### DIFF
--- a/Examples/NMocha/src/Assets/ti.network.httpclient.test.js
+++ b/Examples/NMocha/src/Assets/ti.network.httpclient.test.js
@@ -102,19 +102,29 @@ describe("Titanium.Network.HTTPClient", function () {
         xhr.send();
     });
 
-    it.skip("requestHeaderMethods", function (finish) {
+    it("requestHeaderMethods", function (finish) {
         this.timeout(3e4);
         var xhr = Ti.Network.createHTTPClient();
         xhr.setTimeout(3e4);
         xhr.onload = function (e) {
-            //TODO: set up a server that parrots back the request headers so
-            //that we can verfiy what we actually send.
+            var response;
+            should(e.code).eql(0);
+            if (xhr.status == 200) {
+                should(e.success).eql(true);
+
+                response = JSON.parse(xhr.responseText);
+                response['adhocHeader'].should.eql('notcleared');
+                response.should.not.have.property('clearedHeader');
+            } else if (xhr.status != 503) { // service unavailable (over quota)
+                fail("Received unexpected response: " + xhr.status);
+                return;
+            }
             finish();
         };
         xhr.onerror = function (e) {
-            should(e).should.be.type('undefined');
+            should(e).be.type('undefined');
         };
-        xhr.open("GET", "http://www.appcelerator.com");
+        xhr.open("GET", "http://headers.jsontest.com/");
         xhr.setRequestHeader("adhocHeader", "notcleared");
         xhr.setRequestHeader("clearedHeader", "notcleared");
         should(function () {

--- a/Source/Network/src/HTTPClient.cpp
+++ b/Source/Network/src/HTTPClient.cpp
@@ -140,18 +140,24 @@ namespace TitaniumWindows
 
 		void HTTPClient::send(Windows::Web::Http::IHttpContent^ content)
 		{
-			Windows::Foundation::Uri ^ uri = ref new Windows::Foundation::Uri(TitaniumWindows::Utility::ConvertString(location__));
-
-			Windows::Foundation::IAsyncOperationWithProgress<Windows::Web::Http::HttpResponseMessage^, Windows::Web::Http::HttpProgress>^ operation;
+			auto uri = ref new Windows::Foundation::Uri(TitaniumWindows::Utility::ConvertString(location__));
+			
+			// Set up the request
+			Windows::Web::Http::HttpRequestMessage^ request;
 			if (method__ == Titanium::Network::RequestMethod::Post) {
-				operation = httpClient__->PostAsync(uri, content);
+				request = ref new Windows::Web::Http::HttpRequestMessage(Windows::Web::Http::HttpMethod::Post, uri);
+				request->Content = content;
 			} else if (method__ == Titanium::Network::RequestMethod::Put) {
-				operation = httpClient__->PutAsync(uri, content);
+				request = ref new Windows::Web::Http::HttpRequestMessage(Windows::Web::Http::HttpMethod::Put, uri);
+				request->Content = content;
 			} else if (method__ == Titanium::Network::RequestMethod::Delete) {
-				operation = httpClient__->DeleteAsync(uri);
+				request = ref new Windows::Web::Http::HttpRequestMessage(Windows::Web::Http::HttpMethod::Delete, uri);
 			} else {
-				operation = httpClient__->GetAsync(uri);
+				request = ref new Windows::Web::Http::HttpRequestMessage(Windows::Web::Http::HttpMethod::Get, uri);
 			}
+			setRequestHeaders(request);
+
+			auto operation = httpClient__->SendRequestAsync(request);
 
 			// Startup a timer that will abort the request after the timeout period is reached.
 			startDispatcherTimer();

--- a/Source/TitaniumKit/src/Network/HTTPClient.cpp
+++ b/Source/TitaniumKit/src/Network/HTTPClient.cpp
@@ -321,10 +321,14 @@ namespace Titanium
 		TITANIUM_FUNCTION(HTTPClient, setRequestHeader)
 		{
 			const auto _0 = arguments.at(0);
+			TITANIUM_ASSERT(_0.IsString());
 			const auto _1 = arguments.at(1);
-			TITANIUM_ASSERT(_0.IsString() && _1.IsString());
+			TITANIUM_ASSERT(_1.IsString() || _1.IsNull());
 			const auto name = static_cast<std::string>(_0);
-			const auto value = static_cast<std::string>(_1);
+			std::string value;
+			if (!_1.IsNull()) {
+				value = static_cast<std::string>(_1);
+			}
 			setRequestHeader(name, value);
 			return get_context().CreateUndefined();
 		}


### PR DESCRIPTION
We used to set HTTP request headers for GET only, then when I refactored for the fix recently even that got removed. This is an attempt to bring it back for all request methods.