### PR TITLE
Fix: Word wrap on labels does not work if width and height are not set

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/Label.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/Label.hpp
@@ -11,12 +11,24 @@
 
 #include "TitaniumWindows_UI_EXPORT.h"
 #include "Titanium/UI/Label.hpp"
+#include "TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp"
 
 namespace TitaniumWindows
 {
 	namespace UI
 	{
 		using namespace HAL;
+
+		class TITANIUMWINDOWS_UI_EXPORT WindowsLabelLayoutDelegate : public WindowsViewLayoutDelegate {
+		public:
+			WindowsLabelLayoutDelegate() TITANIUM_NOEXCEPT;
+			virtual ~WindowsLabelLayoutDelegate() = default;
+
+			virtual void setComponent(Windows::UI::Xaml::FrameworkElement^ component) override;
+			virtual void set_width(const std::string& width) TITANIUM_NOEXCEPT override;
+		private:
+			double defaultMaxWidth__;
+		};
 
 		/*!
 		  @class

--- a/Source/UI/include/TitaniumWindows/UI/Label.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/Label.hpp
@@ -26,8 +26,10 @@ namespace TitaniumWindows
 
 			virtual void setComponent(Windows::UI::Xaml::FrameworkElement^ component) override;
 			virtual void set_width(const std::string& width) TITANIUM_NOEXCEPT override;
+			virtual void set_height(const std::string& height) TITANIUM_NOEXCEPT override;
 		private:
 			double defaultMaxWidth__;
+			double defaultMaxHeight__;
 		};
 
 		/*!

--- a/Source/UI/src/Label.cpp
+++ b/Source/UI/src/Label.cpp
@@ -24,11 +24,14 @@ namespace TitaniumWindows
 		{
 			WindowsViewLayoutDelegate::setComponent(label);
 
-			// TIMOB-19048: max width is set to screen width by default
-			defaultMaxWidth__ = label->MaxWidth;
+			// TIMOB-19048: max size is set to screen size by default
+			defaultMaxWidth__  = label->MaxWidth;
+			defaultMaxHeight__ = label->MaxHeight;
 			const auto current = Windows::UI::Xaml::Window::Current;
 			if (current) {
-				label->MaxWidth = current->Bounds.Width;
+				auto b = current->Bounds;
+				label->MaxWidth  = current->Bounds.Width;
+				label->MaxHeight = current->Bounds.Height;
 			}
 		}
 
@@ -36,8 +39,16 @@ namespace TitaniumWindows
 		{
 			WindowsViewLayoutDelegate::set_width(width);
 
-			// reset max width with width is set explicitly
+			// reset max width when width is set explicitly
 			getComponent()->MaxWidth = defaultMaxWidth__;
+		}
+
+		void WindowsLabelLayoutDelegate::set_height(const std::string& height) TITANIUM_NOEXCEPT
+		{
+			WindowsViewLayoutDelegate::set_height(height);
+
+			// reset max height when height is set explicitly
+			getComponent()->MaxHeight = defaultMaxHeight__;
 		}
 
 		// FIXME What file formats does windows support for fonts? We need to limit here! Most of what I read says only TTF, but I see some mentions of OpenType
@@ -69,7 +80,7 @@ namespace TitaniumWindows
 			Titanium::UI::Label::setLayoutDelegate<WindowsLabelLayoutDelegate>();
 
 			label__->TextWrapping = Windows::UI::Xaml::TextWrapping::Wrap;
-			label__->TextTrimming = Windows::UI::Xaml::TextTrimming::Clip;
+			label__->TextTrimming = Windows::UI::Xaml::TextTrimming::None;
 			label__->VerticalAlignment = Windows::UI::Xaml::VerticalAlignment::Center;
 			label__->FontSize = DefaultFontSize;
 

--- a/Source/UI/src/Label.cpp
+++ b/Source/UI/src/Label.cpp
@@ -7,7 +7,6 @@
 */
 
 #include "TitaniumWindows/UI/Label.hpp"
-#include "TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp"
 #include "TitaniumWindows/Utility.hpp"
 #include "Titanium/detail/TiImpl.hpp"
 
@@ -15,6 +14,32 @@ namespace TitaniumWindows
 {
 	namespace UI
 	{
+
+		WindowsLabelLayoutDelegate::WindowsLabelLayoutDelegate() TITANIUM_NOEXCEPT
+			: WindowsViewLayoutDelegate()
+		{
+		}
+
+		void WindowsLabelLayoutDelegate::setComponent(Windows::UI::Xaml::FrameworkElement^ label) 
+		{
+			WindowsViewLayoutDelegate::setComponent(label);
+
+			// TIMOB-19048: max width is set to screen width by default
+			defaultMaxWidth__ = label->MaxWidth;
+			const auto current = Windows::UI::Xaml::Window::Current;
+			if (current) {
+				label->MaxWidth = current->Bounds.Width;
+			}
+		}
+
+		void WindowsLabelLayoutDelegate::set_width(const std::string& width) TITANIUM_NOEXCEPT
+		{
+			WindowsViewLayoutDelegate::set_width(width);
+
+			// reset max width with width is set explicitly
+			getComponent()->MaxWidth = defaultMaxWidth__;
+		}
+
 		// FIXME What file formats does windows support for fonts? We need to limit here! Most of what I read says only TTF, but I see some mentions of OpenType
 		static const std::string ti_label_js = R"TI_LABEL_JS(
 	this.exports = {};
@@ -41,14 +66,14 @@ namespace TitaniumWindows
 			Titanium::UI::Label::postCallAsConstructor(js_context, arguments);
 			
 			label__ = ref new Windows::UI::Xaml::Controls::TextBlock();
-			Titanium::UI::Label::setLayoutDelegate<WindowsViewLayoutDelegate>();
+			Titanium::UI::Label::setLayoutDelegate<WindowsLabelLayoutDelegate>();
 
 			label__->TextWrapping = Windows::UI::Xaml::TextWrapping::Wrap;
 			label__->TextTrimming = Windows::UI::Xaml::TextTrimming::Clip;
 			label__->VerticalAlignment = Windows::UI::Xaml::VerticalAlignment::Center;
 			label__->FontSize = DefaultFontSize;
 
-			getViewLayoutDelegate<WindowsViewLayoutDelegate>()->setComponent(label__);
+			getViewLayoutDelegate<WindowsLabelLayoutDelegate>()->setComponent(label__);
 		}
 
 		void Label::JSExportInitialize()


### PR DESCRIPTION
Fix for [TIMOB-19048](https://jira.appcelerator.org/browse/TIMOB-19048).

```javascript
var win = Ti.UI.createWindow({ backgroundColor: 'white' });

var lbl = Ti.UI.createLabel({
    text: '*** Resources Dir: Test presence of file that exists => blahTest presence of file that does not exist => bleh*** appData Dir:Test presence of file that exists => meh Test presence of file that does not exist => merh',
    color: 'black'
});

win.add(lbl);
win.open();
```

![windows_8_1](https://cloud.githubusercontent.com/assets/1661068/8722435/b672a48e-2bff-11e5-9ed9-09fe10d654de.png)
