### PR TITLE
[TIMOB-19137] Queue alert dialogs - READY

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/AlertDialog.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/AlertDialog.hpp
@@ -11,7 +11,7 @@
 
 #include "TitaniumWindows_UI_EXPORT.h"
 #include "Titanium/UI/AlertDialog.hpp"
-#include <Windows.h>
+#include <ppltasks.h>
 
 namespace TitaniumWindows
 {
@@ -43,12 +43,17 @@ namespace TitaniumWindows
 			virtual void hide() TITANIUM_NOEXCEPT override;
 			virtual void show() TITANIUM_NOEXCEPT override;
 
+		//private:
+#pragma warning(push)
+#pragma warning(disable : 4251)
+			static std::vector<Windows::UI::Popups::MessageDialog^> dialogs__;
+
 #if WINAPI_FAMILY==WINAPI_FAMILY_PHONE_APP
 			static const std::uint32_t MaxButtonCount = 2;
 #else
 			static const std::uint32_t MaxButtonCount = 3;
 #endif
-
+#pragma warning(pop)
 		};
 	} // namespace UI
 } // namespace TitaniumWindows


### PR DESCRIPTION
- Queue alert dialogs so only one is displayed at a time

###### TEST CASE # 1
```Javascript
var n = 0;
function createAlert() {
    var alertDialog = Ti.UI.createAlertDialog({
        message: 'alert #' + n++,
        buttonNames: ['create two alerts', 'close']
    });
    alertDialog.addEventListener('click', function (e) {
        if (e.index === 0) {
            createAlert();
            createAlert();
        }
    });
    alertDialog.show();
}
createAlert();
```

###### TEST CASE # 2
```Javascript
alert('alert #1');
alert('alert #2');
alert('alert #3');
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-19137)