### PR TITLE
Fix TIMOB-19350 tiapp property ti.ui.defaultunit ignored

### DIFF
--- a/Source/LayoutEngine/include/LayoutEngine/LayoutEngine.hpp
+++ b/Source/LayoutEngine/include/LayoutEngine/LayoutEngine.hpp
@@ -164,7 +164,7 @@ namespace Titanium
 		struct ComputedSize doHorizontalLayout(std::vector<struct Element*>, double, double, bool, bool);
 		void measureNodeForHorizontalLayout(struct LayoutProperties, struct Element*);
 		void layoutPropertiesInitialize(struct LayoutProperties*);
-		void populateLayoutPoperties(struct InputProperty, struct LayoutProperties*, double);
+		void populateLayoutProperties(struct InputProperty, struct LayoutProperties*, double, const std::string&);
 		struct ComputedSize doVerticalLayout(std::vector<struct Element*>, double, double, bool, bool);
 		void measureNodeForVerticalLayout(struct LayoutProperties, struct Element*);
 

--- a/Source/LayoutEngine/src/ParseProperty.cpp
+++ b/Source/LayoutEngine/src/ParseProperty.cpp
@@ -29,7 +29,7 @@ namespace Titanium
 			}
 		}
 
-		double _computeValue(const std::string& value, enum ValueType valueType, double ppi)
+		double _computeValue(const std::string& value, enum ValueType valueType, double ppi, const std::string& defaultUnits)
 		{
 			std::string units;
 			double parsedValue = 0;
@@ -39,6 +39,7 @@ namespace Titanium
 			} else if (valueType == Fixed) {
 				if ((value.find("mm") != std::string::npos) || (value.find("cm") != std::string::npos) ||
 				    (value.find("em") != std::string::npos) || (value.find("pt") != std::string::npos) ||
+				    (value.find("pc") != std::string::npos) ||
 				    (value.find("in") != std::string::npos) || (value.find("px") != std::string::npos) ||
 				    (value.find("dp") != std::string::npos) || (value.find("dip") != std::string::npos)) {
 					if ((value.find("dip") != std::string::npos)) {
@@ -50,80 +51,80 @@ namespace Titanium
 					}
 				} else {
 					parsedValue = atof(value.c_str());
-					units = "px";
+					units = defaultUnits;
 				}
 
-				if (units == "mm") {
-					return parsedValue /= 10;
-				} else if (units == "cm") {
-					return parsedValue * 0.393700787 * ppi;
-				} else if (units == "em" || units == "pt") {
-					return parsedValue /= 12;
-				} else if (units == "pc") {
-					return parsedValue /= 6;
+				if (units == "mm") { // 1 mm = 0.0393701 in, 1 in = 25.4 mm
+					return (parsedValue / 25.4) * ppi; // px = (mm / 25.4) * px/in
+				} else if (units == "cm") { // 1 cm = .393700787 in, 1 in = 2.54 cm
+					return (parsedValue / 2.54) * ppi; // px = (cm / 2.54) * px/in
+				} else if (units == "em" || units == "pt") { // 1 inch = 72 pt // FIXME em = font size for element
+					return (parsedValue / 72.0) * ppi; // px = (pt / 72) * px/in
+				} else if (units == "pc") { // pica, 1/6th inch. 1 pc = 12 pt
+					return (parsedValue / 6.0) * ppi; // px = (pc / 6) * px/in
 				} else if (units == "in") {
-					return parsedValue * ppi;
+					return parsedValue * ppi; // px = inches * pixels/inch
 				} else if (units == "px") {
-					return parsedValue;
-				} else if (units == "dp" || units == "dip") {
-					return parsedValue * ppi / 160;
+					return parsedValue; // px is our base value
+				} else if (units == "dp" || units == "dip") { 
+					return (parsedValue * ppi) / 160.0; // px = device independent pixels * pixels/inch / 160, see https://www.google.com/design/spec/layout/units-measurements.html#units-measurements-designing-layouts-for-dp
 				}
 			}
 			return 0;
 		}
 
