### PR TITLE
[TIMOB-19224] Fix 'dp' calculation

### DIFF
--- a/Source/LayoutEngine/src/ParseProperty.cpp
+++ b/Source/LayoutEngine/src/ParseProperty.cpp
@@ -66,7 +66,7 @@ namespace Titanium
 				} else if (units == "px") {
 					return parsedValue;
 				} else if (units == "dp" || units == "dip") {
-					return parsedValue * (ppi / 96);  // 96 - http://en.wikipedia.org/wiki/Dots_per_inch
+					return parsedValue * ppi / 160;
 				}
 			}
 			return 0;


### PR DESCRIPTION
- Fixed ```dp``` calculation
- ```1dp is equal to 1 physical pixel on a 160 DPI screen```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-19224)