### PR TITLE
[TIMOB-19107] Fix 64-bit Java support

### DIFF
--- a/cli/commands/_build/encrypt.js
+++ b/cli/commands/_build/encrypt.js
@@ -77,11 +77,11 @@ function processEncryption(next) {
 				return next();
 			}
 
-			if (process.platform !== 'win32' || !/jvm\.dll/i.test(err.msg)) {
+			if (process.platform !== 'win32' || !/jvm\.dll/i.test(err.msg) && !/JAVA_HOME/i.test(err.msg)) {
 				fatal(err);
 			}
 
-			// windows 64-bit failed, try again using 32-bit
+			// windows 32-bit failed, try again using 64-bit
 			this.logger.debug(__('32-bit titanium prep failed, trying again using 64-bit'));
 			titaniumPrep = 'titanium_prep.win64.exe';
 			titaniumPrepHook(

--- a/cli/commands/_build/validate.js
+++ b/cli/commands/_build/validate.js
@@ -177,13 +177,13 @@ function validate(logger, config, cli) {
 			// detect java development kit.
 			appc.jdk.detect(config, null, function (jdkInfo) {
 				if (!jdkInfo.version) {
-					logger.error(__('Unable to locate the Java Development Kit') + '\n');
-					logger.log(__('You can specify the location by setting the %s environment variable.', 'JAVA_HOME'.cyan) + '\n');
+					this.logger.error(__('Unable to locate the Java Development Kit') + '\n');
+					this.logger.log(__('You can specify the location by setting the %s environment variable.', 'JAVA_HOME'.cyan) + '\n');
 					process.exit(1);
 				}
 
 				if (!version.satisfies(jdkInfo.version, this.packageJson.vendorDependencies.java)) {
-					logger.error(__('JDK version %s detected, but only version %s is supported', jdkInfo.version, this.packageJson.vendorDependencies.java) + '\n');
+					this.logger.error(__('JDK version %s detected, but only version %s is supported', jdkInfo.version, this.packageJson.vendorDependencies.java) + '\n');
 					process.exit(1);
 				}
 


### PR DESCRIPTION
- Retry using 64-bit ```titanium_prep``` if 32-bit failed with ```JAVA_HOME``` error, caused by it being set to a 64-bit JRE
- Fix logger in ```validate.js```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-19107)