### PR TITLE
Revert "Fix TIMOB-19153.." #390

### DIFF
--- a/cli/hooks/wp-run.js
+++ b/cli/hooks/wp-run.js
@@ -212,7 +212,7 @@ exports.init = function (logger, config, cli) {
 					appxExtensions = ['.appx', '.appxbundle'],
 					installs = [];
 
-				function installApp(deviceId, xapFile, opts, next) {
+				function installApp(deviceId, xapFile, opts) {
 					// Now install the real app
 					windowslib.install(deviceId, xapFile, opts)
 						.on('installed', function (handle) {
@@ -241,18 +241,16 @@ exports.init = function (logger, config, cli) {
 								logger.info(__('Waiting for app to connect to log relay'));
 							} else {
 								// no reason to stick around, let the build command finish
-								next(null);
+								finished();
 							}
 						})
 						.on('timeout', function (err) {
 							logRelay && logRelay.stop();
 							logger.error(err.message);
-							next(err);
 						})
 						.on('error', function (err) {
 							logRelay && logRelay.stop();
 							logger.error(err.message);
-							next(err);
 						});
 				}
 
@@ -285,7 +283,7 @@ exports.init = function (logger, config, cli) {
 				});
         		possibleApps.forEach(function(file) {
         			installs.push(function (next) {
-						installApp(builder.deviceId, path.resolve(appxDir, file), opts, next);
+						installApp(builder.deviceId, path.resolve(appxDir, file), opts);
 					});
         		});
 


### PR DESCRIPTION
I would like to revert #390, I had experienced following error during `ti build` for development deployment. I shouldn't have merged it.

```
[ERROR] Failed to start emulator "8-1-1"
[ERROR] Connection failed because of invalid command-line arguments.
```