### PR TITLE
Fix: runtime error when securityManager is null

### DIFF
--- a/Source/TitaniumKit/src/Network/HTTPClient.cpp
+++ b/Source/TitaniumKit/src/Network/HTTPClient.cpp
@@ -391,8 +391,7 @@ namespace Titanium
 
 		TITANIUM_PROPERTY_SETTER(HTTPClient, securityManager)
 		{
-			TITANIUM_ASSERT(argument.IsObject());
-			securityManager__ = static_cast<JSObject>(argument);
+			securityManager__ = argument;
 			return true;
 		}
 


### PR DESCRIPTION
Fix for [TIMOB-19416](https://jira.appcelerator.org/browse/TIMOB-19416). Setting null to `securityManager` should not cause runtime error.

```javascript
var win = Ti.UI.createWindow();
Ti.Network.createHTTPClient({
    securityManager: null
});
win.open();
```