### PR TITLE
[TIMOB-19104] Remove Invalid Chars from Publisher Name

### DIFF
--- a/cli/commands/_build/validate.js
+++ b/cli/commands/_build/validate.js
@@ -21,8 +21,8 @@ function mixin(WindowsBuilder) {
 /**
  * Escapes a value in a relative distinguished name. Used to generate the distinguished name for the windows cert string from tiapp publisher value.
  **/
-function escapeRDN(value) {
-	return value.trim().replace(/\\/g, '\\\\').replace(/([\/,#+<>;"=])/g, '\\$1');
+function restrictToManifestSTPublisher(value) {
+	return value.trim().replace(/[, ="<>#;]/g, '');
 }
 
 /**
@@ -109,16 +109,16 @@ function validate(logger, config, cli) {
 				'ti.windows.publishername is suggested in your tiapp.xml for publishing!' +
 				'\nWe will default to a value generated from your tiapp.publisher value.' +
 				'\nFor example:' +
-				'\n<property name="ti.windows.publishername" type="string">CN=' + escapeRDN(cli.tiapp.publisher) + '</property>'
+				'\n<property name="ti.windows.publishername" type="string">CN=' + cli.tiapp.publisher + '</property>'
 			));
-			this.publisherName = "CN=" + escapeRDN(cli.tiapp.publisher);
+			this.publisherName = "CN=" + cli.tiapp.publisher;
 		}
 		else {
 			logger.error(__(
 				'Publisher and ti.windows.publishername are required in your tiapp.xml!' +
 				'\nFor example:' +
 				'\n<publisher>Appcelerator Inc.</publisher>' +
-				'\n<property name="ti.windows.publishername" type="string">CN=Appcelerator Inc.</property>'
+				'\n<property name="ti.windows.publishername" type="string">CN=Appcelerator, Inc.</property>'
 			));
 			logger.log();
 			process.exit(1);
@@ -126,6 +126,7 @@ function validate(logger, config, cli) {
 	} else {
 		this.publisherName = this.publisherName.value;
 	}
+	this.publisherName = this.publisherName.split('=').map(restrictToManifestSTPublisher).join('=');
 
 	// check that the build directory is writeable
 	// try to build under temp if the path is shorter and we have write access

--- a/cli/hooks/ws-package.js
+++ b/cli/hooks/ws-package.js
@@ -44,8 +44,7 @@ exports.init = function (logger, config, cli) {
 				return;
 			}
 
-			var expirationDate = moment().add(1, 'year').format('MM/DD/YYYY'),
-				pvk = path.join(projectDir, 'generated.pvk'),
+			var pvk = path.join(projectDir, 'generated.pvk'),
 				cer = path.join(projectDir, 'generated.cer'),
 				pfx = path.join(projectDir, 'generated.pfx');
 


### PR DESCRIPTION
Took the regex from Microsoft's specifications for publisher names.
Also, move the trimming so that it will apply to all passed in publisher
names.

It should be tested to work with various deploy types, using a publisher name that contains character's Microsoft doesn't like, such as commas and spaces.

```bash
ti build -p windows -G 00000000-0000-1000-8000-000000000000 -C 8-1-1
ti build -p windows -G 00000000-0000-1000-8000-000000000000 --target dist-winstore
```

https://jira.appcelerator.org/browse/TIMOB-19104