### PR TITLE
Fix: HTTPClient.responseXML throws exception

### DIFF
--- a/Source/TitaniumKit/examples/CMakeLists.txt
+++ b/Source/TitaniumKit/examples/CMakeLists.txt
@@ -42,6 +42,8 @@ set(SOURCE_examples
   NativeFileExample.cpp
   NativeWebViewExample.hpp
   NativeWebViewExample.cpp
+  NativeHTTPClientExample.hpp
+  NativeHTTPClientExample.cpp
   )
 add_library(TitaniumKit_examples
   ${SOURCE_examples}

--- a/Source/TitaniumKit/examples/NativeHTTPClientExample.cpp
+++ b/Source/TitaniumKit/examples/NativeHTTPClientExample.cpp
@@ -1,0 +1,27 @@
+/**
+ * TitaniumKit
+ *
+ * Copyright (c) 2015 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License.
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#include "NativeHTTPClientExample.hpp"
+#include "Titanium/detail/TiLogger.hpp"
+
+NativeHTTPClientExample::NativeHTTPClientExample(const JSContext& js_context) TITANIUM_NOEXCEPT
+    : Titanium::Network::HTTPClient(js_context)
+{
+	TITANIUM_LOG_DEBUG("NativeHTTPClientExample:: ctor ", this);
+}
+
+NativeHTTPClientExample::~NativeHTTPClientExample() TITANIUM_NOEXCEPT
+{
+	TITANIUM_LOG_DEBUG("NativeHTTPClientExample:: dtor ", this);
+}
+
+void NativeHTTPClientExample::JSExportInitialize()
+{
+	JSExport<NativeHTTPClientExample>::SetClassVersion(1);
+	JSExport<NativeHTTPClientExample>::SetParent(JSExport<Titanium::Network::HTTPClient>::Class());
+}

--- a/Source/TitaniumKit/examples/NativeHTTPClientExample.hpp
+++ b/Source/TitaniumKit/examples/NativeHTTPClientExample.hpp
@@ -1,0 +1,37 @@
+/**
+ * TitaniumKit
+ *
+ * Copyright (c) 2015 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License.
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#ifndef _TITANIUM_EXAMPLES_HTTPCLIENTEXAMPLE_HPP_
+#define _TITANIUM_EXAMPLES_HTTPCLIENTEXAMPLE_HPP_
+
+#include "Titanium/Network/HTTPClient.hpp"
+
+using namespace HAL;
+
+/*!
+  @class
+  @discussion This is an example of how to implement Titanium::Network::HTTPClient
+  for a native platform.
+ */
+class NativeHTTPClientExample final : public Titanium::Network::HTTPClient, public JSExport<NativeHTTPClientExample>
+{
+public:
+	NativeHTTPClientExample(const JSContext&) TITANIUM_NOEXCEPT;
+
+	virtual ~NativeHTTPClientExample() TITANIUM_NOEXCEPT;
+	NativeHTTPClientExample(const NativeHTTPClientExample&) = default;
+	NativeHTTPClientExample& operator=(const NativeHTTPClientExample&) = default;
+#ifdef TITANIUM_MOVE_CTOR_AND_ASSIGN_DEFAULT_ENABLE
+	NativeHTTPClientExample(NativeHTTPClientExample&&) = default;
+	NativeHTTPClientExample& operator=(NativeHTTPClientExample&&) = default;
+#endif
+
+	static void JSExportInitialize();
+};
+
+#endif  // _TITANIUM_EXAMPLES_HTTPCLIENTEXAMPLE_HPP_

--- a/Source/TitaniumKit/src/Network/HTTPClient.cpp
+++ b/Source/TitaniumKit/src/Network/HTTPClient.cpp
@@ -354,24 +354,25 @@ namespace Titanium
 
 		TITANIUM_PROPERTY_GETTER(HTTPClient, responseXML)
 		{
-			auto text = js_get_responseText();
+			const auto text = js_get_responseText();
 			if (text.IsNull()) {
 				return text;
 			}
 
-			auto global_object = get_context().get_global_object();
+			const auto global_object = get_context().get_global_object();
 
-			auto ti = global_object.GetProperty("Titanium");
-			auto Titanium = static_cast<JSObject>(ti);
-			auto xml = Titanium.GetProperty("XML");
-			auto XML = static_cast<JSObject>(xml);
+			const auto ti = global_object.GetProperty("Titanium");
+			const auto Titanium = static_cast<JSObject>(ti);
+			const auto xml = Titanium.GetProperty("XML");
+			const auto XML = static_cast<JSObject>(xml);
+			const auto parseString = XML.GetProperty("parseString");
+			const std::vector<JSValue> arguments = { text };
 
-			auto parseString = XML.GetProperty("parseString");
-			auto parseStringObject = static_cast<JSObject>(parseString);
-			std::vector<JSValue> arguments = { text };
-			auto result = parseStringObject(arguments, global_object);
-
-			return result;
+			try {
+				return static_cast<JSObject>(parseString)(arguments, global_object);
+			} catch (const HAL::detail::js_runtime_error& ex) {
+				return get_context().CreateNull();
+			}
 		}
 
 		TITANIUM_FUNCTION(HTTPClient, getResponseXML)

--- a/Source/TitaniumKit/src/Network/HTTPClient.cpp
+++ b/Source/TitaniumKit/src/Network/HTTPClient.cpp
@@ -370,7 +370,7 @@ namespace Titanium
 
 			try {
 				return static_cast<JSObject>(parseString)(arguments, global_object);
-			} catch (const HAL::detail::js_runtime_error& ex) {
+			} catch (const HAL::detail::js_runtime_error&) {
 				return get_context().CreateNull();
 			}
 		}

