### PR TITLE
Fix compile error in TitaniumKit on Travis

### DIFF
--- a/Source/TitaniumKit/include/Titanium/detail/TiUtil.hpp
+++ b/Source/TitaniumKit/include/Titanium/detail/TiUtil.hpp
@@ -23,8 +23,6 @@ namespace Titanium
 			return std::unique_ptr<T>(new T(std::forward<Ts>(params)...));
 		}
 
-		using namespace HAL;
-
 		// Log and throw a std::logic_error from an internal component.
 		TITANIUMKIT_EXPORT void ThrowLogicError(const std::string& internal_component_name, const std::string& message);
 		TITANIUMKIT_EXPORT void ThrowRuntimeError(const std::string& internal_component_name, const std::string& message);


### PR DESCRIPTION
Currently all PR is failing because Travis build is failing at `TitaniumKit`.