### PR TITLE
Fix: HTTPClient.send fails when data has non-string/Blob values

### DIFF
--- a/Examples/NMocha/src/Assets/ti.network.httpclient.test.js
+++ b/Examples/NMocha/src/Assets/ti.network.httpclient.test.js
@@ -175,6 +175,24 @@ describe("Titanium.Network.HTTPClient", function () {
         xhr.send();
     });
 
+    it("sendData", function (finish) {
+        this.timeout(3e4);
+        var xhr = Ti.Network.createHTTPClient();
+        xhr.setTimeout(3e4);
+        xhr.onload = function (e) {
+            finish();
+        };
+        xhr.onerror = function (e) {
+            Ti.API.debug(e);
+            finish(new Error('failed to send data: ' + e));
+        };
+        xhr.open("POST", "http://www.ambientreality.com/ingot/post_test.php");
+        xhr.send({
+            message: "check me out",
+            numericid: 1234
+        });
+    });
+
     // Confirms that only the selected cookie is deleted
     it.skip("clearCookiePositiveTest", function (finish) {
         this.timeout(3e4);

--- a/Source/TitaniumKit/src/Network/HTTPClient.cpp
+++ b/Source/TitaniumKit/src/Network/HTTPClient.cpp
@@ -298,14 +298,18 @@ namespace Titanium
 					for (const auto& property_name : static_cast<std::vector<JSString>>(sendArgs.GetPropertyNames())) {
 						TITANIUM_ASSERT(sendArgs.GetProperty(property_name).IsObject() || sendArgs.GetProperty(property_name).IsString());
 						JSValue prop = sendArgs.GetProperty(property_name);
-						if (prop.IsString()) {
-							std::string str = static_cast<std::string>(prop);
-							std::vector<std::uint8_t> data(str.begin(), str.end());
-							map.insert(std::make_pair(property_name, data));
-						} else {
+						if (prop.IsObject()) {
 							useMultipartForm = true;
 							auto blob_ptr = static_cast<JSObject>(prop).GetPrivate<Titanium::Blob>();
-							map.insert(std::make_pair(property_name, blob_ptr->getData()));
+							if (blob_ptr != nullptr) {
+								map.insert(std::make_pair(property_name, blob_ptr->getData()));
+							} else {
+								std::string str = static_cast<std::string>(prop);
+								map.insert(std::make_pair(property_name, std::vector<std::uint8_t>(str.begin(), str.end())));
+							}
+						} else {
+							std::string str = static_cast<std::string>(prop);
+							map.insert(std::make_pair(property_name, std::vector<std::uint8_t>(str.begin(), str.end())));
 						}
 					}
 					send(map, useMultipartForm);


### PR DESCRIPTION
Fix for [TIMOB-19347](https://jira.appcelerator.org/browse/TIMOB-19347)

```javascript
var win = Ti.UI.createWindow();
win.open();

var xhr = Ti.Network.createHTTPClient();
xhr.setTimeout(3e4);
xhr.onload = function (e) {
    Ti.API.info('onload: ' + xhr.responseText);
    win.backgroundColor = 'green';
};
xhr.onerror = function (e) {
    Ti.API.error('onerror: '+e.error);
};
xhr.open("POST", "http://www.ambientreality.com/ingot/post_test.php");
xhr.send({
    message: "check me out",
    numericid: 1001 
});
```