### PR TITLE
[TIMOB-19038] Throw descriptive runtime error when adding a child to multiple parent views

### DIFF
--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -16,6 +16,8 @@
 #include <cctype>
 #include <collection.h>
 
+#include "TitaniumWindows/Utility.hpp"
+
 #define _USE_MATH_DEFINES
 #include <math.h>
 
@@ -60,8 +62,11 @@ namespace TitaniumWindows
 				if (isLoaded()) {
 					requestLayout();
 				}
-
-				nativeView->Children->Append(nativeChildView);
+				try {
+					nativeView->Children->Append(nativeChildView);
+				} catch(Platform::Exception^ e) {
+					detail::ThrowRuntimeError("add", Utility::ConvertString(e->Message));
+				}
 			} else {
 				TITANIUM_LOG_WARN("WindowsViewLayoutDelegate::add: Unknown child component");
 			}


### PR DESCRIPTION
- Throw runtime error when attempting to add a single instance of a child element to multiple views.

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-19038)