### PR TITLE
ti.windows.publishername tweaks

### DIFF
--- a/Tools/Scripts/build/test.js
+++ b/Tools/Scripts/build/test.js
@@ -100,25 +100,6 @@ function generateWindowsProject(next) {
 	});
 }
 
-// Add required properties
-function addTiAppProperties(next) {
-	var tiapp_xml = path.join(__dirname, 'mocha', 'tiapp.xml'),
-		publishername = '<property name="ti.windows.publishername" type="string">CN=Dawson Toth</property>';
-
-	// Not so smart but this should work...
-	var content = [];
-	fs.readFileSync(tiapp_xml).toString().split(/\r?\n/).forEach(function(line){
-		content.push(line);
-		if (line.indexOf('<guid>') >= 0) {
-			content.push('\t'+publishername);
-			content.push('\t<windows><manifest><Capabilities><Capability Name=\"internetClient\" /></Capabilities></manifest></windows>');
-		}
-	});
-	fs.writeFileSync(tiapp_xml, content.join('\n'));
-
-	next();
-}
-
 function copyMochaAssets(next) {
 	var mochaAssetsDir = path.join(__dirname, '..', '..', '..', 'Examples', 'NMocha', 'src', 'Assets'),
 		dest = path.join(__dirname, 'mocha', 'Resources');
@@ -254,10 +235,6 @@ async.series([
 	function (next) {
 		console.log("Generating Windows project");
 		generateWindowsProject(next);
-	},
-	function (next) {
-		console.log("Adding properties for tiapp.xml");
-		addTiAppProperties(next);
 	},
 	function (next) {
 		console.log("Copying test scripts into project");

--- a/cli/commands/_build/generate.js
+++ b/cli/commands/_build/generate.js
@@ -163,6 +163,7 @@ function generateCmakeList(next) {
 		native_modules = [];
 
 	this.logger.info(__('Writing CMakeLists.txt: %s', this.cmakeListFile.cyan));
+
 	// TODO If forceBuild is false AND no assets have changed, then we can skip this and the cmake step, I think!
 	function getFilesRecursive(folder) {
 		var fileContents = fs.readdirSync(folder),
@@ -238,7 +239,7 @@ function generateCmakeList(next) {
 			version: this.tiapp.version,
 			assets: assetList.join('\n'),
 			publisherDisplayName: this.cli.tiapp.publisher,
-			publisherName: this.cli.tiapp.properties['ti.windows.publishername'].value,
+			publisherName: this.publisherName,
 			appId: this.cli.tiapp.id,
 			sourceGroups: sourceGroups,
 			native_modules: native_modules

--- a/cli/commands/_build/validate.js
+++ b/cli/commands/_build/validate.js
@@ -93,6 +93,30 @@ function validate(logger, config, cli) {
 		process.exit(1);
 	}
 
+	// check the publisher name
+	this.publisherName = cli.tiapp.properties['ti.windows.publishername'];
+	if (!this.publisherName || !this.publisherName.value) {
+		if (cli.tiapp.publisher) {
+			this.logger.warn(__(
+				'ti.windows.publishername is a required tiapp.xml string property for publishing! We will default to a value generated from tiapp.publisher value.' +
+				'\nFor example:' +
+				'\n<property name="ti.windows.publishername" type="string">CN=' + cli.tiapp.publisher + '</property>'
+			));
+			this.publisherName = "CN=" + cli.tiapp.publisher;
+		}
+		else {
+			logger.error(__(
+				'ti.windows.publishername is a required tiapp.xml string property for publishing!' +
+				'\nFor example:' +
+				'\n<property name="ti.windows.publishername" type="string">CN=Appcelerator Inc.</property>'
+			));
+			logger.log();
+			process.exit(1);
+		}
+	} else {
+		this.publisherName = this.publisherName.value;
+	}
+
 	// check that the build directory is writeable
 	// try to build under temp if the path is shorter and we have write access
 	var tempBuildDir = path.join(os.tmpdir());

--- a/cli/hooks/ws-package.js
+++ b/cli/hooks/ws-package.js
@@ -31,18 +31,8 @@ exports.init = function (logger, config, cli) {
 			}
 
 			var projectDir = builder.projectDir,
-				publisherName = builder.tiapp.properties['ti.windows.publishername'],
 				wSDK = builder.windowsInfo.windows[builder.wpsdk],
 				wsCert = builder.wsCert;
-
-			if (!publisherName || !publisherName.value) {
-				return next(new Error(__(
-					'ti.windows.publishername is a required tiapp.xml string property for publishing!' +
-					'\nFor example:' +
-					'\n<property name="ti.windows.publishername" type="string">CN=Appcelerator Inc.</property>'
-				)));
-			}
-			publisherName = publisherName.value;
 
 			if (wsCert) {
 				builder.certificatePath = wsCert;
@@ -69,7 +59,7 @@ exports.init = function (logger, config, cli) {
 					logger.info('');
 					logger.info(__('Creating a certificate'));
 					logger.info(__('Please follow the prompts'));
-					windowslib.certs.generate(publisherName, cer, builder.windowslibOptions, function(err, privateKey, certFile) {
+					windowslib.certs.generate(builder.publisherName, cer, builder.windowslibOptions, function(err, privateKey, certFile) {
 						return !err ? next() : next(err || new Error('Certificate generation failed'));
 					});
 				},


### PR DESCRIPTION
We attempt to use the value if it's there in tiapp, otherwise we generate one with"CN=" + tiapp.publisher (and log a warning). If there's no publisher (display name) then we show an error message about needing the value and exit with error code 1.

https://jira.appcelerator.org/browse/TIMOB-19009
https://jira.appcelerator.org/browse/TIMOB-19025