### PR TITLE
Fix TIMOB-19052 Windows: ti create for modules with long paths fails with cryptic errors

### DIFF
--- a/cli/commands/_buildModule.js
+++ b/cli/commands/_buildModule.js
@@ -146,12 +146,27 @@ WindowsModuleBuilder.prototype.compileModule = function compileModule(next) {
 	var _t = this;
 
 	function build(sln, config, arch, next) {
+		var nativeAssetsDir = path.dirname(sln),
+			vcxproj = path.join(nativeAssetsDir, _t.manifest.moduleIdAsIdentifier+'.vcxproj'),
+			vcxContent,
+			buildPath;
 		// user may skip specific architecture by using CLI.
 		// at least we are skipping WindowsStore.ARM for now
 		if (!fs.existsSync(sln)) {
 			_t.logger.info('Skipping ' + sln);
 			next();
 			return;
+		}
+
+		vcxContent = fs.readFileSync(vcxproj, 'utf8');
+		// Check the build output dir that the module is set up for.
+		// If it doesn't exist, copy our local copy of everything over to it.
+		buildPath = path.resolve(vcxContent.match(/<OutDir .+?>(.+?)<\/OutDir>/)[1], '..');
+		if (!fs.existsSync(buildPath)) {
+			wrench.mkdirSyncRecursive(buildPath);
+			wrench.copyDirSyncRecursive(nativeAssetsDir, buildPath, {
+				forceDelete: true
+			});
 		}
 
 		var p = spawn(_t.windowsInfo.selectedVisualStudio.vcvarsall, [
@@ -187,8 +202,10 @@ WindowsModuleBuilder.prototype.compileModule = function compileModule(next) {
 	var archs = _t.manifest.architectures.split(' ');
 	async.eachSeries(types, function(type, next_type) {
 		async.eachSeries(archs, function(arch, next_arch) {
-			var architecture = vs_architectures[arch];
-			build(path.resolve(_t.projectDir, type+'.'+architecture, _t.manifest.moduleIdAsIdentifier+'.sln'), configuration, architecture, next_arch);
+			var architecture = vs_architectures[arch],
+				sln = path.resolve(_t.projectDir, type+'.'+architecture, _t.manifest.moduleIdAsIdentifier+'.sln');
+
+			build(sln, configuration, architecture, next_arch);
 		}, function(err) {
 			if (err) {
 				throw err;
@@ -279,7 +296,7 @@ WindowsModuleBuilder.prototype.packageZip = function packageZip(next) {
 			// We may have built in temp because of long path issues!
 			// Check to see if the dll exists in normal spot, if not, fall back to trying temp location!
 			if (!fs.existsSync(moduleSrc + '.dll')) {
-				moduleSrc = path.join(os.tmpdir(), path.basename(_t.projectDir), path.basename(moduleProjectDir), configuration, projectname);
+				moduleSrc = path.join(os.tmpdir(), path.basename(path.dirname(_t.projectDir)), path.basename(moduleProjectDir), configuration, projectname);
 			}
 
 			// create module directory

--- a/cli/commands/_buildModule.js
+++ b/cli/commands/_buildModule.js
@@ -162,11 +162,14 @@ WindowsModuleBuilder.prototype.compileModule = function compileModule(next) {
 		// Check the build output dir that the module is set up for.
 		// If it doesn't exist, copy our local copy of everything over to it.
 		buildPath = path.resolve(vcxContent.match(/<OutDir .+?>(.+?)<\/OutDir>/)[1], '..');
-		if (!fs.existsSync(buildPath)) {
-			wrench.mkdirSyncRecursive(buildPath);
+		if (buildPath != nativeAssetsDir) {
+			fs.existsSync(buildPath) && wrench.rmdirSyncRecursive(buildPath);
+			// make sure destination exists
+			fs.existsSync(buildPath) || wrench.mkdirSyncRecursive(buildPath);
 			wrench.copyDirSyncRecursive(nativeAssetsDir, buildPath, {
 				forceDelete: true
 			});
+			sln = path.join(buildPath, _t.manifest.moduleIdAsIdentifier+'.vcxproj');
 		}
 
 		var p = spawn(_t.windowsInfo.selectedVisualStudio.vcvarsall, [

--- a/templates/module/default/hooks/windows-module.js
+++ b/templates/module/default/hooks/windows-module.js
@@ -12,10 +12,13 @@
 const
 	fs = require('fs'),
 	path = require('path'),
+	appc = require('node-appc'),
+	os = require('os'),
 	wrench = require('wrench'),
 	async = require('async'),
 	ejs = require('ejs'),
-	spawn = require('child_process').spawn;
+	spawn = require('child_process').spawn,
+	__ = appc.i18n(__dirname).__;
 
 exports.cliVersion = '>=3.2';
 
@@ -67,7 +70,21 @@ exports.init = function (logger, config, cli) {
 function runCMake(logger, cmake, projectDir, targetEnv, targetArch, callback){
 	var targetDir = path.join(projectDir, targetEnv+'.'+targetArch),
 		generatorName = 'Visual Studio 12 2013'+(targetArch === 'ARM' ? ' ARM' : ''),
-		p;
+		p,
+		originalTargetDir,
+		tempBuildDir;
+
+	// try to build under temp if the path is shorter and we have write access
+	tempBuildDir = path.join(os.tmpdir(), path.basename(projectDir), path.basename(targetDir));
+	if ((tempBuildDir.length < targetDir.length) && appc.fs.isDirWritable(os.tmpdir())) {
+		originalTargetDir = targetDir;
+		targetDir = tempBuildDir; // build under temp!
+		logger.info(__('Generating solution under temp directory to avoid path length issues...'));
+		// if already exists, wipe it
+		fs.existsSync(targetDir) && wrench.rmdirSyncRecursive(targetDir);
+	} else {
+		originalTargetDir = null;
+	}
 
 	if (!fs.existsSync(targetDir)) {
 		wrench.mkdirSyncRecursive(targetDir);
@@ -93,6 +110,18 @@ function runCMake(logger, cmake, projectDir, targetEnv, targetArch, callback){
 	p.on('close', function (code) {
 		if (code != 0) {
 			process.exit(1);
+		}
+		if (originalTargetDir) {
+			// Copy stuff back to original dir!
+			logger.info(__('Copying solution back to module from temp directory...'));
+			// if already exists, wipe it
+			fs.existsSync(originalTargetDir) && wrench.rmdirSyncRecursive(originalTargetDir);
+			// make sure destination exists
+			fs.existsSync(originalTargetDir) || wrench.mkdirSyncRecursive(originalTargetDir);
+			// Now copy back to original location
+			wrench.copyDirSyncRecursive(targetDir, originalTargetDir, {
+				forceDelete: true
+			});
 		}
 		callback();
 	});

--- a/templates/module/default/hooks/windows-module.js
+++ b/templates/module/default/hooks/windows-module.js
@@ -75,7 +75,7 @@ function runCMake(logger, cmake, projectDir, targetEnv, targetArch, callback){
 		tempBuildDir;
 
 	// try to build under temp if the path is shorter and we have write access
-	tempBuildDir = path.join(os.tmpdir(), path.basename(projectDir), path.basename(targetDir));
+	tempBuildDir = path.join(os.tmpdir(), path.basename(path.dirname(projectDir)), path.basename(targetDir));
 	if ((tempBuildDir.length < targetDir.length) && appc.fs.isDirWritable(os.tmpdir())) {
 		originalTargetDir = targetDir;
 		targetDir = tempBuildDir; // build under temp!

--- a/templates/module/default/template/windows/CMakeLists.txt.ejs
+++ b/templates/module/default/template/windows/CMakeLists.txt.ejs
@@ -115,6 +115,4 @@ write_basic_package_version_file(
   COMPATIBILITY AnyNewerVersion
   )
 
-set_target_properties(<%- moduleIdAsIdentifier %> PROPERTIES VS_WINRT_REFERENCES HAL)
-
 export(PACKAGE <%- moduleIdAsIdentifier %>)


### PR DESCRIPTION
:star:  There's a fix in the CMakeLists.txt template that had a bad reference to HAL that would cause warnings during the build process.

But for the main ticket:
- Before we run cmake, we check to see if running it inside the temp dir would result in a shorter path than running in current location. If so we run in temp dir. Later when we do the build, we check the configured build directory and if it's in temp, we ensure we copy over the stuff we need there if it'snot there still.

