### PR TITLE
Fix TIMOB-19144 Windows: Ti.version is blank

### DIFF
--- a/Source/Ti/include/TitaniumWindows/TiModule.hpp
+++ b/Source/Ti/include/TitaniumWindows/TiModule.hpp
@@ -32,20 +32,12 @@ namespace TitaniumWindows
 		TiModule& operator=(TiModule&&) = default;
 #endif
 
-		virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override final;
 		static void JSExportInitialize();
 
 	protected:
 		virtual std::string version() const TITANIUM_NOEXCEPT override final;
 		virtual std::string buildDate() const TITANIUM_NOEXCEPT override final;
 		virtual std::string buildHash() const TITANIUM_NOEXCEPT override final;
-
-	private:
-		std::string loadVersion(const JSContext&, const std::string&);
-#pragma warning(push)
-#pragma warning(disable : 4251)
-		std::string version__;
-#pragma warning(pop)
 	};
 
 }  // namespace TitaniumWindows

--- a/Source/Ti/src/TiModule.cpp
+++ b/Source/Ti/src/TiModule.cpp
@@ -21,55 +21,19 @@ namespace TitaniumWindows
 		TITANIUM_LOG_DEBUG("TitaniumWindows::TiModule::dtor");
 	}
 
-	void TiModule::postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments)
-	{
-		Titanium::TiModule::postCallAsConstructor(js_context, arguments);
-		version__ = loadVersion(js_context, "__TITANIUM_VERSION__");
-	}
-
 	void TiModule::JSExportInitialize()
 	{
 		JSExport<TiModule>::SetClassVersion(1);
 		JSExport<TiModule>::SetParent(JSExport<Titanium::TiModule>::Class());
 	}
 
-	std::string TiModule::loadVersion(const JSContext& context, const std::string& defaultValue)
-	{
-		// FIXME Code copied from AppModule!!!
-		// Statically create json JSValue to load _app_info_.json once
-		static JSValue json = context.CreateUndefined();
-
-		// Statically create loadJson javascript function
-		static JSFunction loadJson = context.CreateFunction(
-			"var file = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory+Ti.Filesystem.separator+'_app_info_.json');"
-			"if (file.exists()) return JSON.parse(file.read().text);"
-			);
-
-		// Statically create readJson javascript function
-		static JSFunction readJson = context.CreateFunction(
-			"if (json != undefined && property in json) return json[property];"
-			"return null;",
-			{ "json", "property" }
-		);
-
-		// Load _app_info_.json
-		if (json.IsUndefined()) json = loadJson(context.get_global_object());
-
-		// Read property
-		std::vector<JSValue> args = { json, context.CreateString("sdkVersion") };
-		auto result = readJson(args, context.get_global_object());
-
-		// Return property value if it exists
-		if (!result.IsNull()) {
-			return static_cast<std::string>(result);
-		} else {
-			return defaultValue;
-		}
-	}
-
 	std::string TiModule::version() const TITANIUM_NOEXCEPT
 	{
-		return version__;
+		auto value = get_context().JSEvaluateScript("Ti.App._sdkVersion;");
+		if (value.IsString()) {
+			return static_cast<std::string>(value);
+		}
+		return std::string("__TITANIUM_VERSION__");
 	}
 
 	std::string TiModule::buildDate() const TITANIUM_NOEXCEPT

--- a/Source/TitaniumKit/include/Titanium/App.hpp
+++ b/Source/TitaniumKit/include/Titanium/App.hpp
@@ -153,6 +153,10 @@ namespace Titanium
 		  @discussion Application version, from `tiapp.xml`.
 		*/
 		virtual std::string version() const TITANIUM_NOEXCEPT;
+
+		// FIXME This is a giant hack to stuff the SDK version into _app_info_.json at build-time. Should be on TiModule!
+		virtual std::string _sdkVersion() const TITANIUM_NOEXCEPT;
+
 		/*!
 		  @method
 		  @abstract fireSystemEvent
@@ -197,6 +201,7 @@ namespace Titanium
 		TITANIUM_PROPERTY_READONLY_DEF(sessionId);
 		TITANIUM_PROPERTY_READONLY_DEF(url);
 		TITANIUM_PROPERTY_READONLY_DEF(version);
+		TITANIUM_PROPERTY_READONLY_DEF(_sdkVersion);
 
 		TITANIUM_FUNCTION_DEF(fireSystemEvent);
 		TITANIUM_FUNCTION_DEF(getAccessibilityEnabled);
@@ -242,6 +247,7 @@ namespace Titanium
 		std::string sessionId__;
 		std::string url__;
 		std::string version__;
+		std::string _sdkVersion__;
 #pragma warning(pop)
 	};
 }

--- a/Source/TitaniumKit/src/App.cpp
+++ b/Source/TitaniumKit/src/App.cpp
@@ -63,7 +63,8 @@ namespace Titanium
 		publisher__("__PUBLISHER__"),
 		sessionId__("__SESSION_ID__"),
 		url__("__URL__"),
-		version__("__VERSION__")
+		version__("__VERSION__"),
+		_sdkVersion__("__TITANIUM_VERSION__") // FIXME This should live in TiModule!
 	{
 		TITANIUM_LOG_DEBUG("AppModule:: ctor ", this);
 	}
@@ -89,6 +90,7 @@ namespace Titanium
 		publisher__ = getAppInfo<std::string>("publisher", publisher__);
 		url__ = getAppInfo<std::string>("url", url__);
 		version__ = getAppInfo<std::string>("version", version__);
+		_sdkVersion__ = getAppInfo<std::string>("sdkVersion", _sdkVersion__);
 	}
 
 	TITANIUM_PROPERTY_GETTER(AppModule, EVENT_ACCESSIBILITY_ANNOUNCEMENT)
@@ -201,6 +203,11 @@ namespace Titanium
 		return version__;
 	}
 
+	std::string AppModule::_sdkVersion() const TITANIUM_NOEXCEPT
+	{
+		return _sdkVersion__;
+	}
+
 	void AppModule::fireSystemEvent(const std::string& eventName, const JSObject& param) TITANIUM_NOEXCEPT
 	{
 		TITANIUM_LOG_WARN("AppModule::fireSystemEvent: Unimplemented");
@@ -234,6 +241,7 @@ namespace Titanium
 		TITANIUM_ADD_PROPERTY_READONLY(AppModule, sessionId);
 		TITANIUM_ADD_PROPERTY_READONLY(AppModule, url);
 		TITANIUM_ADD_PROPERTY_READONLY(AppModule, version);
+		TITANIUM_ADD_PROPERTY_READONLY(AppModule, _sdkVersion);
 
 		TITANIUM_ADD_FUNCTION(AppModule, fireSystemEvent);
 		TITANIUM_ADD_FUNCTION(AppModule, getAccessibilityEnabled);
@@ -372,6 +380,11 @@ namespace Titanium
 	TITANIUM_PROPERTY_GETTER(AppModule, version)
 	{
 		return get_context().CreateString(version());
+	}
+
+	TITANIUM_PROPERTY_GETTER(AppModule, _sdkVersion)
+	{
+		return get_context().CreateString(_sdkVersion());
 	}
 
 	TITANIUM_FUNCTION(AppModule, fireSystemEvent)


### PR DESCRIPTION
This is a very ugly hack. Basically we throw the sdk version from the CLI build into the _app_info_.json file along with some of the other tiapp values. Then When we load those up in the Ti.App module, we load the sdkVersion value too. And when the user asks for Ti.version, we basically just secretly do Ti.App._sdkVersion to grab that value.

https://jira.appcelerator.org/browse/TIMOB-19144