### PR TITLE
[TIMOB-19152] Allow encrypted file types to load if they are not encrypted

### DIFF
--- a/Source/Global/include/TitaniumWindows/GlobalObject.hpp
+++ b/Source/Global/include/TitaniumWindows/GlobalObject.hpp
@@ -37,7 +37,7 @@ namespace TitaniumWindows
 #endif
 
 		static void JSExportInitialize();
-		void SetSeed(const std::string& seed);
+		void setSeed(::Platform::String^ seed);
 		virtual std::string readRequiredModule(const JSObject& parent, const std::string& path) const override final;
 		virtual void registerNativeModuleRequireHook(const std::vector<std::string>& supported_module_names, const std::unordered_map<std::string, JSValue>& preloaded_modules, std::function<JSValue(const std::string&)> requireCallback);
 
@@ -60,10 +60,7 @@ namespace TitaniumWindows
 		virtual std::shared_ptr<Titanium::GlobalObject::Timer> CreateTimer(Callback_t callback, const std::chrono::milliseconds& interval) const TITANIUM_NOEXCEPT override final;
 
 	private:
-#pragma warning(push)
-#pragma warning(disable : 4251)
-		std::string seed__;
-#pragma warning(pop)
+		::Platform::String^ seed__;
 	};
 
 }  // namespace TitaniumWindows

--- a/Source/Titanium/src/TitaniumWindows.cpp
+++ b/Source/Titanium/src/TitaniumWindows.cpp
@@ -80,7 +80,7 @@ namespace TitaniumWindows
 		auto js_global = js_context__.get_global_object();
 		auto global = js_global.GetPrivate<TitaniumWindows::GlobalObject>();
 		TITANIUM_ASSERT(global != nullptr);
-		global->SetSeed(TitaniumWindows::Utility::ConvertString(seed));
+		global->setSeed(seed);
 	}
 
 	Application::~Application()


### PR DESCRIPTION
- Allows unencrypted file types to load by checking if an ```.iv``` is present
- ```seed__``` is now a ```::Platform::String^``` to prevent unnecessary string conversions
- Changed variable names to match our naming convention

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-19152)