### PR TITLE
Add "itemId" and "bindId" for ListView itemclick event

### DIFF
--- a/Examples/RSSReader/src/Assets/alloy/controllers/master.js
+++ b/Examples/RSSReader/src/Assets/alloy/controllers/master.js
@@ -83,6 +83,10 @@ function Controller() {
         id: "master"
     });
     $.__views.master && $.addTopLevelView($.__views.master);
+    $.__views.commandBar = Ti.UI.Windows.createCommandBar({
+        id: "commandBar"
+    });
+    $.__views.master.add($.__views.commandBar);
     var __alloyId3 = {};
     var __alloyId6 = [];
     var __alloyId8 = {
@@ -149,6 +153,13 @@ function Controller() {
     var moment = require("alloy/moment");
     !function() {
         "use strict";
+        $.refreshButton = Ti.UI.Windows.createAppBarButton({
+            icon: Ti.UI.Windows.SystemIcon.REFRESH
+        });
+        $.refreshButton.addEventListener("click", function() {
+            refresh();
+        });
+        $.commandBar.items = [ $.refreshButton ];
         refresh();
     }(arguments[0] || {});
     __defers["$.__views.__alloyId2!itemclick!select"] && $.addListener($.__views.__alloyId2, "itemclick", select);

--- a/Source/UI/src/ListView.cpp
+++ b/Source/UI/src/ListView.cpp
@@ -122,13 +122,19 @@ namespace TitaniumWindows
 					const auto result = searchFromSelectedIndex(selectedIndex);
 					const auto sectionIndex = std::get<0>(result);
 					const auto itemIndex    = std::get<1>(result);
+					const auto section      = sections__.at(sectionIndex);
+					const auto properties   = section->getItemAt(itemIndex).properties;
 
 					JSObject eventArgs = ctx.CreateObject();
-					eventArgs.SetProperty("section", sections__.at(sectionIndex)->get_object());
+					if (properties.find("itemId") != properties.end()) {
+						eventArgs.SetProperty("itemId", properties.at("itemId"));
+					}
+					if (properties.find("bindId") != properties.end()) {
+						eventArgs.SetProperty("bindId", properties.at("bindId"));
+					}
+					eventArgs.SetProperty("section", section->get_object());
 					eventArgs.SetProperty("sectionIndex", ctx.CreateNumber(sectionIndex));
 					eventArgs.SetProperty("itemIndex", ctx.CreateNumber(itemIndex));
-
-					// TODO more properties
 					this->fireEvent("itemclick", eventArgs);
 				});
 			}

--- a/Source/UI/src/ListView.cpp
+++ b/Source/UI/src/ListView.cpp
@@ -123,14 +123,17 @@ namespace TitaniumWindows
 					const auto sectionIndex = std::get<0>(result);
 					const auto itemIndex    = std::get<1>(result);
 					const auto section      = sections__.at(sectionIndex);
-					const auto properties   = section->getItemAt(itemIndex).properties;
 
 					JSObject eventArgs = ctx.CreateObject();
-					if (properties.find("itemId") != properties.end()) {
-						eventArgs.SetProperty("itemId", properties.at("itemId"));
-					}
-					if (properties.find("bindId") != properties.end()) {
-						eventArgs.SetProperty("bindId", properties.at("bindId"));
+					if (itemIndex >= 0) {
+						TITANIUM_ASSERT(section->get_items().size() > static_cast<std::uint32_t>(itemIndex));
+						const auto properties = section->getItemAt(itemIndex).properties;
+						if (properties.find("itemId") != properties.end()) {
+							eventArgs.SetProperty("itemId", properties.at("itemId"));
+						}
+						if (properties.find("bindId") != properties.end()) {
+							eventArgs.SetProperty("bindId", properties.at("bindId"));
+						}
 					}
 					eventArgs.SetProperty("section", section->get_object());
 					eventArgs.SetProperty("sectionIndex", ctx.CreateNumber(sectionIndex));


### PR DESCRIPTION
Part of [TIMOB-19056](https://jira.appcelerator.org/browse/TIMOB-19056)

- Add support for `itemId` and `bindId` properties for `itemclick` event on ListView.
- Implement "Refresh" button for RSS reader

```javascript
var win = Ti.UI.createWindow({ backgroundColor: 'blue' });
var listView = Ti.UI.createListView();
var sections = [];

var fruitSection = Ti.UI.createListSection({ headerTitle: 'Fruits' });
var fruitDataSet = [
    { properties: { title: 'Apple', itemId:'apple' } },
    { properties: { title: 'Banana', itemId:'banana' } },
];
fruitSection.setItems(fruitDataSet);
sections.push(fruitSection);

var vegSection = Ti.UI.createListSection({ headerTitle: 'Vegetables' });
var vegDataSet = [
    { properties: { title: 'Carrots', itemId:'carrots' } },
    { properties: { title: 'Potatoes', itemId:'potatos' } },
];
vegSection.setItems(vegDataSet);
sections.push(vegSection);

listView.sections = sections;

listView.addEventListener('itemclick', function(e) {
    Ti.API.info(e.itemId);
});

win.add(listView);
win.open();
```
