### PR TITLE
TIMOB-19127 Windows: Ti.Platform.createUUID() should not have curly brackets

### DIFF
--- a/Examples/NMocha/src/Assets/ti.platform.test.js
+++ b/Examples/NMocha/src/Assets/ti.platform.test.js
@@ -9,8 +9,16 @@ var should = require('./should');
 
 describe("Titanium.Platform", function () {
     it("createUUID", function (finish) {
+        var result;
         should(Ti.Platform.createUUID).be.a.Function;
-        should(Ti.Platform.createUUID()).be.a.String;
+
+        result = Ti.Platform.createUUID();
+        should(result).be.a.String;
+        should(result.length).eql(36);
+        // Verify format using regexp!
+        should(result.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i)).not.eql(null);
+        should(result.charAt(0)).not.eql("{");
+        should(result.charAt(result.length - 1)).not.eql("}");
         finish();
     });
     it("openURL", function (finish) {

--- a/Source/Ti/src/Platform.cpp
+++ b/Source/Ti/src/Platform.cpp
@@ -46,7 +46,7 @@ namespace TitaniumWindows
 		CoCreateGuid(&gdn);
 		::Platform::Guid guid(gdn);
 		auto guid_str = guid.ToString();
-		return std::string(guid_str->Begin(), guid_str->End());
+		return std::string((guid_str->Begin()) + 1, (guid_str->End()) - 1);
 	}
 
 	std::string Platform::address() const TITANIUM_NOEXCEPT

--- a/Source/TitaniumKit/src/analytics.js
+++ b/Source/TitaniumKit/src/analytics.js
@@ -29,7 +29,7 @@ var ANALYTICS_URL = 'https://api.appcelerator.com/p/v3/mobile-track/',
  * @constructor
  */
 function Analytics() {
-	this.sessionId = Ti.Platform.createUUID().replace(/[{}]/g,'');
+	this.sessionId = Ti.Platform.createUUID();
 	this.eventQueue = [];
 	if (!this.analyticsFile) {
 	    this.analyticsFile = Ti.Filesystem.getFile(Ti.Filesystem.applicationDataDirectory + Ti.Filesystem.separator + ANALYTICS_FILE);
@@ -59,7 +59,7 @@ Analytics.prototype.saveEventQueue = function saveEventQueue() {
  */
 Analytics.prototype.createEvent = function createEvent(eventType, data) {
 	var event = {
-		id: Ti.Platform.createUUID().replace(/[{}]/g,'') + ':' + Ti.Platform.id,
+		id: Ti.Platform.createUUID() + ':' + Ti.Platform.id,
 		sid: this.sessionId,
 		ts: new Date().toISOString(),
 		event: eventType,
@@ -208,7 +208,7 @@ analytics.postEvents();
 Ti.App.addEventListener('resume', function resume(e) {
 	// generate a new sessionId if we have been suspeneded for over 30 seconds
 	if (analytics.timestamp && (new Date().getTime() - analytics.timestamp) > SESSION_TIME_SEPARATION) {
-		analytics.sessionId = Ti.Platform.createUUID().replace(/[{}]/g,'');
+		analytics.sessionId = Ti.Platform.createUUID();
 	}
 	// queue ti.foreground event
 	analytics.createForegroundEvent();


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-19127

This adds more testing of the createUUID value in our unit tests to validate that the UUID is 36 characters long, doesn't start with open brace or end with close brace and tests against a regexp for format.

I also remove the hacks around the issue in analytics.