### PR TITLE
Fix so visible property changes are actually done

### DIFF
--- a/Examples/NMocha/src/Assets/app.js
+++ b/Examples/NMocha/src/Assets/app.js
@@ -46,6 +46,7 @@ require('./ti.ui.scrollableview.test');
 require('./ti.ui.switch.test');
 require('./ti.ui.tableview.test');
 require('./ti.ui.textfield.test');
+require('./ti.ui.view.test');
 require('./ti.ui.window.test');
 require('./ti.utils.test');
 require('./ti.xml.test');

--- a/Examples/NMocha/src/Assets/ti.ui.view.test.js
+++ b/Examples/NMocha/src/Assets/ti.ui.view.test.js
@@ -1,0 +1,38 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2015 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+require('ti-mocha');
+var should = require('should');
+
+describe("Titanium.UI.View", function () {
+
+    it("hide() and show() change visible property value", function (finish) {
+        this.timeout(5000);
+        var w = Ti.UI.createWindow({
+            backgroundColor: 'blue',
+            width: 100,
+            height: 100
+        });
+       
+        w.addEventListener('focus', function () {
+            Ti.API.info("Got focus event");
+            should(w.visible).be.true;
+            Ti.API.info("Was visible");
+            w.hide();
+            should(w.visible).be.false;
+            Ti.API.info("Was not visible after hide()");
+            w.show();
+            should(w.visible).be.true;
+            Ti.API.info("Was visible after show()");
+            setTimeout(function () {
+                w.close();
+                finish();
+            }, 1000);
+        });
+        w.open();
+    });
+});

--- a/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
@@ -43,32 +43,6 @@ namespace TitaniumWindows
 			/*!
 			  @method
 
-			  @abstract hide() : void
-
-			  @discussion Hides the view and it's chldren in the view's hierarchy.
-
-			  @param 
-
-			  @result void
-			*/
-			virtual void hide() TITANIUM_NOEXCEPT override;
-
-			/*!
-			  @method
-
-			  @abstract show() : void
-
-			  @discussion Causes the view and the view's hierarchy to be displayed. 
-
-			  @param 
-
-			  @result void
-			*/
-			virtual void show() TITANIUM_NOEXCEPT override;
-
-			/*!
-			  @method
-
 			  @abstract backgroundColor : String
 
 			  @discussion Background color of the view, as a color name or hex triplet.
@@ -326,6 +300,16 @@ namespace TitaniumWindows
 			  Titanium.UI.SIZE
 			*/
 			virtual void set_width(const std::string& width) TITANIUM_NOEXCEPT override;
+
+			/*!
+			  @method
+
+			  @abstract visible : Boolean
+
+			  @discussion Determines whether the view is visible
+			*/
+			virtual bool get_visible() const TITANIUM_NOEXCEPT override;
+			virtual void set_visible(const bool& visible) TITANIUM_NOEXCEPT override;
 
 			WindowsViewLayoutDelegate() TITANIUM_NOEXCEPT;
 			virtual ~WindowsViewLayoutDelegate() = default;

--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -99,16 +99,15 @@ namespace TitaniumWindows
 			}
 		}
 
-		void WindowsViewLayoutDelegate::hide() TITANIUM_NOEXCEPT
+		bool WindowsViewLayoutDelegate::get_visible() const TITANIUM_NOEXCEPT
 		{
-			Titanium::UI::ViewLayoutDelegate::hide();
-			getComponent()->Visibility = Windows::UI::Xaml::Visibility::Collapsed;
+			return getComponent()->Visibility == Windows::UI::Xaml::Visibility::Visible;
 		}
 
-		void WindowsViewLayoutDelegate::show() TITANIUM_NOEXCEPT
+		void WindowsViewLayoutDelegate::set_visible(const bool& visible) TITANIUM_NOEXCEPT
 		{
-			Titanium::UI::ViewLayoutDelegate::show();
-			getComponent()->Visibility = Windows::UI::Xaml::Visibility::Visible;
+			Titanium::UI::ViewLayoutDelegate::set_visible(visible);
+			getComponent()->Visibility = (visible ? Windows::UI::Xaml::Visibility::Visible : Windows::UI::Xaml::Visibility::Collapsed);
 		}
 
 		void WindowsViewLayoutDelegate::animate(const std::shared_ptr<Titanium::UI::Animation>& animation, JSObject& callback, const JSObject& this_object) TITANIUM_NOEXCEPT


### PR DESCRIPTION
We had overridden hide() and show() for Windows, but really could have kept them as set_visible(true/false) calls up in TitaniumKit. We never overrode set/get_visible though, so assigning to the visible property wasn't honored.

Fixed that and added a unit test for it.