--- a/Source/TitaniumKit/test/DatabaseTests.cpp
+++ b/Source/TitaniumKit/test/DatabaseTests.cpp
@@ -54,4 +54,6 @@ TEST_F(DatabaseTests, BasicFeatures)
 	XCTAssertTrue(Database.HasProperty("install"));
 	XCTAssertTrue(Database.HasProperty("open"));
 
+	auto json_result = js_context.JSEvaluateScript("JSON.stringify(Ti.Database);");
+	XCTAssertTrue(static_cast<std::string>(json_result).find("\"FIELD_TYPE_DOUBLE\":") != std::string::npos);
 }

--- a/Source/TitaniumKit/test/FilesystemTests.cpp
+++ b/Source/TitaniumKit/test/FilesystemTests.cpp
@@ -54,4 +54,6 @@ TEST_F(FilesystemTests, BasicFeatures)
 	XCTAssertTrue(Filesystem.HasProperty("getLineEnding"));
 	XCTAssertNoThrow(js_context.JSEvaluateScript("Ti.Filesystem.getLineEnding();"));
 
+	auto json_result = js_context.JSEvaluateScript("JSON.stringify(Ti.Filesystem);");
+	XCTAssertTrue(static_cast<std::string>(json_result).find("\"lineEnding\":") != std::string::npos);
 }

--- a/Source/TitaniumKit/test/MediaTests.cpp
+++ b/Source/TitaniumKit/test/MediaTests.cpp
@@ -228,6 +228,9 @@ TEST_F(MediaTests, BasicFeatures)
 	XCTAssertTrue(Media.HasProperty("getPeakMicrophonePower"));
 	XCTAssertTrue(Media.HasProperty("getSystemMusicPlayer"));
 	XCTAssertTrue(Media.HasProperty("getVolume"));
+
+	auto json_result = js_context.JSEvaluateScript("JSON.stringify(Ti.Media);");
+	XCTAssertTrue(static_cast<std::string>(json_result).find("\"appMusicPlayer\":") != std::string::npos);
 }
 
 TEST_F(MediaTests, AudioPlayerBasicFeatures)

--- a/Source/TitaniumKit/test/ModuleTests.cpp
+++ b/Source/TitaniumKit/test/ModuleTests.cpp
@@ -103,4 +103,10 @@ TEST_F(ModuleTests, properties)
 	XCTAssertNoThrow(result = js_context.JSEvaluateScript("module.enabled;"));
 	XCTAssertTrue(result.IsBoolean());
 	XCTAssertFalse(static_cast<bool>(result));
+
+	auto json_result = js_context.JSEvaluateScript("JSON.stringify(Ti.Module);");
+	XCTAssertEqual("{}", static_cast<std::string>(json_result));
+
+	json_result = js_context.JSEvaluateScript("JSON.stringify(module);");
+	XCTAssertEqual("{\"enabled\":false}", static_cast<std::string>(json_result));
 }

--- a/Source/TitaniumKit/test/NativeAccelerometerTests.cpp
+++ b/Source/TitaniumKit/test/NativeAccelerometerTests.cpp
@@ -55,4 +55,6 @@ TEST_F(AccelerometerTests, logging)
 
 	XCTAssertTrue(Accelerometer.HasProperty("addEventListener"));
 	ASSERT_NO_THROW(js_context.JSEvaluateScript("Ti.Accelerometer.addEventListener('update', function(){});"));
+
+	ASSERT_NO_THROW(js_context.JSEvaluateScript("JSON.stringify(Ti.Accelerometer);"));
 }

