### PR TITLE
Implement TabGroup for Windows Store app

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/Tab.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/Tab.hpp
@@ -47,6 +47,8 @@ namespace TitaniumWindows
 		private:
 #if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
 			Windows::UI::Xaml::Controls::PivotItem^ pivotItem__;
+#else
+			Windows::UI::Xaml::Controls::Grid^  grid__;
 #endif
 		};
 	}  // namespace UI

--- a/Source/UI/include/TitaniumWindows/UI/TabGroup.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/TabGroup.hpp
@@ -11,6 +11,7 @@
 
 #include "TitaniumWindows_UI_EXPORT.h"
 #include "Titanium/UI/TabGroup.hpp"
+#include <collection.h>
 
 namespace TitaniumWindows
 {
@@ -52,10 +53,19 @@ namespace TitaniumWindows
 #pragma warning(push)
 #pragma warning(disable : 4251)
 			std::shared_ptr<TitaniumWindows::UI::Window> window__;
+			Windows::UI::Xaml::Controls::Grid^  grid__;
 
 #if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
-			Windows::UI::Xaml::Controls::Grid^  grid__;
 			Windows::UI::Xaml::Controls::Pivot^ pivot__;
+#else
+			//
+			// We're going to use ListView for tab navigation because there's no Pivot for Windows Store app.
+			// On Windows 10 we might want to use SplitView instead.
+			// http://igrali.com/2015/04/12/getting-started-with-splitview-control-in-universal-apps/
+			//
+			Windows::UI::Xaml::Controls::ListView^ sectionView__;
+			Windows::UI::Xaml::Data::CollectionViewSource^ sectionViewSource__;
+			Windows::Foundation::Collections::IObservableVector<::Platform::String^>^ sectionViewItems__;
 #endif
 
 #pragma warning(pop)

--- a/Source/UI/src/TabGroup.cpp
+++ b/Source/UI/src/TabGroup.cpp
@@ -10,12 +10,14 @@
 #include "TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp"
 #include "TitaniumWindows/UI/Tab.hpp"
 #include "TitaniumWindows/UI/Window.hpp"
+#include "TitaniumWindows/Utility.hpp"
 
 namespace TitaniumWindows
 {
 	namespace UI
 	{
-
+		using namespace Platform::Collections;
+		using namespace Windows::UI::Xaml;
 		using namespace Windows::UI::Xaml::Controls;
 
 		TabGroup::TabGroup(const JSContext& js_context) TITANIUM_NOEXCEPT
@@ -26,13 +28,14 @@ namespace TitaniumWindows
 		void TabGroup::postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments)
 		{
 			Titanium::UI::TabGroup::postCallAsConstructor(js_context, arguments);	
-			
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+
 			// root Window object to make layout work
 			window__ = js_context.CreateObject(JSExport<TitaniumWindows::UI::Window>::Class()).CallAsConstructor().GetPrivate<TitaniumWindows::UI::Window>();
 			window__->setTabGroupContainer(true);
 
 			grid__  = ref new Grid();
+
+#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
 			pivot__ = ref new Pivot();
 
 			pivot__->SelectionChanged += ref new SelectionChangedEventHandler([this](Platform::Object^ sender, SelectionChangedEventArgs^ e) {
@@ -41,6 +44,57 @@ namespace TitaniumWindows
 			});
 
 			grid__->Children->Append(pivot__);
+#else
+			sectionView__ = ref new ListView();
+			sectionView__->IsItemClickEnabled = true;
+
+			//
+			// ListView.ItemContainerStyle
+			//
+			Platform::String^ style = R"(
+<Style xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" TargetType="ListViewItem">
+  <Setter Property="HorizontalContentAlignment" Value="Center" />
+  <Setter Property="VerticalContentAlignment" Value="Center" />
+  <Setter Property="FontSize" Value="20"/>
+</Style>
+			)";
+			sectionView__->ItemContainerStyle = static_cast<Style^>(Markup::XamlReader::Load(style));
+
+			sectionView__->ItemClick += ref new Controls::ItemClickEventHandler(
+				[this](Platform::Object^ sender, Controls::ItemClickEventArgs^ e) {
+				const auto listview = safe_cast<Controls::ListView^>(sender);
+
+				uint32_t selectedIndex = -1;
+				listview->Items->IndexOf(e->ClickedItem, &selectedIndex);
+				if (selectedIndex == -1) return;
+
+				TITANIUM_LOG_WARN(tabs__.size() > selectedIndex);
+				set_activeTab(tabs__.at(selectedIndex));
+			});
+
+			sectionViewSource__ = ref new Data::CollectionViewSource();
+			sectionViewItems__ = ref new Vector<Platform::String^>();
+			sectionViewSource__->Source = sectionViewItems__;
+
+			auto binding = ref new Data::Binding();
+			binding->Source = sectionViewSource__;
+			Data::BindingOperations::SetBinding(sectionView__, Controls::ListView::ItemsSourceProperty, binding);
+
+			const auto col1 = ref new ColumnDefinition();
+			const auto col2 = ref new ColumnDefinition();
+			const auto row1    = ref new RowDefinition();
+
+			col1->Width = GridLengthHelper::FromValueAndType(0.25, GridUnitType::Star); // 25%
+			col2->Width = GridLengthHelper::FromValueAndType(0.75, GridUnitType::Star); // 75%
+
+			grid__->ColumnDefinitions->Append(col1);
+			grid__->ColumnDefinitions->Append(col2);
+			grid__->RowDefinitions->Append(row1);
+
+			grid__->Children->Append(sectionView__);
+			grid__->SetColumn(sectionView__, 0);
+			grid__->SetRow(sectionView__, 0);
+#endif
 
 			Titanium::UI::TabGroup::setLayoutDelegate<WindowsViewLayoutDelegate>();
 			layoutDelegate__->set_defaultWidth(Titanium::UI::LAYOUT::FILL);
@@ -48,7 +102,6 @@ namespace TitaniumWindows
 			getViewLayoutDelegate<WindowsViewLayoutDelegate>()->setComponent(grid__);
 
 			window__->getViewLayoutDelegate<WindowsViewLayoutDelegate>()->add(get_object().GetPrivate<Titanium::UI::View>());
-#endif
 		}
 
 		void TabGroup::set_activeTab(const std::shared_ptr<Titanium::UI::Tab>& activeTab) TITANIUM_NOEXCEPT
@@ -58,17 +111,30 @@ namespace TitaniumWindows
 
 		void TabGroup::set_activeTab(const std::shared_ptr<Titanium::UI::Tab>& activeTab, bool updateUI) TITANIUM_NOEXCEPT
 		{
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
 			if (updateUI && activeTab != activeTab__) {
-				pivot__->SelectedItem = activeTab->getViewLayoutDelegate<WindowsViewLayoutDelegate>()->getComponent();
-			}
+				const auto tabview = activeTab->getViewLayoutDelegate<WindowsViewLayoutDelegate>()->getComponent();
+#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+				pivot__->SelectedItem = tabview;
+#else
+				if (grid__->Children->Size > 1) {
+					grid__->Children->RemoveAt(1);
+				}
+				grid__->Children->Append(tabview);
+				grid__->SetColumn(tabview, 1);
+				grid__->SetRow(tabview, 0);
 #endif
+			}
 			Titanium::UI::TabGroup::set_activeTab(activeTab);
 		}
 
 		void TabGroup::open() TITANIUM_NOEXCEPT
 		{
 			window__->open(nullptr);
+
+			if (tabs__.size() > 0) {
+				set_activeTab(tabs__.at(0));
+			}
+
 			Titanium::UI::TabGroup::open();
 		}
 
