### PR TITLE
[TIMOB-18757] Implement Titanium.UI.Clipboard

### DIFF
--- a/Source/Titanium/src/TitaniumWindows.cpp
+++ b/Source/Titanium/src/TitaniumWindows.cpp
@@ -11,6 +11,7 @@
 #include "Titanium/ApplicationBuilder.hpp"
 #include "TitaniumWindows/TiModule.hpp"
 #include "TitaniumWindows/UIModule.hpp"
+#include "TitaniumWindows/UI/Clipboard.hpp"
 #include "TitaniumWindows/API.hpp"
 #include "TitaniumWindows/AppModule.hpp"
 #include "TitaniumWindows/Locale.hpp"
@@ -101,6 +102,7 @@ namespace TitaniumWindows
 		                                                            .GeolocationObject(js_context__.CreateObject(JSExport<TitaniumWindows::Geolocation>::Class()))
 		                                                            .AccelerometerObject(js_context__.CreateObject(JSExport<TitaniumWindows::Accelerometer>::Class()))
 		                                                            .ViewObject(js_context__.CreateObject(JSExport<TitaniumWindows::UI::View>::Class()))
+		                                                            .ClipboardObject(js_context__.CreateObject(JSExport<TitaniumWindows::UI::Clipboard>::Class()))
 		                                                            .TextAreaObject(js_context__.CreateObject(JSExport<TitaniumWindows::UI::TextArea>::Class()))
 		                                                            .NotificationObject(js_context__.CreateObject(JSExport<TitaniumWindows::UI::Notification>::Class()))
 		                                                            .SwitchObject(js_context__.CreateObject(JSExport<TitaniumWindows::UI::Switch>::Class()))