--- a/Source/TitaniumKit/test/NativeBlobTests.cpp
+++ b/Source/TitaniumKit/test/NativeBlobTests.cpp
@@ -78,4 +78,9 @@ TEST_F(BlobTests, logging)
 	XCTAssertTrue(blob.HasProperty("getWidth"));
 	XCTAssertTrue(blob.HasProperty("append"));
 	XCTAssertTrue(blob.HasProperty("toString"));
+
+	global_object.SetProperty("blob", blob);
+
+	auto json_result = js_context.JSEvaluateScript("JSON.stringify(blob);");
+	XCTAssertTrue(static_cast<std::string>(json_result).find("\"mimeType\":") != std::string::npos);
 }

--- a/Source/TitaniumKit/test/NativeButtonTests.cpp
+++ b/Source/TitaniumKit/test/NativeButtonTests.cpp
@@ -76,4 +76,7 @@ TEST_F(ButtonTests, basic_functionality)
 	XCTAssertTrue(result.IsObject());
 	JSObject button = static_cast<JSObject>(result);
 	XCTAssertTrue(button.HasProperty("title"));
+
+	auto json_result = js_context.JSEvaluateScript("JSON.stringify(Ti.UI.createButton());");
+	XCTAssertTrue(static_cast<std::string>(json_result).find("\"textAlign\":") != std::string::npos);
 }

--- a/Source/TitaniumKit/test/NativeFileTests.cpp
+++ b/Source/TitaniumKit/test/NativeFileTests.cpp
@@ -84,6 +84,9 @@ TEST_F(FileTests, logging)
 	XCTAssertTrue(Filesystem.HasProperty("getResourcesDirectory"));
 	XCTAssertTrue(Filesystem.HasProperty("getTempDirectory"));
 
+	auto json_result = js_context.JSEvaluateScript("JSON.stringify(Ti.Filesystem);");
+	XCTAssertTrue(static_cast<std::string>(json_result).find("\"separator\":") != std::string::npos);
+
 	auto File_ptr = File.GetPrivate<NativeFileExample>();
 	XCTAssertNotEqual(nullptr, File_ptr);
 
@@ -133,4 +136,8 @@ TEST_F(FileTests, logging)
 	XCTAssertTrue(file.HasProperty("resolve"));
 	XCTAssertTrue(file.HasProperty("spaceAvailable"));
 	XCTAssertTrue(file.HasProperty("write"));
+
+	global_object.SetProperty("file", file);
+	json_result = js_context.JSEvaluateScript("JSON.stringify(file);");
+	XCTAssertTrue(static_cast<std::string>(json_result).find("\"symbolicLink\":") != std::string::npos);
 }

--- a/Source/TitaniumKit/test/NativeGestureTests.cpp
+++ b/Source/TitaniumKit/test/NativeGestureTests.cpp
@@ -64,4 +64,7 @@ TEST_F(GestureTests, logging)
 	JSValue result = js_context.CreateNull();
 	XCTAssertNoThrow(result = js_context.JSEvaluateScript("Ti.Gesture.landscape"));
 	XCTAssertTrue(result.IsBoolean());
+
+	auto json_result = js_context.JSEvaluateScript("JSON.stringify(Ti.Gesture);");
+	XCTAssertTrue(static_cast<std::string>(json_result).find("\"orientation\":") != std::string::npos);
 }

--- a/Source/TitaniumKit/test/NativePlatformTests.cpp
+++ b/Source/TitaniumKit/test/NativePlatformTests.cpp
@@ -120,4 +120,7 @@ TEST_F(PlatformTests, logging)
 	XCTAssertTrue(result.IsString());
 	std::string SIZE = static_cast<std::string>(result);
 	XCTAssertEqual("osx", SIZE);
+
+	auto json_result = js_context.JSEvaluateScript("JSON.stringify(Ti.Platform);");
+	XCTAssertTrue(static_cast<std::string>(json_result).find("\"osname\":") != std::string::npos);
 }

--- a/Source/TitaniumKit/test/NativeTiTests.cpp
+++ b/Source/TitaniumKit/test/NativeTiTests.cpp
@@ -71,4 +71,7 @@ TEST_F(TitaniumTests, logging)
 	XCTAssertTrue(result.IsString());
 	std::string userAgent = static_cast<std::string>(result);
 	XCTAssertEqual("__TITANIUM_USER_AGENT__", userAgent);
+
+	auto json_result = js_context.JSEvaluateScript("JSON.stringify(Ti);");
+	XCTAssertTrue(static_cast<std::string>(json_result).find("\"version\":") != std::string::npos);
 }

