### PR TITLE
FIx; Wrong use of std::unordered_map::emplace

### DIFF
--- a/Source/Global/src/GlobalObject.cpp
+++ b/Source/Global/src/GlobalObject.cpp
@@ -32,13 +32,15 @@ namespace TitaniumWindows
 	{
 		// store supported native module names
 		for (const auto v : native_module_names) {
-			native_module_names__.emplace(v, false);
+			const auto insert_result = native_module_names__.emplace(v,  false);
+			TITANIUM_ASSERT(insert_result.second);
 		}
 
 		// register preloaded modules
 		for (const auto v : preloaded_modules) {
-			native_module_cache__.emplace(v.first, v.second);
-			native_module_names__.emplace(v.first, true); // mark it as loaded
+			const auto insert_result = native_module_cache__.emplace(v.first,  v.second);
+			TITANIUM_ASSERT(insert_result.second);
+			native_module_names__[v.first] = true; // mark it as loaded
 		}
 
 		// register require callback
@@ -57,7 +59,7 @@ namespace TitaniumWindows
 			return native_module_cache__.at(moduleId);
 		}
 		// mark it as loaded
-		native_module_names__.emplace(moduleId, true);
+		native_module_names__[moduleId] = true;
 
 		// otherwise try to load dynamically
 		return native_module_requireHook__(moduleId);

--- a/Source/TitaniumKit/src/Database/DB.cpp
+++ b/Source/TitaniumKit/src/Database/DB.cpp
@@ -174,7 +174,8 @@ namespace Titanium
 			const auto resultSet_object = get_context().CreateObject(JSExport<Titanium::Database::ResultSet>::Class());
 			const auto resultSet = resultSet_object.GetPrivate<Titanium::Database::ResultSet>();
 			resultSet->setDatabase(this);
-			resultSets__.emplace(statement, resultSet);
+			const auto insert_result = resultSets__.emplace(statement, resultSet);
+			TITANIUM_ASSERT(insert_result.second);
 			int affectedRows = 0;
 			if (stepResult == SQLITE_DONE) {
 				sqlite3_finalize(statement);


### PR DESCRIPTION
Fix for [TIMOB-19216](https://jira.appcelerator.org/browse/TIMOB-19216)

`std::unordered_map::emplace` should not be used to replace elements because it works only when key is unique. Also added assertion to make sure if it's unique when you use `emplace`.