### PR TITLE
[TIMOB-19119] Fix layout ppi value

### DIFF
--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <cctype>
 #include <collection.h>
+#include <Windows.h>
 
 #include "TitaniumWindows/Utility.hpp"
 
@@ -795,13 +796,16 @@ namespace TitaniumWindows
 			}
 
 			auto info = Windows::Graphics::Display::DisplayInformation::GetForCurrentView();
-			// FIXME We should ook at _what_ property is and determine if it's vertical or horizontal to know
+#if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP)
+			// FIXME We should look at _what_ property is and determine if it's vertical or horizontal to know
 			// if we should use x or y dpi - since they _can_ differ. On emulators I've seen them be 365 and 366, so typically it's unusual to have wildly different scaling
 			auto dpiX = info->RawDpiX;
 			//auto dpiY = info->RawDpiY;
 			auto rppp = info->RawPixelsPerViewPixel;
-
 			auto ppi = dpiX / rppp;
+#else
+			auto ppi = info->LogicalDpi;
+#endif
 			Titanium::LayoutEngine::populateLayoutPoperties(prop, &layout_node__->properties, ppi);
 
 			if (isLoaded()) {

--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -794,7 +794,14 @@ namespace TitaniumWindows
 				prop.value = "UI.FILL";
 			}
 
-			auto ppi = Windows::Graphics::Display::DisplayInformation::GetForCurrentView()->LogicalDpi;
+			auto info = Windows::Graphics::Display::DisplayInformation::GetForCurrentView();
+			// FIXME We should ook at _what_ property is and determine if it's vertical or horizontal to know
+			// if we should use x or y dpi - since they _can_ differ. On emulators I've seen them be 365 and 366, so typically it's unusual to have wildly different scaling
+			auto dpiX = info->RawDpiX;
+			//auto dpiY = info->RawDpiY;
+			auto rppp = info->RawPixelsPerViewPixel;
+
+			auto ppi = dpiX / rppp;
 			Titanium::LayoutEngine::populateLayoutPoperties(prop, &layout_node__->properties, ppi);
 
 			if (isLoaded()) {


### PR DESCRIPTION
This supercedes #341 

I fiddled with checking all the values of actual pixels, versus what the APIs report, the logical dpi, raw dpi, etc. Eventually I figured out how many pixels equaled an inch (based on using the stated size of the emulator as being the diagonal size) and found the right values that would scale us properly when using inches as our units and made some buttons to ensure they looked the right size visually given the expected actual width in inches of the device.

By my calculations, the 6" emulator should be ~2.958" wide.
The 4.7" emulator should be ~2.304" wide.

So then I just generated a simple app and set some views up using inches as measurements and verified those widths panned out. They (more or less) do now.