--- a/Source/TitaniumKit/CMakeLists.txt
+++ b/Source/TitaniumKit/CMakeLists.txt
@@ -200,6 +200,8 @@ set(SOURCE_Network
   )
 
 set(SOURCE_UI
+  include/Titanium/UI/Clipboard.hpp
+  src/UI/Clipboard.cpp
   include/Titanium/UI/2DMatrix.hpp
   src/UI/2DMatrix.cpp
   include/Titanium/UI/ActivityIndicator.hpp

--- a/Source/TitaniumKit/include/Titanium/ApplicationBuilder.hpp
+++ b/Source/TitaniumKit/include/Titanium/ApplicationBuilder.hpp
@@ -77,6 +77,9 @@ namespace Titanium
 		JSObject TextAreaObject() const TITANIUM_NOEXCEPT;
 		ApplicationBuilder& TextAreaObject(const JSObject&) TITANIUM_NOEXCEPT;
 
+		JSObject ClipboardObject() const TITANIUM_NOEXCEPT;
+		ApplicationBuilder& ClipboardObject(const JSObject&) TITANIUM_NOEXCEPT;
+
 		JSObject ViewObject() const TITANIUM_NOEXCEPT;
 		ApplicationBuilder& ViewObject(const JSObject&) TITANIUM_NOEXCEPT;
 
@@ -235,6 +238,7 @@ namespace Titanium
 		JSObject api__;
 		JSObject locale__;
 		JSObject view__;
+		JSObject clipboard__;
 		JSObject textarea__;
 		JSObject notification__;
 		JSObject twodmatrix__;

--- a/Source/TitaniumKit/include/Titanium/UI/Clipboard.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/Clipboard.hpp
@@ -1,0 +1,109 @@
+/**
+ * TitaniumKit Titanium.UI.Clipboard
+ *
+ * Copyright (c) 2015 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License.
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#ifndef _TITANIUM_CLIPBOARD_HPP_
+#define _TITANIUM_CLIPBOARD_HPP_
+
+#include "Titanium/UI/View.hpp"
+
+namespace Titanium
+{
+	namespace UI
+	{
+		using namespace HAL;
+
+		/*!
+		  @class
+		  @discussion This is the Titanium Clipboard Module.
+		  See http://docs.appcelerator.com/titanium/latest/#!/api/Titanium.UI.Clipboard
+		*/
+		class TITANIUMKIT_EXPORT Clipboard : public View, public JSExport<Clipboard>
+		{
+
+		public:
+
+			/*!
+			  @method
+			  @abstract clearData
+			  @discussion Deletes data of the specified MIME type stored in the clipboard. If MIME type omitted, all data is deleted.
+			*/
+			virtual void clearData(const std::string& type) TITANIUM_NOEXCEPT;
+
+			/*!
+			  @method
+			  @abstract clearText
+			  @discussion Deletes all text data stored in the clipboard.
+			*/
+			virtual void clearText() TITANIUM_NOEXCEPT;
+
+			/*!
+			  @method
+			  @abstract getData
+			  @discussion Gets data of the specified MIME type stored in the clipboard.
+			*/
+			virtual JSObject getData(const std::string& type) TITANIUM_NOEXCEPT;
+
+			/*!
+			  @method
+			  @abstract getText
+			  @discussion Gets text data stored in the clipboard.
+			*/
+			virtual std::string getText() TITANIUM_NOEXCEPT;
+
+			/*!
+			  @method
+			  @abstract hasData
+			  @discussion Indicates whether any data of the specified MIME type is stored in the clipboard.
+			*/
+			virtual bool hasData(const std::string& type) TITANIUM_NOEXCEPT;
+
+			/*!
+			  @method
+			  @abstract hasText
+			  @discussion Indicates whether any text data is stored in the clipboard.
+			*/
+			virtual bool hasText() TITANIUM_NOEXCEPT;
+
+			/*!
+			  @method
+			  @abstract setData
+			  @discussion Stores data of the specified MIME type in the clipboard.
+			*/
+			virtual void setData(const std::string& type, JSObject data) TITANIUM_NOEXCEPT;
+
+			/*!
+			  @method
+			  @abstract setText
+			  @discussion Stores text data in the clipboard.
+			*/
+			virtual void setText(const std::string& text) TITANIUM_NOEXCEPT;
+
+			Clipboard(const JSContext&, const std::vector<JSValue>& arguments = {}) TITANIUM_NOEXCEPT;
+			virtual ~Clipboard()                   = default;
+			Clipboard(const Clipboard&)            = default;
+			Clipboard& operator=(const Clipboard&) = default;
+#ifdef TITANIUM_MOVE_CTOR_AND_ASSIGN_DEFAULT_ENABLE
+			Clipboard(Clipboard&&)                 = default;
+			Clipboard& operator=(Clipboard&&)      = default;
+#endif
+
+			static void JSExportInitialize();
+
+			TITANIUM_FUNCTION_DEF(clearData);
+			TITANIUM_FUNCTION_DEF(clearText);
+			TITANIUM_FUNCTION_DEF(getData);
+			TITANIUM_FUNCTION_DEF(getText);
+			TITANIUM_FUNCTION_DEF(hasData);
+			TITANIUM_FUNCTION_DEF(hasText);
+			TITANIUM_FUNCTION_DEF(setData);
+			TITANIUM_FUNCTION_DEF(setText);
+		};
+
+	} // namespace UI
+} // namespace Titanium
+#endif // _TITANIUM_CLIPBOARD_HPP_

--- a/Source/TitaniumKit/src/ApplicationBuilder.cpp
+++ b/Source/TitaniumKit/src/ApplicationBuilder.cpp
@@ -13,6 +13,7 @@
 #include "Titanium/GlobalString.hpp"
 #include "Titanium/TiModule.hpp"
 #include "Titanium/UIModule.hpp"
+#include "Titanium/UI/Clipboard.hpp"
 #include "Titanium/API.hpp"
 #include "Titanium/Locale.hpp"
 #include "Titanium/UI/View.hpp"
@@ -86,6 +87,7 @@ namespace Titanium
 		  api__(js_context__.CreateObject(JSExport<Titanium::API>::Class())),
 		  locale__(js_context__.CreateObject(JSExport<Titanium::Locale>::Class())),
 		  view__(js_context__.CreateObject(JSExport<Titanium::UI::View>::Class())),