-		void populateLayoutPoperties(struct InputProperty inputProperty, struct LayoutProperties* layoutProperties, double ppi)
+		void populateLayoutProperties(struct InputProperty inputProperty, struct LayoutProperties* layoutProperties, double ppi, const std::string& defaultUnits)
 		{
 			switch (inputProperty.name) {
 				case MinHeight:
 					(*layoutProperties).minHeight.valueType = _getValueType(inputProperty.value);
 					(*layoutProperties).minHeight.value = _computeValue(inputProperty.value,
-					                                                    (*layoutProperties).minHeight.valueType, ppi);
+					                                                    (*layoutProperties).minHeight.valueType, ppi, defaultUnits);
 					break;
 				case MinWidth:
 					(*layoutProperties).minWidth.valueType = _getValueType(inputProperty.value);
 					(*layoutProperties).minWidth.value = _computeValue(inputProperty.value,
-					                                                   (*layoutProperties).minWidth.valueType, ppi);
+					                                                   (*layoutProperties).minWidth.valueType, ppi, defaultUnits);
 					break;
 				case Width:
 					(*layoutProperties).width.valueType = _getValueType(inputProperty.value);
 					(*layoutProperties).width.value = _computeValue(inputProperty.value,
-					                                                (*layoutProperties).width.valueType, ppi);
+					                                                (*layoutProperties).width.valueType, ppi, defaultUnits);
 					break;
 				case Height:
 					(*layoutProperties).height.valueType = _getValueType(inputProperty.value);
 					(*layoutProperties).height.value = _computeValue(inputProperty.value,
-					                                                 (*layoutProperties).height.valueType, ppi);
+					                                                 (*layoutProperties).height.valueType, ppi, defaultUnits);
 					break;
 				case Left:
 					(*layoutProperties).left.valueType = _getValueType(inputProperty.value);
 					(*layoutProperties).left.value = _computeValue(inputProperty.value,
-					                                               (*layoutProperties).left.valueType, ppi);
+					                                               (*layoutProperties).left.valueType, ppi, defaultUnits);
 					break;
 				case CenterX:
 					(*layoutProperties).centerX.valueType = _getValueType(inputProperty.value);
 					(*layoutProperties).centerX.value = _computeValue(inputProperty.value,
-					                                                  (*layoutProperties).centerX.valueType, ppi);
+					                                                  (*layoutProperties).centerX.valueType, ppi, defaultUnits);
 					break;
 				case CenterY:
 					(*layoutProperties).centerY.valueType = _getValueType(inputProperty.value);
 					(*layoutProperties).centerY.value = _computeValue(inputProperty.value,
-					                                                  (*layoutProperties).centerY.valueType, ppi);
+					                                                  (*layoutProperties).centerY.valueType, ppi, defaultUnits);
 					break;
 				case Right:
 					(*layoutProperties).right.valueType = _getValueType(inputProperty.value);
 					(*layoutProperties).right.value = _computeValue(inputProperty.value,
-					                                                (*layoutProperties).right.valueType, ppi);
+					                                                (*layoutProperties).right.valueType, ppi, defaultUnits);
 					break;
 				case Top:
 					(*layoutProperties).top.valueType = _getValueType(inputProperty.value);
 					(*layoutProperties).top.value = _computeValue(inputProperty.value,
-					                                              (*layoutProperties).top.valueType, ppi);
+					                                              (*layoutProperties).top.valueType, ppi, defaultUnits);
 					break;
 				case Bottom:
 					(*layoutProperties).bottom.valueType = _getValueType(inputProperty.value);
 					(*layoutProperties).bottom.value = _computeValue(inputProperty.value,
-					                                                 (*layoutProperties).bottom.valueType, ppi);
+					                                                 (*layoutProperties).bottom.valueType, ppi, defaultUnits);
 					break;
 			}
 		}

--- a/Source/LayoutEngine/test/PropertyParserTest.cpp
+++ b/Source/LayoutEngine/test/PropertyParserTest.cpp
@@ -26,6 +26,6 @@ TEST(ParserProperties, populate_layout)
 	inputProperty.name = Titanium::LayoutEngine::Top;
 	inputProperty.value = "99px";
 	// 96 is the ppi
-	Titanium::LayoutEngine::populateLayoutPoperties(inputProperty, &layoutProperties, 96);
+	Titanium::LayoutEngine::populateLayoutProperties(inputProperty, &layoutProperties, 96, "px");
 	EXPECT_EQ(layoutProperties.top.value, (float)99.0);
 }

--- a/Source/TitaniumKit/include/Titanium/App.hpp
+++ b/Source/TitaniumKit/include/Titanium/App.hpp
@@ -55,6 +55,9 @@ namespace Titanium
 		  @discussion Application copyright statement, determined by `tiapp.xml`.
 		*/
 		virtual std::string copyright() const TITANIUM_NOEXCEPT;
