### PR TITLE
Fix: AlertDialog is not shown more than twice

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/AlertDialog.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/AlertDialog.hpp
@@ -46,7 +46,7 @@ namespace TitaniumWindows
 		//private:
 #pragma warning(push)
 #pragma warning(disable : 4251)
-			static std::vector<Windows::UI::Popups::MessageDialog^> dialogs__;
+			static std::vector<Windows::UI::Popups::MessageDialog^> dialog_queue__;
 
 #if WINAPI_FAMILY==WINAPI_FAMILY_PHONE_APP
 			static const std::uint32_t MaxButtonCount = 2;

--- a/Source/UI/src/AlertDialog.cpp
+++ b/Source/UI/src/AlertDialog.cpp
@@ -18,7 +18,7 @@ namespace TitaniumWindows
 		using namespace Windows::UI::Popups;
 		using namespace Windows::Foundation;
 
-		std::vector<Windows::UI::Popups::MessageDialog^> AlertDialog::dialogs__;
+		std::vector<Windows::UI::Popups::MessageDialog^> AlertDialog::dialog_queue__;
 
 		AlertDialog::AlertDialog(const JSContext& js_context) TITANIUM_NOEXCEPT
 		    : Titanium::UI::AlertDialog(js_context)
@@ -39,8 +39,8 @@ namespace TitaniumWindows
 
 		void AlertDialog::show() TITANIUM_NOEXCEPT
 		{
-			std::string title   = get_title();
-			std::string message = get_message();
+			const std::string title   = get_title();
+			const std::string message = get_message();
 
 			Windows::UI::Popups::MessageDialog^ dialog = ref new Windows::UI::Popups::MessageDialog(TitaniumWindows::Utility::ConvertUTF8String(message), TitaniumWindows::Utility::ConvertUTF8String(title));
 			dialog->DefaultCommandIndex = 0;
@@ -52,14 +52,14 @@ namespace TitaniumWindows
 
 			auto maxButtons = buttonNames__.size();
 			if (buttonNames__.size() > MaxButtonCount) {
-				auto Titanium_property = get_context().get_global_object().GetProperty("Titanium");
+				const auto Titanium_property = get_context().get_global_object().GetProperty("Titanium");
 				TITANIUM_ASSERT(Titanium_property.IsObject());  // precondition
-				auto Titanium = static_cast<JSObject>(Titanium_property);
+				const auto Titanium = static_cast<JSObject>(Titanium_property);
 
-				auto Object_property = Titanium.GetProperty("API");
+				const auto Object_property = Titanium.GetProperty("API");
 				TITANIUM_ASSERT(Object_property.IsObject());  // precondition
-				auto api = static_cast<JSObject>(Object_property);
-				auto native_api = api.GetPrivate<Titanium::API>();
+				const auto api = static_cast<JSObject>(Object_property);
+				const auto native_api = api.GetPrivate<Titanium::API>();
 				native_api->error("Number of buttons exceeds platform maximum (" + std::to_string(MaxButtonCount) + "), list will be truncated.");
 				maxButtons = MaxButtonCount;
 			}
@@ -68,31 +68,35 @@ namespace TitaniumWindows
 			}
 
 			try {
-				dialogs__.push_back(dialog);
-				if (dialogs__.size() == 1) {
-					static std::function<void(IUICommand^)> on_click;
-					on_click = [this](IUICommand^ command) {
-						std::int32_t index = 0;
-						if (command != nullptr) {
-							auto casted = dynamic_cast<IPropertyValue^>(command->Id);
-							if (casted != nullptr) {
-								index = casted->GetInt32();
-							}
+				const static std::function<void(IUICommand^)> on_click = [this](IUICommand^ command) {
+					std::int32_t index = 0;
+					if (command != nullptr) {
+						const auto casted = dynamic_cast<IPropertyValue^>(command->Id);
+						if (casted != nullptr) {
+							index = casted->GetInt32();
 						}
-						const JSContext ctx = get_context();
-						JSObject eventArgs = ctx.CreateObject();
-						eventArgs.SetProperty("index", ctx.CreateNumber(index));
-						eventArgs.SetProperty("cancel", ctx.CreateBoolean(index == get_cancel()));
-						fireEvent("click", eventArgs);
+					}
+					const JSContext ctx = get_context();
+					JSObject eventArgs = ctx.CreateObject();
+					eventArgs.SetProperty("index", ctx.CreateNumber(index));
+					eventArgs.SetProperty("cancel", ctx.CreateBoolean(index == get_cancel()));
+					fireEvent("click", eventArgs);
 
-						// display next dialog in queue
-						if (dialogs__.size() > 1) {
-							dialogs__.erase(dialogs__.begin());
-							concurrency::create_task(dialogs__.front()->ShowAsync()).then(on_click);
-						}
-					};
-					concurrency::create_task(dialog->ShowAsync()).then(on_click);
+					dialog_queue__.erase(dialog_queue__.begin());
+
+					if (dialog_queue__.size() > 0) {
+						concurrency::create_task(dialog_queue__.at(0)->ShowAsync()).then(on_click);
+					}
+
+				};
+
+				dialog_queue__.push_back(dialog);
+
+				// show first dialog and then proceed to next after finishing click event
+				if (dialog_queue__.size() == 1) {
+					concurrency::create_task(dialog_queue__.at(0)->ShowAsync()).then(on_click);
 				}
+
 			} catch (::Platform::COMException^ ce) {
 				// Typically would have happened on phone if we supplied more than max buttons allowed
 				detail::ThrowRuntimeError("Ti.UI.AlertDialog", "Exception during show(): " + Utility::ConvertUTF8String(ce->Message));


### PR DESCRIPTION
Fix for [TIMOB-19219](https://jira.appcelerator.org/browse/TIMOB-19219)

Test case 1:

1. Show dialog once by clicking "Push" button
2. Close the dialog
3. Show dialog once again by clicking " "Push" button
4. AlertDialog should be shown again

```javascript
var win = Ti.UI.createWindow();
var btn = Ti.UI.createButton({title:'Push'});

btn.addEventListener('click', function (e) {
    var dialog = Ti.UI.createAlertDialog({
        message: 'Okay',
        title: 'Alert Dialog Test'
    });
    dialog.show();
});

win.add(btn);
win.open();
```

Test case 2: This should not cause runtime exception ([TIMOB-19137](https://jira.appcelerator.org/browse/TIMOB-19137))
```javascript
var n = 0;
function createAlert() {
    var alertDialog = Ti.UI.createAlertDialog({
        message: 'alert #' + n++,
        buttonNames: ['create two alerts', 'close']
    });
    alertDialog.addEventListener('click', function (e) {
        if (e.index === 0) {
            createAlert();
            createAlert();
        }
    });
    alertDialog.show();
}
createAlert();
```

Test case 3: This should not cause runtime exception ([TIMOB-19137](https://jira.appcelerator.org/browse/TIMOB-19137))
```javascript
alert('alert #1');
alert('alert #2');
alert('alert #3');
```