+		  clipboard__(js_context__.CreateObject(JSExport<Titanium::UI::Clipboard>::Class())),
 		  textarea__(js_context__.CreateObject(JSExport<Titanium::UI::TextArea>::Class())),
 		  notification__(js_context__.CreateObject(JSExport<Titanium::UI::Notification>::Class())),
 		  twodmatrix__(js_context__.CreateObject(JSExport<Titanium::UI::TwoDMatrix>::Class())),
@@ -154,6 +156,7 @@ namespace Titanium
 		ui__.SetProperty("AlertDialog", alertDialog__, {JSPropertyAttribute::ReadOnly, JSPropertyAttribute::DontDelete});
 		ui__.SetProperty("Animation", animation__, {JSPropertyAttribute::ReadOnly, JSPropertyAttribute::DontDelete});
 		ui__.SetProperty("Button", button__, {JSPropertyAttribute::ReadOnly, JSPropertyAttribute::DontDelete});
+		ui__.SetProperty("Clipboard", clipboard__, { JSPropertyAttribute::ReadOnly, JSPropertyAttribute::DontDelete });
 		ui__.SetProperty("EmailDialog", emaildialog__, {JSPropertyAttribute::ReadOnly, JSPropertyAttribute::DontDelete});
 		ui__.SetProperty("ImageView", imageview__, {JSPropertyAttribute::ReadOnly, JSPropertyAttribute::DontDelete});
 		ui__.SetProperty("Label", label__, {JSPropertyAttribute::ReadOnly, JSPropertyAttribute::DontDelete});
@@ -468,6 +471,17 @@ namespace Titanium
 	ApplicationBuilder& ApplicationBuilder::TextAreaObject(const JSObject& TextArea) TITANIUM_NOEXCEPT
 	{
 		textarea__ = TextArea;
+		return *this;
+	}
+
+	JSObject ApplicationBuilder::ClipboardObject() const TITANIUM_NOEXCEPT
+	{
+		return clipboard__;
+	}
+
+	ApplicationBuilder& ApplicationBuilder::ClipboardObject(const JSObject& Clipboard) TITANIUM_NOEXCEPT
+	{
+		clipboard__ = Clipboard;
 		return *this;
 	}
 

