### PR TITLE
Revert #317

### DIFF
--- a/Source/UI/src/Label.cpp
+++ b/Source/UI/src/Label.cpp
@@ -48,9 +48,6 @@ namespace TitaniumWindows
 			label__->VerticalAlignment = Windows::UI::Xaml::VerticalAlignment::Center;
 			label__->FontSize = DefaultFontSize;
 
-			getViewLayoutDelegate<WindowsViewLayoutDelegate>()->set_defaultWidth(Titanium::UI::LAYOUT::FILL);
-			getViewLayoutDelegate<WindowsViewLayoutDelegate>()->set_defaultHeight(Titanium::UI::LAYOUT::FILL);
-
 			getViewLayoutDelegate<WindowsViewLayoutDelegate>()->setComponent(label__);
 		}
 


### PR DESCRIPTION
Revert #317, because it introduces another layout issue. For example it breaks layout of the default app template, the "I am Window 1" label should have been aligned in center of the view but it's not.

Also, I am not sure if [TIMOB-19048](https://jira.appcelerator.org/browse/TIMOB-19048) is valid, because :

- According to [Transitioning to the New UI Layout System](http://docs.appcelerator.com/platform/latest/#!/guide/Transitioning_to_the_New_UI_Layout_System), default layout of `Ti.UI.Label` should be `Ti.UI.SIZE` for both `width` and `height`.
- API document for [Ti.UI.Label](http://docs.appcelerator.com/platform/latest/#!/api/Titanium.UI.Label) doesn't specify how it should resize itself when text is longer than UI width. (For example, should it change its height when width is too short when there's no `width`? Do we need to calculate preferable component size based on text content and font size when there's no `width` and `height` specified?) I think currently it all depends on each platform components' behavior.

Currently layout of following code (the default app template) is broken.

```javascript
var tabGroup = Titanium.UI.createTabGroup();

var win1 = Titanium.UI.createWindow({  
    title:'Tab 1',
    backgroundColor:'#fff'
});
var tab1 = Titanium.UI.createTab({  
    icon:'KS_nav_views.png',
    title:'Tab 1',
    window:win1
});

var label1 = Titanium.UI.createLabel({
	color:'#999',
	text:'I am Window 1',
	font:{fontSize:20,fontFamily:'Helvetica Neue'},
	textAlign:'center',
	width:'auto'
});

win1.add(label1);

var win2 = Titanium.UI.createWindow({  
    title:'Tab 2',
    backgroundColor:'#fff'
});
var tab2 = Titanium.UI.createTab({  
    icon:'KS_nav_ui.png',
    title:'Tab 2',
    window:win2
});

var label2 = Titanium.UI.createLabel({
	color:'#999',
	text:'I am Window 2',
	font:{fontSize:20,fontFamily:'Helvetica Neue'},
	textAlign:'center',
	width:'auto'
});

win2.add(label2);
tabGroup.addTab(tab1);  
tabGroup.addTab(tab2);  

tabGroup.open();
```