### PR TITLE
Fix TIMOB-19114 Ti.UI.Windows.AppBarToggleButton:click does not include checked like documented

### DIFF
--- a/Source/UI/src/Windows/AppBarToggleButton.cpp
+++ b/Source/UI/src/Windows/AppBarToggleButton.cpp
@@ -86,8 +86,11 @@ namespace TitaniumWindows
 				Titanium::Module::enableEvent(event_name);
 
 				if (event_name == "click") {
-					click_event__ = button__->Click += ref new RoutedEventHandler([this](Platform::Object^ sender, RoutedEventArgs^ e) {
-						this->fireEvent("click");
+					const auto ctx = this->get_context();
+					click_event__ = button__->Click += ref new RoutedEventHandler([this, ctx](Platform::Object^ sender, RoutedEventArgs^ e) {
+						auto eventArgs = ctx.CreateObject();
+						eventArgs.SetProperty("checked", ctx.CreateBoolean(button__->IsChecked->Value));
+						this->fireEvent("click", eventArgs);
 					});
 
 				}


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-19114

```javascript
var win = Ti.UI.createWindow({
    backgroundColor: 'black'
});
var likeButton = Ti.UI.Windows.createAppBarToggleButton({
    icon: Ti.UI.Windows.SystemIcon.LIKEDISLIKE
});

likeButton.addEventListener('click', function (e) {
    console.log(JSON.stringify(e, null, 2));
});

win.add(Ti.UI.Windows.createCommandBar({
    items: [likeButton]
}));

win.open();
```