### PR TITLE
Fix TIMOB-19129 Windows: HTTPClient does not send User-Agent

### DIFF
--- a/Source/TitaniumKit/src/ApplicationBuilder.cpp
+++ b/Source/TitaniumKit/src/ApplicationBuilder.cpp
@@ -256,11 +256,14 @@ namespace Titanium
 			  // Load _app_info_.json
 			  Ti.App._loadAppInfo();
 
-			  // Start analytics
-			  Ti.Analytics._start();
-
+			  // Let's set up our user agent in JS, way easier this way...
+			  Ti.userAgent = 'Appcelerator Titanium/' + Ti.version + ' (' + Ti.Platform.model + '/' + Ti.Platform.version + '; ' + Ti.Platform.osname + '; ' + Ti.Platform.locale + ';)';
+				
 			  Ti.Network.encodeURIComponent = encodeURIComponent;
 			  Ti.Network.decodeURIComponent = decodeURIComponent;
+
+			  // Start analytics
+			  Ti.Analytics._start();
 
 			  L = Ti.Locale.getString;
 			)js";


### PR DESCRIPTION
- Use JS to build the default userAgent string when we do our other global setup
- Set the User-Agent header on HTTPClient.open(), handle the header specially (like we do for Content-Type)
- Set the X-Titanium-Id header when we prepare a request with the Ti.App.guid.
- Implement Ti.Platform.version. We had hard-coded "0.0" for os version, but I found a hacky way around it using PnP device sniffing. We basically take the first "Microsoft" provider listing and use it's version. Typically that is right and is something along the lines of "6.3.9651.0" (for windows phone), which in Windows version world means Windows 8.1. Desktop should return "6.3.9600" or equivalent.

https://jira.appcelerator.org/browse/TIMOB-19129