### PR TITLE
Fix: Creating windows module errors out due to missing boost libraries

### DIFF
--- a/templates/module/default/template/windows/CMakeLists.txt.ejs
+++ b/templates/module/default/template/windows/CMakeLists.txt.ejs
@@ -34,11 +34,6 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 get_filename_component(APPCELERATOR_CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake ABSOLUTE)
 list(INSERT CMAKE_MODULE_PATH 0 ${APPCELERATOR_CMAKE_MODULE_PATH})
 
-set(Boost_USE_STATIC_LIBS ON )
-set(Boost_USE_MULTITHREADED ON )
-set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.55.0 REQUIRED)
-
 find_package(HAL REQUIRED)
 find_package(TitaniumKit REQUIRED)
 find_package(JavaScriptCore REQUIRED)
@@ -68,11 +63,9 @@ target_include_directories(<%- moduleIdAsIdentifier %> PUBLIC
   $<TARGET_PROPERTY:HAL,INTERFACE_INCLUDE_DIRECTORIES>
   $<TARGET_PROPERTY:TitaniumKit,INTERFACE_INCLUDE_DIRECTORIES>
   ${JavaScriptCore_INCLUDE_DIRS}
-  ${Boost_INCLUDE_DIRS}
   )
 
 target_link_libraries(<%- moduleIdAsIdentifier %>
-  ${Boost_LIBRARIES}
   HAL
   TitaniumKit
   )


### PR DESCRIPTION
Fix for [TIMOB-19108](https://jira.appcelerator.org/browse/TIMOB-19108).
