### PR TITLE
Fix TIMOB-19123 Ti.UI.OptionDialog crashes with unknown exception

### DIFF
--- a/Source/UI/src/OptionDialog.cpp
+++ b/Source/UI/src/OptionDialog.cpp
@@ -46,7 +46,10 @@ namespace TitaniumWindows
 			}
 
 			concurrency::create_task(dialog->ShowAsync()).then([this](IUICommand^ command) {
-				const auto index = dynamic_cast<IPropertyValue^>(command->Id)->GetInt32();
+				std::int32_t index = 0;
+				if (command != nullptr) {
+					index = dynamic_cast<IPropertyValue^>(command->Id)->GetInt32();
+				}
 				const JSContext ctx = get_context();
 				JSObject eventArgs = ctx.CreateObject();
 				eventArgs.SetProperty("index", ctx.CreateNumber(index));


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-19123

Same issue we ran into with AlertDialog and fixed in this commit: https://github.com/appcelerator/titanium_mobile_windows/commit/a5b5306870fb622a49f9f7a2526b43ff47dece7d