### PR TITLE
Fix: wrong callback for AlertDialog

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/AlertDialog.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/AlertDialog.hpp
@@ -11,8 +11,8 @@
 
 #include "TitaniumWindows_UI_EXPORT.h"
 #include "Titanium/UI/AlertDialog.hpp"
-#include <ppltasks.h>
 #include <functional>
+#include <agile.h>
 
 namespace TitaniumWindows
 {
@@ -45,10 +45,11 @@ namespace TitaniumWindows
 			virtual void hide() TITANIUM_NOEXCEPT override;
 			virtual void show() TITANIUM_NOEXCEPT override;
 
-		//private:
+		protected:
 #pragma warning(push)
 #pragma warning(disable : 4251)
-			static std::vector<Windows::UI::Popups::MessageDialog^> dialog_queue__;
+			::Platform::Agile<Windows::UI::Popups::MessageDialog^> dialog__;
+			static std::vector<std::shared_ptr<AlertDialog>> dialog_queue__;
 			std::function<void(Windows::UI::Popups::IUICommand^)> on_click__;
 
 #if WINAPI_FAMILY==WINAPI_FAMILY_PHONE_APP

--- a/Source/UI/include/TitaniumWindows/UI/AlertDialog.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/AlertDialog.hpp
@@ -12,6 +12,7 @@
 #include "TitaniumWindows_UI_EXPORT.h"
 #include "Titanium/UI/AlertDialog.hpp"
 #include <ppltasks.h>
+#include <functional>
 
 namespace TitaniumWindows
 {
@@ -39,6 +40,7 @@ namespace TitaniumWindows
 #endif
 
 			static void JSExportInitialize();
+			virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;
 
 			virtual void hide() TITANIUM_NOEXCEPT override;
 			virtual void show() TITANIUM_NOEXCEPT override;
@@ -47,6 +49,7 @@ namespace TitaniumWindows
 #pragma warning(push)
 #pragma warning(disable : 4251)
 			static std::vector<Windows::UI::Popups::MessageDialog^> dialog_queue__;
+			std::function<void(Windows::UI::Popups::IUICommand^)> on_click__;
 
 #if WINAPI_FAMILY==WINAPI_FAMILY_PHONE_APP
 			static const std::uint32_t MaxButtonCount = 2;


### PR DESCRIPTION
Fix for [TIMOB-19225](https://jira.appcelerator.org/browse/TIMOB-19225)

Following code should print "Callback from Push 1" when you dismiss alert dialog from Push1 button, and should print "Callback from Push 2" when you dismiss alert dialog from Push2 button.

```javascript
var win = Ti.UI.createWindow({layout:'vertical'});

var btn1 = Ti.UI.createButton({ title: 'Push 1' });
btn1.addEventListener('click', function (e) {
    var dialog = Ti.UI.createAlertDialog({
        message: 'Okay 1',
        title: 'Alert Dialog Test 1'
    });
    dialog.addEventListener('click', function (e) {
        Ti.API.info('Callback from Push 1');
    });
    dialog.show();
});
win.add(btn1);

var btn2 = Ti.UI.createButton({ title: 'Push 2' });
btn2.addEventListener('click', function (e) {
    var dialog = Ti.UI.createAlertDialog({
        message: 'Okay 2',
        title: 'Alert Dialog Test 2'
    });
    dialog.addEventListener('click', function (e) {
        Ti.API.info('Callback from Push 2');
    });
    dialog.show();
});
win.add(btn2);

win.open();
```