### PR TITLE
[TIMOB-19048] Word wrap on labels does not work if width and height are not set

### DIFF
--- a/Source/UI/src/Label.cpp
+++ b/Source/UI/src/Label.cpp
@@ -47,8 +47,10 @@ namespace TitaniumWindows
 			label__->VerticalAlignment = Windows::UI::Xaml::VerticalAlignment::Center;
 			label__->FontSize = DefaultFontSize;
 
-			getViewLayoutDelegate<WindowsViewLayoutDelegate>()->setComponent(label__);
+			getViewLayoutDelegate<WindowsViewLayoutDelegate>()->set_defaultWidth(Titanium::UI::LAYOUT::FILL);
+			getViewLayoutDelegate<WindowsViewLayoutDelegate>()->set_defaultHeight(Titanium::UI::LAYOUT::FILL);
 
+			getViewLayoutDelegate<WindowsViewLayoutDelegate>()->setComponent(label__);
 		}
 
 		void Label::JSExportInitialize()


### PR DESCRIPTION
- Set default ```width``` and ```height``` to ```Ti.UI.FILL```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-19048)