### PR TITLE
[TIMOB-19180] Remove JavascriptCore dependancy from modules

### DIFF
--- a/templates/module/default/template/windows/CMakeLists.txt.ejs
+++ b/templates/module/default/template/windows/CMakeLists.txt.ejs
@@ -36,7 +36,6 @@ list(INSERT CMAKE_MODULE_PATH 0 ${APPCELERATOR_CMAKE_MODULE_PATH})
 
 find_package(HAL REQUIRED)
 find_package(TitaniumKit REQUIRED)
-find_package(JavaScriptCore REQUIRED)
 
 enable_testing()
 
@@ -62,7 +61,6 @@ target_include_directories(<%- moduleIdAsIdentifier %> PUBLIC
   ${PROJECT_SOURCE_DIR}/include
   $<TARGET_PROPERTY:HAL,INTERFACE_INCLUDE_DIRECTORIES>
   $<TARGET_PROPERTY:TitaniumKit,INTERFACE_INCLUDE_DIRECTORIES>
-  ${JavaScriptCore_INCLUDE_DIRS}
   )
 
 target_link_libraries(<%- moduleIdAsIdentifier %>


### PR DESCRIPTION
- Remove unnecessary ```JavascriptCore``` dependency from module generation

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-19180)