+
+		std::string defaultUnit() TITANIUM_NOEXCEPT;
+
 		/*!
 		  @property
 		  @abstract deployType
@@ -232,6 +235,7 @@ namespace Titanium
 		bool accessibilityEnabled__;
 		bool analytics__;
 		std::string copyright__;
+		std::string defaultUnit__;
 		std::string deployType__;
 		std::string description__;
 		bool disableNetworkActivityIndicator__;

--- a/Source/TitaniumKit/src/App.cpp
+++ b/Source/TitaniumKit/src/App.cpp
@@ -8,6 +8,7 @@
 
 #include "Titanium/detail/TiImpl.hpp"
 #include "Titanium/App.hpp"
+#include "Titanium/App/Properties.hpp"
 
 namespace Titanium
 {
@@ -59,6 +60,7 @@ namespace Titanium
 		accessibilityEnabled__(false),
 		analytics__(false),
 		copyright__("__COPYRIGHT__"),
+		defaultUnit__(""),
 		deployType__("__DEPLOY_TYPE__"),
 		description__("__DESCRIPTION__"),
 		disableNetworkActivityIndicator__(false),
@@ -126,6 +128,36 @@ namespace Titanium
 	std::string AppModule::copyright() const TITANIUM_NOEXCEPT
 	{
 		return copyright__;
+	}
+
+	std::string AppModule::defaultUnit() TITANIUM_NOEXCEPT
+	{
+		if (defaultUnit__.empty()) {
+			JSObject App = GetStaticObject(get_context());
+
+			JSValue Properties_property = App.GetProperty("Properties");
+			TITANIUM_ASSERT(Properties_property.IsObject());  // precondition
+			JSObject Properties = static_cast<JSObject>(Properties_property);
+
+			auto props = Properties.GetPrivate<::Titanium::App::Properties>();
+			auto defaultUnit = props->getString("ti.ui.defaultunit", boost::optional<std::string>("px"));
+
+			if (!defaultUnit || *defaultUnit == "system")
+			{
+				defaultUnit__ = "px";
+			}
+			// Validate that unit is one of our set of known units!
+			// FIXME Some platforms allow other units. See "sp" and "sip" for Android
+			if (defaultUnit__ != "mm" && defaultUnit__ != "cm" && 
+				defaultUnit__ != "em" && defaultUnit__ != "pt" &&
+				defaultUnit__ != "pc" && defaultUnit__ != "in" &&
+				defaultUnit__ != "px" && defaultUnit__ != "dp" &&
+				defaultUnit__ != "dip")
+			{
+				defaultUnit__ = "px";
+			}
+		}
+		return defaultUnit__;
 	}
 
 	std::string AppModule::deployType() const TITANIUM_NOEXCEPT

--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -11,6 +11,7 @@
 #include "Titanium/UI/Animation.hpp"
 #include "Titanium/UI/2DMatrix.hpp"
 #include "Titanium/detail/TiImpl.hpp"
+#include "Titanium/App.hpp"
 #include <string>
 #include <algorithm>
 #include <cctype>
@@ -897,7 +898,24 @@ namespace TitaniumWindows
 					break;
 			}
 #endif
-			Titanium::LayoutEngine::populateLayoutPoperties(prop, &layout_node__->properties, ppi);
+			// Get the defaultUnits from ti.ui.defaultUnit!
+			std::string defaultUnits = "px";
+			auto event_delegate = event_delegate__.lock();
+		 	if (event_delegate != nullptr) {
+			 	JSContext js_context = event_delegate->get_context();
+
+			 	JSValue Titanium_property = js_context.get_global_object().GetProperty("Titanium");
+				TITANIUM_ASSERT(Titanium_property.IsObject());  // precondition
+				JSObject Titanium = static_cast<JSObject>(Titanium_property);
+
+				JSValue App_property = Titanium.GetProperty("App");
+				TITANIUM_ASSERT(App_property.IsObject());  // precondition
+				JSObject App = static_cast<JSObject>(App_property);
+
+				const auto object_ptr = App.GetPrivate<Titanium::AppModule>();
+				defaultUnits = object_ptr->defaultUnit();
+		 	}
+			Titanium::LayoutEngine::populateLayoutProperties(prop, &layout_node__->properties, ppi, defaultUnits);
 
 			if (isLoaded()) {
 				requestLayout();


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-19350

Fixed a typo in method name in LayoutEngine. Added comments and fixed calculations for certain units.
Added a Titanium::AppModule::defaultUnit() method that pulls the units from Ti.App.Properties.getString("ti.ui.defaultunit"). If the property is empty, is "system" or is not a recognized unit, we default to "px".
We pass in the default unit to the LayoutEngine along with the ppi/dpi whenever we set a layout property.
Technically this is a potentially useless perf hit since we only really need the default units if there's no valid units specified for the value.