### PR TITLE
[TIMOB-19119] Fix LayoutEngine 'left, right' and 'top, bottom' scaling

### DIFF
--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -686,8 +686,6 @@ namespace TitaniumWindows
 				rect.width = component->ActualWidth;
 			}
 
-			oldRect__ = Titanium::LayoutEngine::RectMake(rect.x, rect.y, rect.width, rect.height);
-
 			if (is_panel__) {
 				for (auto child : panel->Children) {
 					child->Visibility = Visibility::Collapsed;
@@ -698,10 +696,20 @@ namespace TitaniumWindows
 			}
 
 			if ((!is_panel__ && setWidthOnWidget) || setWidth) {
+				if (layout_node__->properties.left.valueType != Titanium::LayoutEngine::None &&
+					layout_node__->properties.right.valueType != Titanium::LayoutEngine::None &&
+					component->ActualWidth == rect.width) {
+					rect.width = oldRect__.width;
+				}
 				component->Width = rect.width;
 			}
 
 			if ((!is_panel__ && setHeightOnWidget) || setHeight) {
+				if (layout_node__->properties.top.valueType != Titanium::LayoutEngine::None &&
+					layout_node__->properties.bottom.valueType != Titanium::LayoutEngine::None &&
+					component->ActualHeight == rect.height) {
+					rect.height = oldRect__.height;
+				}
 				component->Height = rect.height;
 			}
 
@@ -713,6 +721,8 @@ namespace TitaniumWindows
 					child->Visibility = Visibility::Visible;
 				}
 			}
+
+			oldRect__ = Titanium::LayoutEngine::RectMake(rect.x, rect.y, rect.width, rect.height);
 		}
 
 		void WindowsViewLayoutDelegate::requestLayout(const bool& fire_event)


### PR DESCRIPTION
- Fix ```left, right``` and ```top, bottom``` scaling for sized components such as ```TextField```

###### EXAMPLE
```Javascript
var win = Ti.UI.createWindow({
    backgroundColor: 'blue'
});
var viewA = Ti.UI.createTextField({
    hintText: 'SOME TEXT',
    top: '5dp',
    left: '10dp',
    
    // removing this line should allow the TextField to scale according to its contents
    // retaining this line should scale the TextField to the same size as the red view below
    right: '10dp',
    
    height: '40dp'
});
var viewB = Ti.UI.createView({
    backgroundColor: 'red',
    top: '60dp',
    left: '10dp',
    right: '10dp',
    height: '40dp'
});
win.add(viewA);
win.add(viewB);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-19119)