### PR TITLE
Fix: Tabs added using the TabGroup property are not rendered

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/TabGroup.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/TabGroup.hpp
@@ -46,10 +46,14 @@ namespace TitaniumWindows
 			virtual void open() TITANIUM_NOEXCEPT override;
 			virtual void close() TITANIUM_NOEXCEPT override;
 
+			virtual void set_tabs(const std::vector<std::shared_ptr<Titanium::UI::Tab>>& tabs) TITANIUM_NOEXCEPT override;
+
 			virtual void set_activeTab(const std::shared_ptr<Titanium::UI::Tab>& activeTab) TITANIUM_NOEXCEPT override;
 			virtual void set_activeTab(const std::shared_ptr<Titanium::UI::Tab>& activeTab, const bool updateUI) TITANIUM_NOEXCEPT;
 
 		private:
+			void appendWindowsTabItem(const std::shared_ptr<Titanium::UI::Tab>& tab) TITANIUM_NOEXCEPT;
+
 #pragma warning(push)
 #pragma warning(disable : 4251)
 			std::shared_ptr<TitaniumWindows::UI::Window> window__;

--- a/Source/UI/src/TabGroup.cpp
+++ b/Source/UI/src/TabGroup.cpp
@@ -144,9 +144,27 @@ namespace TitaniumWindows
 			window__->close(nullptr);
 		}
 
+		void TabGroup::set_tabs(const std::vector<std::shared_ptr<Titanium::UI::Tab>>& tabs) TITANIUM_NOEXCEPT
+		{
+			Titanium::UI::TabGroup::set_tabs(tabs);
+#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+			pivot__->Items->Clear();
+#else
+			sectionViewItems__->Clear();
+#endif
+			for (const auto tab : tabs) {
+				appendWindowsTabItem(tab);
+			}
+		}
+
 		void TabGroup::addTab(const std::shared_ptr<Titanium::UI::Tab>& tab) TITANIUM_NOEXCEPT
 		{
 			Titanium::UI::TabGroup::addTab(tab);
+			appendWindowsTabItem(tab);
+		}
+
+		void TabGroup::appendWindowsTabItem(const std::shared_ptr<Titanium::UI::Tab>& tab) TITANIUM_NOEXCEPT
+		{
 			const auto windows_tab = dynamic_cast<TitaniumWindows::UI::Tab*>(tab.get());
 			const auto tabview = windows_tab->getViewLayoutDelegate<WindowsViewLayoutDelegate>()->getComponent();
 			if (windows_tab) {


### PR DESCRIPTION
Fix for [TIMOB-19251](https://jira.appcelerator.org/browse/TIMOB-19251)

```javascript
var win1 = Ti.UI.createWindow({
    backgroundColor: 'blue',
    title: 'Blue'
});
win1.add(Ti.UI.createLabel({ text: 'I am a blue window.' }));

var win2 = Ti.UI.createWindow({
    backgroundColor: 'red',
    title: 'Red'
});
win2.add(Ti.UI.createLabel({ text: 'I am a red window.' }));

var tab1 = Ti.UI.createTab({
    window: win1,
    title: 'Blue'
}),
tab2 = Ti.UI.createTab({
    window: win2,
    title: 'Red'
}),
tabGroup = Ti.UI.createTabGroup({
   tabs: [tab1, tab2]
});
//tabGroup.addTab(tab1);
//tabGroup.addTab(tab2);
//tabGroup.tabs = [tab1, tab2];
//tabGroup.setTabs([tab1, tab2]);
tabGroup.open();
```