### PR TITLE
Fix TIMOB-19175 Windows: Tiapp version isn't populated into app's manifest file

### DIFF
--- a/cli/commands/_build/generate.js
+++ b/cli/commands/_build/generate.js
@@ -236,7 +236,7 @@ function generateCmakeList(next) {
 		{
 			projectName: this.sanitizeProjectName(this.cli.tiapp.name),
 			windowsSrcDir: path.resolve(__dirname, '..', '..', '..').replace(/\\/g, '/').replace(' ', '\\ '), // cmake likes unix separators
-			version: this.tiapp.version,
+			version: appc.version.format(this.tiapp.version, 4, 4, true),
 			assets: assetList.join('\n'),
 			publisherDisplayName: this.cli.tiapp.publisher,
 			publisherName: this.publisherName,

--- a/cli/hooks/wp-run.js
+++ b/cli/hooks/wp-run.js
@@ -194,7 +194,7 @@ exports.init = function (logger, config, cli) {
 
 				var tiapp = builder.tiapp,
 					// name of the directory holding appx and dependencies subfolder
-					dirName = sanitizeProjectName(tiapp.name) + '_1.1.0.0' + ((builder.buildConfiguration == 'Debug') ? '_Debug_Test' : '_Test');
+					dirName = sanitizeProjectName(tiapp.name) + '_' + appc.version.format(tiapp.version, 4, 4, true) + ((builder.buildConfiguration == 'Debug') ? '_Debug_Test' : '_Test');
 					// path to folder holding appx
 					appxDir = path.resolve(builder.cmakeTargetDir, 'AppPackages', sanitizeProjectName(tiapp.name), dirName),
 					// path to folder holding depencies of the app

--- a/templates/build/Package.phone.appxmanifest.in.ejs
+++ b/templates/build/Package.phone.appxmanifest.in.ejs
@@ -5,7 +5,7 @@
   
   <Identity Name="@PACKAGE_GUID@"
 	    Publisher="@PUBLISHER_NAME@"
-	    Version="1.1.0.0" />
+	    Version="@VERSION@" />
   
   <mp:PhoneIdentity PhoneProductId="@PHONE_PRODUCT_ID@"
         PhonePublisherId="00000000-0000-0000-0000-000000000000" />

--- a/templates/build/Package.store.appxmanifest.in.ejs
+++ b/templates/build/Package.store.appxmanifest.in.ejs
@@ -4,7 +4,7 @@
 
   <Identity Name="@PACKAGE_GUID@"
 	    Publisher="@PUBLISHER_NAME@"
-	    Version="1.1.0.0" />
+	    Version="@VERSION@" />
 
   <Properties>
     <DisplayName>@SHORT_NAME@</DisplayName>


### PR DESCRIPTION
This attempts to enforce a 4 part version string and passes that version into the app manifest. CMake also can take up to 4 version segments, so using same version variable for both looks OK.

https://jira.appcelerator.org/browse/TIMOB-19175