### PR TITLE
Error log should be debug log

### DIFF
--- a/Source/TitaniumKit/src/Module.cpp
+++ b/Source/TitaniumKit/src/Module.cpp
@@ -216,7 +216,7 @@ namespace Titanium
 			}
 		}
 
-		TITANIUM_LOG_ERROR("Module::eventListenerIndex: index = ", index, " for event '", name, "'");
+		TITANIUM_LOG_DEBUG("Module::eventListenerIndex: index = ", index, " for event '", name, "'");
 		return index;
 	}
 


### PR DESCRIPTION
These logs should be debug logs and not error logs.

```
TitaniumKit 000000120 Mon Jun 22 16:03:50 2015 ERROR: Module::eventListenerIndex: index = 0 for event 'click'.
```