### PR TITLE
Support `build.js --only WindowsPhone-x86`

### DIFF
--- a/Tools/Scripts/build/build.js
+++ b/Tools/Scripts/build/build.js
@@ -21,6 +21,7 @@ var rootDir = path.join(__dirname, '..', '..', '..'),
 	distLib = path.join(distRoot, 'lib'),
 	beQuiet = process.argv.indexOf('--quiet') >= 0,
 	beParallel = process.argv.indexOf('--parallel') >= 0,
+	limitArchitectures = process.argv.indexOf('--only') >= 0,
 	overallTimer = process.hrtime(),
 	timer = process.hrtime();
 
@@ -35,7 +36,14 @@ async.series([
 			{target: 'WindowsPhone', architecture: 'x86'},
 			{target: 'WindowsPhone', architecture: 'ARM'},
 			{target: 'WindowsStore', architecture: 'x86'}
-		], function (configuration, next) {
+		].filter(function (item) {
+				if (!limitArchitectures) {
+					return true;
+				}
+				else {
+					return process.argv.indexOf(item.target + '-' + item.architecture) >= 0;
+				}
+			}), function (configuration, next) {
 			buildAndPackage(titaniumWindowsSrc, buildRoot, distLib, 'Release', configuration.target, configuration.architecture, next);
 		}, next);
 	},


### PR DESCRIPTION
This way we can just build the architectures that we care about when
testing. The others can be skipped easily from the command line.

    node build.js --only WindowsPhone-x86