### PR TITLE
Fix TIMOB-19044 Windows: Accessing a sliders value always returns 0

### DIFF
--- a/Source/TitaniumKit/src/UI/Slider.cpp
+++ b/Source/TitaniumKit/src/UI/Slider.cpp
@@ -44,7 +44,7 @@ namespace Titanium
 
 		TITANIUM_PROPERTY_GETTER(Slider, max)
 		{
-			return get_context().CreateNumber(max__);
+			return get_context().CreateNumber(get_max());
 		}
 
 		TITANIUM_PROPERTY_SETTER(Slider, max)
@@ -56,7 +56,7 @@ namespace Titanium
 
 		TITANIUM_PROPERTY_GETTER(Slider, min)
 		{
-			return get_context().CreateNumber(min__);
+			return get_context().CreateNumber(get_min());
 		}
 
 		TITANIUM_PROPERTY_SETTER(Slider, min)
@@ -68,7 +68,7 @@ namespace Titanium
 
 		TITANIUM_PROPERTY_GETTER(Slider, value)
 		{
-			return get_context().CreateNumber(value__);
+			return get_context().CreateNumber(get_value());
 		}
 
 		TITANIUM_PROPERTY_SETTER(Slider, value)

--- a/Source/UI/include/TitaniumWindows/UI/Slider.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/Slider.hpp
@@ -42,6 +42,7 @@ namespace TitaniumWindows
 
 			virtual void set_max(const double& max) TITANIUM_NOEXCEPT override final;
 			virtual void set_min(const double& min) TITANIUM_NOEXCEPT override final;
+			virtual double get_value() const TITANIUM_NOEXCEPT override final;
 			virtual void set_value(const double& value) TITANIUM_NOEXCEPT override final;
 
 			virtual void enableEvent(const std::string& event_name) TITANIUM_NOEXCEPT override final;

--- a/Source/UI/src/Slider.cpp
+++ b/Source/UI/src/Slider.cpp
@@ -47,6 +47,11 @@ namespace TitaniumWindows
 			slider__->Minimum = min;
 		}
 
+		double Slider::get_value() const TITANIUM_NOEXCEPT
+		{
+			return slider__->Value;
+		}
+
 		void Slider::set_value(const double& value) TITANIUM_NOEXCEPT
 		{
 			Titanium::UI::Slider::set_value(value);


### PR DESCRIPTION
The problem is that we need to override the getter for value in the Windows subclass to always return the value from the widget itself, rather than just parrot back the internal value field (which is only changed by the property setter, not from actually manipulating the widget).

https://jira.appcelerator.org/browse/TIMOB-19044