### PR TITLE
Fix TIMOB-19112 Windows: Splash Screen not showing

### DIFF
--- a/cli/commands/_build/copy.js
+++ b/cli/commands/_build/copy.js
@@ -260,7 +260,25 @@ function copyResources(next) {
 	}
 
 	var tasks = [
-		// first task is to copy all files in the Resources directory, but ignore
+		// First, copy template files for CMake/MSBuild FIXME Move these into subdir so we copy only ones we need!
+		function (cb) {
+			var src = path.join(this.platformPath, 'templates', 'build');
+			copyDir.call(this, {
+				src: src,
+				dest: this.buildDir // throw into top-level build dir
+			}, cb);
+		},
+
+		// Copy cmake folder over, with our helper scripts to find the bundled dependency libs
+		function (cb) {
+			var src = path.join(this.platformPath, 'templates', 'build', 'cmake');
+			copyDir.call(this, {
+				src: src,
+				dest: path.join(this.buildDir, 'cmake')
+			}, cb);
+		},
+
+		// Next task is to copy all files in the Resources directory, but ignore
 		// any directory that is the name of a known platform
 		function (cb) {
 			var src = path.join(this.projectDir, 'Resources');
@@ -277,24 +295,6 @@ function copyResources(next) {
 			copyDir.call(this, {
 				src: src,
 				dest: this.buildTargetAssetsDir
-			}, cb);
-		},
-
-		// next copy template files for CMake/MSBuild FIXME Move these into subdir so we copy only ones we need!
-		function (cb) {
-			var src = path.join(this.platformPath, 'templates', 'build');
-			copyDir.call(this, {
-				src: src,
-				dest: this.buildDir // throw into top-level build dir
-			}, cb);
-		},
-
-		// Copy cmake folder over, with our helper scripts to find the bundled dependency libs
-		function (cb) {
-			var src = path.join(this.platformPath, 'templates', 'build', 'cmake');
-			copyDir.call(this, {
-				src: src,
-				dest: path.join(this.buildDir, 'cmake')
 			}, cb);
 		},
 


### PR DESCRIPTION
Changed the copy order. First we copy over the template files, then copy the app files over top. That way app's branding/assets "win".

https://jira.appcelerator.org/browse/TIMOB-19112