### PR TITLE
[TIMOB-19148] Fix MSBuild error output

### DIFF
--- a/cli/commands/_build/compile.js
+++ b/cli/commands/_build/compile.js
@@ -81,7 +81,7 @@ function compileApp(next) {
 		p.stdout.on('data', function (data) {
 			var line = data.toString().trim();
 			if (line.indexOf('error ') >= 0) {
-				_t.logger.warn(line);
+				_t.logger.error(line);
 			}
 			else if (line.indexOf('warning ') >= 0) {
 				_t.logger.warn(line);


### PR DESCRIPTION
- Fix ```error``` output being displayed as a ```warning```

[TIMOB-19148](https://jira.appcelerator.org/browse/TIMOB-19148)