--- a/Source/TitaniumKit/test/NativeWebViewTests.cpp
+++ b/Source/TitaniumKit/test/NativeWebViewTests.cpp
@@ -67,4 +67,7 @@ TEST_F(WebViewTests, basic_functionality)
 	JSObject webview = static_cast<JSObject>(result);
 	XCTAssertTrue(webview.HasProperty("canGoBack"));
 
+	global_object.SetProperty("webview", result);
+	auto json_result = js_context.JSEvaluateScript("JSON.stringify(webview);");
+	XCTAssertTrue(static_cast<std::string>(json_result).find("\"url\":") != std::string::npos);
 }

--- a/Source/TitaniumKit/test/NativeWindowTests.cpp
+++ b/Source/TitaniumKit/test/NativeWindowTests.cpp
@@ -77,4 +77,7 @@ TEST_F(WindowTests, basic_functionality)
 	XCTAssertTrue(window.HasProperty("open"));
 
 	XCTAssertNoThrow(js_context.JSEvaluateScript("var window = Ti.UI.createWindow(); window.open();"));
+
+	auto json_result = js_context.JSEvaluateScript("JSON.stringify(window);");
+	XCTAssertTrue(static_cast<std::string>(json_result).find("\"backgroundColor\":") != std::string::npos);
 }

--- a/Source/TitaniumKit/test/NetworkTests.cpp
+++ b/Source/TitaniumKit/test/NetworkTests.cpp
@@ -8,6 +8,8 @@
 #include "Titanium/NetworkModule.hpp"
 #include "Titanium/Network/Cookie.hpp"
 #include "Titanium/Network/HTTPClient.hpp"
+#include "Titanium/XML.hpp"
+#include "NativeHTTPClientExample.hpp"
 #include "gtest/gtest.h"
 
 #define XCTAssertEqual ASSERT_EQ
@@ -52,6 +54,16 @@ TEST_F(NetworkTests, BasicFeatures)
 	auto Network = js_context.CreateObject(JSExport<Titanium::NetworkModule>::Class());
 	Titanium.SetProperty("Network", Network, {JSPropertyAttribute::ReadOnly, JSPropertyAttribute::DontDelete});
 	XCTAssertTrue(Titanium.HasProperty("Network"));
+
+	XCTAssertFalse(Titanium.HasProperty("XML"));
+	auto XML = js_context.CreateObject(JSExport<Titanium::XML>::Class());
+	Titanium.SetProperty("XML", XML, {JSPropertyAttribute::ReadOnly, JSPropertyAttribute::DontDelete});
+	XCTAssertTrue(Titanium.HasProperty("XML"));
+
+	XCTAssertFalse(Network.HasProperty("HTTPClient"));
+	auto HTTPClient = js_context.CreateObject(JSExport<NativeHTTPClientExample>::Class());
+	Network.SetProperty("HTTPClient", HTTPClient, {JSPropertyAttribute::ReadOnly, JSPropertyAttribute::DontDelete});
+	XCTAssertTrue(Network.HasProperty("HTTPClient"));
 
 	XCTAssertTrue(Network.HasProperty("NETWORK_LAN"));
 	XCTAssertTrue(Network.HasProperty("NETWORK_MOBILE"));
@@ -100,6 +112,9 @@ TEST_F(NetworkTests, BasicFeatures)
 	XCTAssertTrue(Network.HasProperty("getRemoteNotificationsEnabled"));
 	XCTAssertTrue(Network.HasProperty("getHttpURLFormatter"));
 	XCTAssertTrue(Network.HasProperty("setHttpURLFormatter"));
+
+	auto json_result = js_context.JSEvaluateScript("JSON.stringify(Ti.Network.createHTTPClient());");
+	XCTAssertTrue(static_cast<std::string>(json_result).find("\"connectionType\":\"\"") != std::string::npos);
 }
 
 TEST_F(NetworkTests, CookieBasicFeatures)
@@ -117,10 +132,15 @@ TEST_F(NetworkTests, CookieBasicFeatures)
 	global_object.SetProperty("Ti", Titanium, {JSPropertyAttribute::ReadOnly, JSPropertyAttribute::DontDelete});
 	XCTAssertTrue(global_object.HasProperty("Ti"));
 
-	XCTAssertFalse(Titanium.HasProperty("Cookie"));
+	XCTAssertFalse(Titanium.HasProperty("Network"));
+	auto Network = js_context.CreateObject(JSExport<Titanium::NetworkModule>::Class());
+	Titanium.SetProperty("Network", Network, {JSPropertyAttribute::ReadOnly, JSPropertyAttribute::DontDelete});
+	XCTAssertTrue(Titanium.HasProperty("Network"));
+
+	XCTAssertFalse(Network.HasProperty("Cookie"));
 	auto Cookie = js_context.CreateObject(JSExport<Titanium::Network::Cookie>::Class());
