### PR TITLE
Fix: Setting both left and right properties causes wrong layout

### DIFF
--- a/Examples/NMocha/src/Assets/ti.ui.layout.test.js
+++ b/Examples/NMocha/src/Assets/ti.ui.layout.test.js
@@ -989,31 +989,51 @@ describe("Titanium.UI.Layout", function () {
         
     });
     */
+
+    it("twoPins", function (finish) {
+        var win = createWindow({}, finish);
+        var view = Ti.UI.createView({
+            width: 100,
+            height: 100
+        });
+        var inner_view = Ti.UI.createView({
+            left: 10,
+            right: 10
+        });
+        view.add(inner_view);
+        win.add(view);
+        win.addEventListener("postlayout", function (e) {
+            should(inner_view.size.width).eql(80);
+            should(inner_view.rect.width).eql(80);
+        });
+        win.open();
+    });
+
     it("fourPins", function (finish) {
         var win = createWindow({}, finish);
         var view = Ti.UI.createView({
             width: 100,
             height: 100
         });
-        var label = Ti.UI.createLabel({
+        var inner_view = Ti.UI.createView({
             left: 10,
             right: 10,
             top: 10,
             bottom: 10
         });
-        view.add(label);
+        view.add(inner_view);
         win.add(view);
         win.addEventListener("postlayout", function (e) {
-            should(label.size.width).eql(80);
-            should(label.size.height).eql(80);
-            should(label.left).eql(10);
-            should(label.right).eql(10);
-            should(label.top).eql(10);
-            should(label.bottom).eql(10);
-            should(label.rect.x).eql(10);
-            should(label.rect.width).eql(80);
-            should(label.rect.y).eql(10);
-            should(label.rect.height).eql(80);
+            should(inner_view.size.width).eql(80);
+            should(inner_view.size.height).eql(80);
+            should(inner_view.left).eql(10);
+            should(inner_view.right).eql(10);
+            should(inner_view.top).eql(10);
+            should(inner_view.bottom).eql(10);
+            should(inner_view.rect.x).eql(10);
+            should(inner_view.rect.width).eql(80);
+            should(inner_view.rect.y).eql(10);
+            should(inner_view.rect.height).eql(80);
         });
         win.open();
     });

--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -666,10 +666,10 @@ namespace TitaniumWindows
 		{
 			using namespace Windows::UI::Xaml::Controls;
 			using namespace Windows::UI::Xaml;
-			if (is_height_size__ && rect.height == 0)
-				return;
-			if (is_width_size__ && rect.width == 0)
-				return;
+			
+			auto skipHeight = (is_height_size__ && rect.height == 0);
+			auto skipWidth  = (is_width_size__  && rect.width  == 0);
+
 			if (rect.width < 0 || rect.height < 0)
 				return;
 			if (Titanium::LayoutEngine::RectIsEmpty(rect))
@@ -705,10 +705,10 @@ namespace TitaniumWindows
 			}
 
 			// Use actual size when LayoutEngine does nothing against the component size
-			if (rect.height <= 0) {
+			if (!skipHeight && rect.height <= 0) {
 				rect.height = component->ActualHeight;
 			}
-			if (rect.width <= 0) {
+			if (!skipWidth && rect.width <= 0) {
 				rect.width = component->ActualWidth;
 			}
 
@@ -721,7 +721,7 @@ namespace TitaniumWindows
 				setHeight = true;
 			}
 
-			if ((!is_panel__ && setWidthOnWidget) || setWidth) {
+			if (!skipWidth && ((!is_panel__ && setWidthOnWidget) || setWidth)) {
 				if (layout_node__->properties.left.valueType != Titanium::LayoutEngine::None &&
 					layout_node__->properties.right.valueType != Titanium::LayoutEngine::None &&
 					component->ActualWidth == rect.width) {
@@ -730,7 +730,7 @@ namespace TitaniumWindows
 				component->Width = rect.width;
 			}
 
-			if ((!is_panel__ && setHeightOnWidget) || setHeight) {
+			if (!skipHeight && ((!is_panel__ && setHeightOnWidget) || setHeight)) {
 				if (layout_node__->properties.top.valueType != Titanium::LayoutEngine::None &&
 					layout_node__->properties.bottom.valueType != Titanium::LayoutEngine::None &&
 					component->ActualHeight == rect.height) {


### PR DESCRIPTION
Fix for [TIMOB-19294](https://jira.appcelerator.org/browse/TIMOB-19294).

```javascript
var win = Ti.UI.createWindow({layout: 'vertical'});
var tf1 = Ti.UI.createTextField({
	left: 10,
	right: 10,
	hintText: 'blah blah blah'
});
win.add(tf1);
var tf2 = Ti.UI.createTextField({
	width: 100,
	hintText: 'yada yada yada'
});
win.add(tf2);
win.open();
```