--- a/Source/TitaniumKit/src/UI/Clipboard.cpp
+++ b/Source/TitaniumKit/src/UI/Clipboard.cpp
@@ -1,0 +1,146 @@
+/**
+ * TitaniumKit Titanium.UI.Clipboard
+ *
+ * Copyright (c) 2015 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License.
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#include "Titanium/UI/Clipboard.hpp"
+
+namespace Titanium
+{
+	namespace UI
+	{
+
+		Clipboard::Clipboard(const JSContext& js_context, const std::vector<JSValue>& arguments) TITANIUM_NOEXCEPT
+			: View(js_context)
+		{
+		}
+
+		void Clipboard::clearData(const std::string& type) TITANIUM_NOEXCEPT
+		{
+			TITANIUM_LOG_WARN("Clipboard::clearData: Unimplemented");
+		}
+
+		void Clipboard::clearText() TITANIUM_NOEXCEPT
+		{
+			TITANIUM_LOG_WARN("Clipboard::clearText: Unimplemented");
+		}
+
+		JSObject Clipboard::getData(const std::string& type) TITANIUM_NOEXCEPT
+		{
+			TITANIUM_LOG_WARN("Clipboard::getData: Unimplemented");
+			return get_context().CreateObject();
+		}
+
+		std::string Clipboard::getText() TITANIUM_NOEXCEPT
+		{
+			TITANIUM_LOG_WARN("Clipboard::getText: Unimplemented");
+			return "";
+		}
+
+		bool Clipboard::hasData(const std::string& type) TITANIUM_NOEXCEPT
+		{
+			TITANIUM_LOG_WARN("Clipboard::hasData: Unimplemented");
+			return false;
+		}
+
+		bool Clipboard::hasText() TITANIUM_NOEXCEPT
+		{
+			TITANIUM_LOG_WARN("Clipboard::hasText: Unimplemented");
+			return false;
+		}
+
+		void Clipboard::setData(const std::string& type, JSObject data) TITANIUM_NOEXCEPT
+		{
+			TITANIUM_LOG_WARN("Clipboard::setData: Unimplemented");
+		}
+
+		void Clipboard::setText(const std::string& text) TITANIUM_NOEXCEPT
+		{
+			TITANIUM_LOG_WARN("Clipboard::setText: Unimplemented");
+		}
+
+		void Clipboard::JSExportInitialize() {
+			JSExport<Clipboard>::SetClassVersion(1);
+			JSExport<Clipboard>::SetParent(JSExport<Module>::Class());
+
+			TITANIUM_ADD_FUNCTION(Clipboard, clearData);
+			TITANIUM_ADD_FUNCTION(Clipboard, clearText);
+			TITANIUM_ADD_FUNCTION(Clipboard, getData);
+			TITANIUM_ADD_FUNCTION(Clipboard, getText);
+			TITANIUM_ADD_FUNCTION(Clipboard, hasData);
+			TITANIUM_ADD_FUNCTION(Clipboard, hasText);
+			TITANIUM_ADD_FUNCTION(Clipboard, setData);
+			TITANIUM_ADD_FUNCTION(Clipboard, setText);
+		}
+
+		TITANIUM_FUNCTION(Clipboard, clearData)
+		{
+			ENSURE_OPTIONAL_STRING_AT_INDEX(type, 0, "");
+			clearData(type);
+			return get_context().CreateUndefined();
+		}
+
+		TITANIUM_FUNCTION(Clipboard, clearText)
+		{
+			clearText();
+			return get_context().CreateUndefined();
+		}
+
+		TITANIUM_FUNCTION(Clipboard, getData)
+		{
+			if (arguments.empty()) {
+				return get_context().CreateUndefined();
+			}
+
+			ENSURE_STRING_AT_INDEX(type, 0);
+			return getData(type);
+		}
+
+		TITANIUM_FUNCTION(Clipboard, getText)
+		{
+			return get_context().CreateString(getText());
+		}
+
+		TITANIUM_FUNCTION(Clipboard, hasData)
+		{
+			if (arguments.empty()) {
+				return get_context().CreateUndefined();
+			}
+
+			ENSURE_STRING_AT_INDEX(type, 0);
+			return get_context().CreateBoolean(hasData(type));
+		}
+
+		TITANIUM_FUNCTION(Clipboard, hasText)
+		{
+			return get_context().CreateBoolean(hasText());
+		}
+
+		TITANIUM_FUNCTION(Clipboard, setData)
+		{
+			if (arguments.size() < 2) {
+				return get_context().CreateUndefined();
+			}
+
+			ENSURE_STRING_AT_INDEX(type, 0);
+			ENSURE_OBJECT_AT_INDEX(data, 1);
+			setData(type, data);
+			return get_context().CreateUndefined();
+		}
+
+		TITANIUM_FUNCTION(Clipboard, setText)
+		{
+			if (arguments.empty()) {
+				return get_context().CreateUndefined();
+			}
+
+			ENSURE_STRING_AT_INDEX(text, 0);
+			setText(text);
+			return get_context().CreateUndefined();
+		}
+
+	} // namespace UI
+} // namespace Titanium

--- a/Source/UI/CMakeLists.txt
+++ b/Source/UI/CMakeLists.txt
@@ -48,6 +48,8 @@ if(NOT TARGET TitaniumWindows_Utility)
 endif()
 
 set(SOURCE_UI
+  include/TitaniumWindows/UI/Clipboard.hpp
+  src/Clipboard.cpp
   include/TitaniumWindows/UI/detail/UIBase.hpp
   include/TitaniumWindows/UI.hpp
   include/TitaniumWindows/UI/ActivityIndicator.hpp
@@ -137,6 +139,7 @@ target_include_directories(TitaniumWindows_UI PUBLIC
   ${PROJECT_SOURCE_DIR}/include
   $<TARGET_PROPERTY:TitaniumKit,INTERFACE_INCLUDE_DIRECTORIES>
   $<TARGET_PROPERTY:TitaniumWindows_Utility,INTERFACE_INCLUDE_DIRECTORIES>
+  $<TARGET_PROPERTY:TitaniumWindows,INTERFACE_INCLUDE_DIRECTORIES>
   $<TARGET_PROPERTY:LayoutEngine,INTERFACE_INCLUDE_DIRECTORIES>
   )
 

--- a/Source/UI/include/TitaniumWindows/UI.hpp
+++ b/Source/UI/include/TitaniumWindows/UI.hpp
@@ -30,5 +30,6 @@
 #include "TitaniumWindows/UI/View.hpp"
 #include "TitaniumWindows/UI/WebView.hpp"
 #include "TitaniumWindows/UI/Window.hpp"
+#include "TitaniumWindows/UI/Clipboard.hpp"
 
 #endif  // _TITANIUMWINDOWS_UI_HPP_

--- a/Source/UI/include/TitaniumWindows/UI/Clipboard.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/Clipboard.hpp
@@ -1,0 +1,56 @@
+/**
+ * Titanium.UI.Clipboard for Windows
+ *
+ * Copyright (c) 2015 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License.
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#ifndef _TITANIUMWINDOWS_CLIPBOARD_HPP_
+#define _TITANIUMWINDOWS_CLIPBOARD_HPP_
+
+#include "TitaniumWindows_UI_EXPORT.h"
+#include "Titanium/UI/Clipboard.hpp"
+
+namespace TitaniumWindows
+{
+	namespace UI
+	{
+		using namespace HAL;
+
+		/*!
+		  @class
+
+		  @discussion This is the Titanium.UI.Clipboard implementation for Windows.
+		*/
+		class TITANIUMWINDOWS_UI_EXPORT Clipboard final : public Titanium::UI::Clipboard, public JSExport<Clipboard>
+		{
+
+		public:
+			
+			Clipboard(const JSContext&, const std::vector<JSValue>& arguments = {}) TITANIUM_NOEXCEPT;
+			virtual ~Clipboard()                   = default;
+			Clipboard(const Clipboard&)            = default;
+			Clipboard& operator=(const Clipboard&) = default;
+#ifdef TITANIUM_MOVE_CTOR_AND_ASSIGN_DEFAULT_ENABLE
+			Clipboard(Clipboard&&)                 = default;
+			Clipboard& operator=(Clipboard&&)      = default;
+#endif
+
+			static void JSExportInitialize();
+
+		private:
+
+			virtual void clearData(const std::string& type) TITANIUM_NOEXCEPT;
+			virtual void clearText() TITANIUM_NOEXCEPT;
+			virtual JSObject getData(const std::string& type) TITANIUM_NOEXCEPT;
+			virtual std::string getText() TITANIUM_NOEXCEPT;
+			virtual bool hasData(const std::string& type) TITANIUM_NOEXCEPT;
+			virtual bool hasText() TITANIUM_NOEXCEPT;
+			virtual void setData(const std::string& type, JSObject data) TITANIUM_NOEXCEPT;
+			virtual void setText(const std::string& text) TITANIUM_NOEXCEPT;
+
+		};
+	}  // namespace UI
+}  // namespace TitaniumWindows
+#endif // _TITANIUMWINDOWS_CLIPBOARD_HPP_

