### PR TITLE
Fix TIMOB-19130 Ti.UI.Window.remove() generates runtime error, view is not removed

### DIFF
--- a/Source/TitaniumKit/include/Titanium/UI/View.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/View.hpp
@@ -71,6 +71,7 @@ namespace Titanium
 			TITANIUM_FUNCTION_DEF(add);
 			TITANIUM_FUNCTION_DEF(animate);
 			TITANIUM_FUNCTION_DEF(hide);
+			TITANIUM_FUNCTION_DEF(remove);
 			TITANIUM_FUNCTION_DEF(show);
 			
 			TITANIUM_PROPERTY_DEF(backgroundColor);

--- a/Source/TitaniumKit/src/UI/View.cpp
+++ b/Source/TitaniumKit/src/UI/View.cpp
@@ -49,6 +49,7 @@ namespace Titanium
 			TITANIUM_ADD_FUNCTION(View, add);
 			TITANIUM_ADD_FUNCTION(View, animate);
 			TITANIUM_ADD_FUNCTION(View, hide);
+			TITANIUM_ADD_FUNCTION(View, remove);
 			TITANIUM_ADD_FUNCTION(View, show);
 
 			// properties
@@ -115,6 +116,13 @@ namespace Titanium
 		{
 			TITANIUM_ASSERT(arguments.size() == 0);
 			layoutDelegate__->hide();
+			return get_context().CreateUndefined();
+		}
+
+		TITANIUM_FUNCTION(View, remove)
+		{
+			ENSURE_OBJECT_AT_INDEX(view, 0);
+			layoutDelegate__->remove(view.GetPrivate<View>());
 			return get_context().CreateUndefined();
 		}
 


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-19130

```javascript
var win = Ti.UI.createWindow();
 
var view = Ti.UI.createView({
	top: 100,
	width: 100,
	height: 100,
	backgroundColor: 'red'
});
 
win.add(view);
 
var btn = Ti.UI.createButton({
	top: 300,
	title: 'Click'
});
 
btn.addEventListener('click', function (e) {
	win.remove(view);
});
 
win.add(btn);
win.open();
```