### PR TITLE
Fix: Alloy.Globals not accessible from a commonjs module

### DIFF
--- a/Source/Titanium/src/TitaniumWindows.cpp
+++ b/Source/Titanium/src/TitaniumWindows.cpp
@@ -229,7 +229,7 @@ namespace TitaniumWindows
 
 			// Place the frame in the current Window.
 			Windows::UI::Xaml::Window::Current->Content = rootFrame;
-			application__->Run("./app");
+			application__->Run("/app");
 		}
 		// Ensure the current Window is active.
 		Windows::UI::Xaml::Window::Current->Activate();


### PR DESCRIPTION
Fix for [TIMOB-19305](https://jira.appcelerator.org/browse/TIMOB-19305) and [TIMOB-19084](https://jira.appcelerator.org/browse/TIMOB-19084).

When requiring files, only `app.js` should be treated special. It should expose every variables to child.

`app.js`
```javascript
var Alloy = { Globals:{} };
Alloy.Globals.winTop = 6;

var m = require('testmodule')
m.test();
```

`testmodule.js`
```javascript
exports.test = function() {
    Ti.API.info("Test Module");
    Ti.API.info("Module Wintop " + Alloy.Globals.winTop);
};
```