--- a/Source/UI/src/Clipboard.cpp
+++ b/Source/UI/src/Clipboard.cpp
@@ -1,0 +1,118 @@
+/**
+ * Titanium.UI.Clipboard for Windows
+ *
+ * Copyright (c) 2015 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License.
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#include "TitaniumWindows/UI/Clipboard.hpp"
+#include "Titanium/detail/TiBase.hpp"
+#include "TitaniumWindows/Utility.hpp"
+
+#include <boost/algorithm/string.hpp>
+
+#if WINAPI_FAMILY == WINAPI_FAMILY_PC_APP
+using Windows::ApplicationModel::DataTransfer::Clipboard;
+using Windows::ApplicationModel::DataTransfer::StandardDataFormats;
+using Windows::ApplicationModel::DataTransfer::DataPackage;
+#endif
+
+namespace TitaniumWindows
+{
+	namespace UI
+	{
+		Clipboard::Clipboard(const JSContext& js_context, const std::vector<JSValue>& arguments) TITANIUM_NOEXCEPT
+			: Titanium::UI::Clipboard(js_context, arguments)
+		{
+		}
+
+		void Clipboard::JSExportInitialize() {
+			JSExport<Clipboard>::SetClassVersion(1);
+			JSExport<Clipboard>::SetParent(JSExport<Titanium::UI::Clipboard>::Class());
+		}
+
+		void Clipboard::clearData(const std::string& type) TITANIUM_NOEXCEPT
+		{
+#if WINAPI_FAMILY == WINAPI_FAMILY_PC_APP
+			Windows::ApplicationModel::DataTransfer::Clipboard::Clear();
+#endif
+		}
+
+		void Clipboard::clearText() TITANIUM_NOEXCEPT
+		{
+#if WINAPI_FAMILY == WINAPI_FAMILY_PC_APP
+			Windows::ApplicationModel::DataTransfer::Clipboard::Clear();
+#endif
+		}
+
+		JSObject Clipboard::getData(const std::string& type) TITANIUM_NOEXCEPT
+		{
+#if WINAPI_FAMILY == WINAPI_FAMILY_PC_APP
+			auto content = ::Clipboard::GetContent();
+
+			if (boost::starts_with(type, "text") && content->Contains(::StandardDataFormats::Text)) {
+				return static_cast<JSObject>(get_context().CreateValueFromJSON(getText()));
+			}
+#endif	
+			return get_context().CreateObject();
+		}
+
+		std::string Clipboard::getText() TITANIUM_NOEXCEPT
+		{
+#if WINAPI_FAMILY == WINAPI_FAMILY_PC_APP
+			auto content = ::Clipboard::GetContent();
+			Platform::String^ buffer;
+			concurrency::event event;
+
+			auto task = concurrency::create_task(content->GetTextAsync()).then([&event, &buffer](concurrency::task<Platform::String^> text) {
+				buffer = text.get();
+				event.set();
+			}, concurrency::task_continuation_context::use_arbitrary());
+			event.wait();
+
+			return Utility::ConvertString(buffer);
+#else
+			return "";
+#endif
+		}
+
+		bool Clipboard::hasData(const std::string& type) TITANIUM_NOEXCEPT
+		{
+#if WINAPI_FAMILY == WINAPI_FAMILY_PC_APP
+			auto content = ::Clipboard::GetContent();
+			return content->Contains(::StandardDataFormats::Text);
+#else
+			return false;
+#endif
+		}
+
+		bool Clipboard::hasText() TITANIUM_NOEXCEPT
+		{
+#if WINAPI_FAMILY == WINAPI_FAMILY_PC_APP
+			auto content = ::Clipboard::GetContent();
+			return content->Contains(::StandardDataFormats::Text);
+#else
+			return false;
+#endif
+		}
+
+		void Clipboard::setData(const std::string& type, JSObject data) TITANIUM_NOEXCEPT
+		{
+#if WINAPI_FAMILY == WINAPI_FAMILY_PC_APP
+			auto json = static_cast<JSValue>(data).ToJSONString();
+			setText(json);
+#endif
+		}
+
+		void Clipboard::setText(const std::string& text) TITANIUM_NOEXCEPT
+		{
+#if WINAPI_FAMILY == WINAPI_FAMILY_PC_APP
+			::DataPackage^ content = ref new ::DataPackage();
+			content->SetText(Utility::ConvertString(text));
+			::Clipboard::SetContent(content);
+#endif
+		}
+
+	}  // namespace UI
+}  // namespace TitaniumWindows


### PR DESCRIPTION
- Implement ```Titanium.UI.Clipboard```
- ```getData()``` and ```setData()``` are implemented similar to our Android implementation

###### NOTE
- This is for ```WindowsStore``` applications __ONLY__.

###### TEST CASE
```Javascript
Ti.UI.Clipboard.clearText();
Ti.UI.Clipboard.setText('Hello World!');
if (Ti.UI.Clipboard.hasText()) {
	Ti.API.info('getText() : ' + Ti.UI.Clipboard.getText());
}

var obj = { test: 'Hello World!' };
Ti.UI.Clipboard.setData('text', obj);
if (Ti.UI.Clipboard.hasData('text')) {
	Ti.API.info('getData() : ' + JSON.stringify(Ti.UI.Clipboard.getData('text')));
}
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-18757)