### PR TITLE
[TIMOB-19143] Fix width sizing for Button and TextField

### DIFF
--- a/Source/UI/src/Button.cpp
+++ b/Source/UI/src/Button.cpp
@@ -47,6 +47,9 @@ namespace TitaniumWindows
 			button__->VerticalAlignment = Windows::UI::Xaml::VerticalAlignment::Center;
 			button__->FontSize = DefaultFontSize;
 
+			// TIMOB-19143: reset MinWidth to fix size issues
+			button__->MinWidth = 0;
+
 			getViewLayoutDelegate<WindowsViewLayoutDelegate>()->setComponent(button__);
 		}
 

--- a/Source/UI/src/TextField.cpp
+++ b/Source/UI/src/TextField.cpp
@@ -28,6 +28,9 @@ namespace TitaniumWindows
 			text_box__->AcceptsReturn = false;
 			text_box__->IsSpellCheckEnabled = true;
 
+			// TIMOB-19143: reset MinWidth to fix size issues
+			text_box__->MinWidth = 0;
+
 			Titanium::UI::TextField::setLayoutDelegate<WindowsViewLayoutDelegate>();
 			getViewLayoutDelegate<WindowsViewLayoutDelegate>()->setComponent(text_box__);
 		}


### PR DESCRIPTION
- Reset component ```MinWidth``` for ```Button``` and ```TextField```

###### TEST CASE
```Javascript
var win = Ti.UI.createWindow({
    backgroundColor: 'blue'
});
var viewA = Ti.UI.createTextField({
    top: '5dp',
    width: '20dp',
    height: '20dp'
});
var viewB = Ti.UI.createView({
    backgroundColor: 'white',
    top: '35dp',
    width: '20dp',
    height: '20dp'
});
var viewC = Ti.UI.createButton({
    top: '55dp',
    width: '20dp',
    height: '20dp'
});
win.add(viewA);
win.add(viewB);
win.add(viewC);
win.open();
```

###### NOTE
I don't think this https://github.com/appcelerator/titanium_mobile_windows/blob/master/Source/UI/src/TextField.cpp#L40 has any effect any more

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-19143)