@@ -81,12 +147,15 @@ namespace TitaniumWindows
 		void TabGroup::addTab(const std::shared_ptr<Titanium::UI::Tab>& tab) TITANIUM_NOEXCEPT
 		{
 			Titanium::UI::TabGroup::addTab(tab);
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
 			const auto windows_tab = dynamic_cast<TitaniumWindows::UI::Tab*>(tab.get());
+			const auto tabview = windows_tab->getViewLayoutDelegate<WindowsViewLayoutDelegate>()->getComponent();
 			if (windows_tab) {
-				pivot__->Items->Append(windows_tab->getViewLayoutDelegate<WindowsViewLayoutDelegate>()->getComponent());
-			}
+#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+				pivot__->Items->Append(tabview);
+#else
+				sectionViewItems__->Append(Utility::ConvertUTF8String(windows_tab->get_title()));
 #endif
+			}
 		}
 
 		void TabGroup::JSExportInitialize() 


### PR DESCRIPTION
Implement TabGroup for Windows Store app. [TIMOB-19187](https://jira.appcelerator.org/browse/TIMOB-19187).

TabGroup for Windows Store now uses [ListView](https://msdn.microsoft.com/library/windows/apps/windows.ui.xaml.controls.listview.aspx) for the navigation because there's no [Pivot](https://msdn.microsoft.com/en-us/library/windows/apps/ff941097%28v=vs.105%29.aspx) for Windows Store app.  [Hub](https://msdn.microsoft.com/en-us/library/windows/apps/dn958438.aspx) is not suitable because it is meant to provide previews/summaries. On the coming Windows 10 we might want to use [SplitView](http://igrali.com/2015/04/12/getting-started-with-splitview-control-in-universal-apps/) instead because it is conceptually well suitable for TabGroup.