-	Titanium.SetProperty("Cookie", Cookie, {JSPropertyAttribute::ReadOnly, JSPropertyAttribute::DontDelete});
-	XCTAssertTrue(Titanium.HasProperty("Cookie"));
+	Network.SetProperty("Cookie", Cookie, {JSPropertyAttribute::ReadOnly, JSPropertyAttribute::DontDelete});
+	XCTAssertTrue(Network.HasProperty("Cookie"));
 
 	XCTAssertTrue(Cookie.HasProperty("comment"));
 	XCTAssertTrue(Cookie.HasProperty("domain"));
@@ -169,10 +189,15 @@ TEST_F(NetworkTests, HTTPClientBasicFeatures)
 	global_object.SetProperty("Ti", Titanium, {JSPropertyAttribute::ReadOnly, JSPropertyAttribute::DontDelete});
 	XCTAssertTrue(global_object.HasProperty("Ti"));
 
-	XCTAssertFalse(Titanium.HasProperty("HTTPClient"));
-	auto HTTPClient = js_context.CreateObject(JSExport<Titanium::Network::HTTPClient>::Class());
-	Titanium.SetProperty("HTTPClient", HTTPClient, {JSPropertyAttribute::ReadOnly, JSPropertyAttribute::DontDelete});
-	XCTAssertTrue(Titanium.HasProperty("HTTPClient"));
+	XCTAssertFalse(Titanium.HasProperty("Network"));
+	auto Network = js_context.CreateObject(JSExport<Titanium::NetworkModule>::Class());
+	Titanium.SetProperty("Network", Network, {JSPropertyAttribute::ReadOnly, JSPropertyAttribute::DontDelete});
+	XCTAssertTrue(Titanium.HasProperty("Network"));
+
+	XCTAssertFalse(Network.HasProperty("HTTPClient"));
+	auto HTTPClient = js_context.CreateObject(JSExport<NativeHTTPClientExample>::Class());
+	Network.SetProperty("HTTPClient", HTTPClient, {JSPropertyAttribute::ReadOnly, JSPropertyAttribute::DontDelete});
+	XCTAssertTrue(Network.HasProperty("HTTPClient"));
 
 	XCTAssertTrue(HTTPClient.HasProperty("autoEncodeUrl"));
 	XCTAssertTrue(HTTPClient.HasProperty("autoRedirect"));

--- a/Source/TitaniumKit/test/TiAppTests.cpp
+++ b/Source/TitaniumKit/test/TiAppTests.cpp
@@ -54,6 +54,8 @@ TEST_F(TiAppTests, BasicFeatures)
 	XCTAssertTrue(App.HasProperty("getVersion"));
 	XCTAssertNoThrow(js_context.JSEvaluateScript("Ti.App.getVersion();"));
 
+	auto json_result = js_context.JSEvaluateScript("JSON.stringify(Ti.App);");
+	XCTAssertTrue(static_cast<std::string>(json_result).find("\"version\":") != std::string::npos);
 }
 
 TEST_F(TiAppTests, TIMOB_19213)

--- a/Source/TitaniumKit/test/UITests.cpp
+++ b/Source/TitaniumKit/test/UITests.cpp
@@ -215,4 +215,8 @@ TEST_F(UITests, ActivityIndicator)
 	XCTAssertNoThrow(js_context.JSEvaluateScript("var indicator = Ti.UI.createActivityIndicator();"));
 	XCTAssertTrue(static_cast<bool>(js_context.JSEvaluateScript("indicator.style == Ti.UI.ActivityIndicatorStyle.PLAIN")));
 
+	// make sure JSON.stringify returns ActivityIndicatorStyle-specific property
+	auto json_result = js_context.JSEvaluateScript("JSON.stringify(indicator);");
+	XCTAssertTrue(static_cast<std::string>(json_result).find("\"indicatorColor\":\"\"") != std::string::npos);
+
 }


### PR DESCRIPTION
Fix for [TIMOB-19181](https://jira.appcelerator.org/browse/TIMOB-19181) and [TIMOB-19183](https://jira.appcelerator.org/browse/TIMOB-19183).

- Fix: JSON.stringify fails for Ti.Network.HTTPClient
- Add unit test for JSON.stringify

```javascript
var win = Ti.UI.createWindow();
Ti.API.info(JSON.stringify(Ti.Network.createHTTPClient(), null, 2));
win.open();
```
