### PR TITLE
Fix: AlertDialog.show() fails with "unknown error" message

### DIFF
--- a/Source/UI/src/AlertDialog.cpp
+++ b/Source/UI/src/AlertDialog.cpp
@@ -50,17 +50,21 @@ namespace TitaniumWindows
 				dialog->Commands->Append(ref new Windows::UI::Popups::UICommand(TitaniumWindows::Utility::ConvertUTF8String(buttonNames__[i]), nullptr, PropertyValue::CreateInt32(i)));
 			}
 
-			concurrency::create_task(dialog->ShowAsync()).then([this](IUICommand^ command) {
-				std::int32_t index = 0;
-				if (command != nullptr) {
-					index = dynamic_cast<IPropertyValue^>(command->Id)->GetInt32();
-				}
-				const JSContext ctx = get_context();
-				JSObject eventArgs = ctx.CreateObject();
-				eventArgs.SetProperty("index", ctx.CreateNumber(index));
-				eventArgs.SetProperty("cancel", ctx.CreateBoolean(index == get_cancel()));
-				fireEvent("click", eventArgs);
-			});
+			try {
+				concurrency::create_task(dialog->ShowAsync()).then([this](IUICommand^ command) {
+					std::int32_t index = 0;
+					if (command != nullptr) {
+						index = dynamic_cast<IPropertyValue^>(command->Id)->GetInt32();
+					}
+					const JSContext ctx = get_context();
+					JSObject eventArgs = ctx.CreateObject();
+					eventArgs.SetProperty("index", ctx.CreateNumber(index));
+					eventArgs.SetProperty("cancel", ctx.CreateBoolean(index == get_cancel()));
+					fireEvent("click", eventArgs);
+				});
+			} catch (...) {
+				detail::ThrowRuntimeError("Ti.UI.AlertDialog", "Exception during show()");
+			}
 		}
 	} // namespace UI
 } // namespace TitaniumWindows


### PR DESCRIPTION
Fix for [TIMOB-19065](https://jira.appcelerator.org/browse/TIMOB-19065)

Following code should show Application Error dialog on debug mode with appropriate error message. Originally I thought we could check number of buttons available and assert when it's too much, but it turns out  there's no documentation on limitation of the number [according to Microsoft](https://msdn.microsoft.com/en-us/library/windows/apps/windows.ui.popups.messagedialog.commands). So we just can check if it throws exception and re-throw it with error message.


```javascript
var win = Ti.UI.createWindow();
var button = Ti.UI.createButton({ title: 'PUSH' });

button.addEventListener('click', function () {
    Ti.UI.createAlertDialog({
        title: 'Title',
        message: 'Message',
        buttonNames: ['A', 'B', 'C']
    }).show();
});

win.add(button);
win.open();
```