### PR TITLE
Re-introduce Fix for TIMOB-19153

### DIFF
--- a/cli/hooks/wp-run.js
+++ b/cli/hooks/wp-run.js
@@ -214,7 +214,7 @@ exports.init = function (logger, config, cli) {
 					appxExtensions = ['.appx', '.appxbundle'],
 					installs = [];
 
-				function installApp(deviceId, xapFile, opts) {
+				function installApp(deviceId, xapFile, opts, next) {
 					// Now install the real app
 					windowslib.install(deviceId, xapFile, opts)
 						.on('installed', function (handle) {
@@ -243,16 +243,18 @@ exports.init = function (logger, config, cli) {
 								logger.info(__('Waiting for app to connect to log relay'));
 							} else {
 								// no reason to stick around, let the build command finish
-								finished();
+								next(null);
 							}
 						})
 						.on('timeout', function (err) {
 							logRelay && logRelay.stop();
 							logger.error(err.message);
+							next(err);
 						})
 						.on('error', function (err) {
 							logRelay && logRelay.stop();
 							logger.error(err.message);
+							next(err);
 						});
 				}
 
@@ -285,7 +287,7 @@ exports.init = function (logger, config, cli) {
 				});
         		possibleApps.forEach(function(file) {
         			installs.push(function (next) {
-						installApp(builder.deviceId, path.resolve(appxDir, file), opts);
+						installApp(builder.deviceId, path.resolve(appxDir, file), opts, next);
 					});
         		});
 


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-19153

I think the error Kota ran into before was related to issues seen on the build machine - where suddenly shorthand options are not working for titanium CLI (i.e. -C and -T versus --device-id and --target), see https://jira.appcelerator.org/browse/TIMOB-19281

Reverts appcelerator/titanium_mobile_windows#393