### PR TITLE
[TIMOB-19132] Ti.UI.Switch cannot be positioned (absolute)

### DIFF
--- a/Source/TitaniumKit/src/UI/Switch.cpp
+++ b/Source/TitaniumKit/src/UI/Switch.cpp
@@ -23,7 +23,7 @@ namespace Titanium
 
 		void Switch::JSExportInitialize() {
 			JSExport<Switch>::SetClassVersion(1);
-			JSExport<Switch>::SetParent(JSExport<Module>::Class());
+			JSExport<Switch>::SetParent(JSExport<View>::Class());
 
 			TITANIUM_ADD_PROPERTY(Switch, value);
 			TITANIUM_ADD_FUNCTION(Switch, getValue);

--- a/Source/UI/src/Switch.cpp
+++ b/Source/UI/src/Switch.cpp
@@ -31,7 +31,6 @@ namespace TitaniumWindows
 			});
 
 			Titanium::UI::Switch::setLayoutDelegate<WindowsViewLayoutDelegate>();
-			layoutDelegate__->set_defaultWidth(Titanium::UI::LAYOUT::FILL);
 			getViewLayoutDelegate<WindowsViewLayoutDelegate>()->setComponent(switch__);
 		}
 


### PR DESCRIPTION
Fix for [TIMOB-19132](https://jira.appcelerator.org/browse/TIMOB-19132)

```javascript
var win = Ti.UI.createWindow();
win.add(Ti.UI.createSwitch({
	top: 20,
	left: 20
}));

win.open();
```