### PR TITLE
TIMOB-19394 Ti.UI.View.add should support array of views

### DIFF
--- a/Source/TitaniumKit/include/Titanium/UI/ProgressBar.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/ProgressBar.hpp
@@ -71,20 +71,6 @@ namespace Titanium
 			*/
 			TITANIUM_PROPERTY_IMPL_DEF(double, value);
 
-			/*!
-			  @method
-			  @abstract remove
-			  @discussion Removes a child view from this view's hierarchy.
-			*/
-			virtual void remove(const std::shared_ptr<View>& view) TITANIUM_NOEXCEPT;
-
-			/*!
-			  @method
-			  @abstract add
-			  @discussion Adds a child to this view's hierarchy.
-			*/
-			virtual void add(const std::shared_ptr<View>& view) TITANIUM_NOEXCEPT;
-
 			ProgressBar(const JSContext&) TITANIUM_NOEXCEPT;
 
 			virtual ~ProgressBar() = default;

--- a/Source/TitaniumKit/include/Titanium/UI/View.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/View.hpp
@@ -59,6 +59,12 @@ namespace Titanium
 			virtual void blur();
 			virtual void focus();
 
+			/*!
+				This delegates to the layout_delegate__ to add the view, but allows for platform-specific overrides of handling the wrapped view.
+				This is important so the underlying platform can handle automatically wrapping/unwrapping native UI widgets mixed with Titanium UI.
+			*/
+			virtual void add(const JSObject&) TITANIUM_NOEXCEPT;
+
 			View(const JSContext&) TITANIUM_NOEXCEPT;
 
 			virtual ~View() TITANIUM_NOEXCEPT;  //= default;
@@ -71,7 +77,7 @@ namespace Titanium
 
 			static void JSExportInitialize();
 
-			virtual TITANIUM_FUNCTION_DEF(add);
+			TITANIUM_FUNCTION_DEF(add);
 			TITANIUM_FUNCTION_DEF(animate);
 			TITANIUM_FUNCTION_DEF(hide);
 			TITANIUM_FUNCTION_DEF(remove);

--- a/Source/TitaniumKit/src/UI/ProgressBar.cpp
+++ b/Source/TitaniumKit/src/UI/ProgressBar.cpp
@@ -32,16 +32,6 @@ namespace Titanium
 		TITANIUM_PROPERTY_READWRITE(ProgressBar, double, min)
 		TITANIUM_PROPERTY_READWRITE(ProgressBar, double, value)
 
-		void ProgressBar::remove(const std::shared_ptr<View>& view) TITANIUM_NOEXCEPT
-		{
-			TITANIUM_LOG_DEBUG("ProgressBar::add");
-		}
-
-		void ProgressBar::add(const std::shared_ptr<View>& view) TITANIUM_NOEXCEPT
-		{
-			TITANIUM_LOG_DEBUG("ProgressBar::remove");
-		}
-
 		void ProgressBar::JSExportInitialize() 
 		{
 			JSExport<ProgressBar>::SetClassVersion(1);
@@ -55,8 +45,6 @@ namespace Titanium
 			TITANIUM_ADD_PROPERTY(ProgressBar, style);
 			TITANIUM_ADD_PROPERTY(ProgressBar, value);
 
-			TITANIUM_ADD_FUNCTION(ProgressBar, remove);
-			TITANIUM_ADD_FUNCTION(ProgressBar, add);
 			TITANIUM_ADD_FUNCTION(ProgressBar, getColor);
 			TITANIUM_ADD_FUNCTION(ProgressBar, setColor);
 			TITANIUM_ADD_FUNCTION(ProgressBar, getFont);
@@ -93,20 +81,6 @@ namespace Titanium
 
 		TITANIUM_PROPERTY_GETTER_UNIMPLEMENTED(ProgressBar, style)
 		TITANIUM_PROPERTY_SETTER_UNIMPLEMENTED(ProgressBar, style)
-
-		TITANIUM_FUNCTION(ProgressBar, remove)
-		{
-			ENSURE_OBJECT_AT_INDEX(view, 0);
-			remove(view.GetPrivate<View>());
-			return get_context().CreateUndefined();
-		}
-
-		TITANIUM_FUNCTION(ProgressBar, add)
-		{
-			ENSURE_OBJECT_AT_INDEX(view, 0);
-			add(view.GetPrivate<View>());
-			return get_context().CreateUndefined();
-		}
 
 		TITANIUM_FUNCTION_AS_GETTER(ProgressBar, getColor, color)
 		TITANIUM_FUNCTION_AS_SETTER(ProgressBar, setColor, color)

--- a/Source/TitaniumKit/src/UI/View.cpp
+++ b/Source/TitaniumKit/src/UI/View.cpp
@@ -52,6 +52,11 @@ namespace Titanium
 			fireEvent("focus");
 		}
 
+		void View::add(const JSObject& view) TITANIUM_NOEXCEPT
+		{
+			layoutDelegate__->add(view.GetPrivate<View>());
+		}
+
 		void View::JSExportInitialize()
 		{
 			JSExport<View>::SetClassVersion(1);
@@ -93,7 +98,21 @@ namespace Titanium
 		TITANIUM_FUNCTION(View, add)
 		{
 			ENSURE_OBJECT_AT_INDEX(view, 0);
-			layoutDelegate__->add(view.GetPrivate<View>());
+
+			// Support single view, or an array of views
+			std::vector<JSObject> views;
+			if (view.IsArray()) {
+				auto js_array = static_cast<std::vector<JSValue>>(static_cast<JSArray>(view));
+				for (auto v : js_array) {
+					views.push_back(static_cast<JSObject>(v));
+				}
+			} else {
+				views.push_back(view);
+			}
+
+			for (auto v : views) {
+				add(v);
+			}
 			return get_context().CreateUndefined();
 		}
 

--- a/Source/UI/include/TitaniumWindows/UI/View.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/View.hpp
@@ -30,6 +30,8 @@ namespace TitaniumWindows
 		public:
 			View(const JSContext&) TITANIUM_NOEXCEPT;
 
+			virtual void add(const JSObject&) TITANIUM_NOEXCEPT override final;
+
 			virtual ~View();
 			View(const View&) = default;
 			View& operator=(const View&) = default;
@@ -44,7 +46,6 @@ namespace TitaniumWindows
 			virtual void enableEvent(const std::string& event_name) TITANIUM_NOEXCEPT override final;
 			virtual void disableEvent(const std::string& event_name) TITANIUM_NOEXCEPT override final;
 
-			virtual JSValue js_add(const std::vector<JSValue>& arguments, JSObject& this_object) override final;
 			virtual void registerNativeUIWrapHook(std::function<JSObject(const JSContext&, const JSObject&)> requireCallback);
 
 			virtual Windows::UI::Xaml::FrameworkElement^ getComponent() TITANIUM_NOEXCEPT;

--- a/Source/UI/src/View.cpp
+++ b/Source/UI/src/View.cpp
@@ -49,14 +49,11 @@ namespace TitaniumWindows
 			JSExport<View>::SetParent(JSExport<Titanium::UI::View>::Class());
 		}
 
-		TITANIUM_FUNCTION(View, add)
+		void View::add(const JSObject& view) TITANIUM_NOEXCEPT
 		{
-			ENSURE_OBJECT_AT_INDEX(view, 0);
 			auto ui_view = view.GetPrivate<::Titanium::UI::View>();
-			if (ui_view) {
-				layoutDelegate__->add(ui_view);
-			} else {
-				// If this is a native wrapper, we need to jump thorugh a lot of hoops to basically unwrap and rewrap as a Ti.UI.View
+			if (!ui_view) {
+				// If this is a native wrapper, we need to jump through a lot of hoops to basically unwrap and rewrap as a Ti.UI.View
 				auto context = get_context();
 
 				JSValue Titanium_property = context.get_global_object().GetProperty("Titanium");
@@ -75,9 +72,8 @@ namespace TitaniumWindows
 
 				auto rewrapped = windows_view->native_wrapper_hook__(context, view);
 				ui_view = rewrapped.GetPrivate<::Titanium::UI::View>();
-				layoutDelegate__->add(ui_view);
 			}
-			return get_context().CreateUndefined();
+			Titanium::UI::View::add(ui_view);
 		}
 
 		void View::registerNativeUIWrapHook(std::function<JSObject(const JSContext&, const JSObject&)> requireHook)

--- a/Source/UI/src/View.cpp
+++ b/Source/UI/src/View.cpp
@@ -52,28 +52,30 @@ namespace TitaniumWindows
 		void View::add(const JSObject& view) TITANIUM_NOEXCEPT
 		{
 			auto ui_view = view.GetPrivate<::Titanium::UI::View>();
-			if (!ui_view) {
-				// If this is a native wrapper, we need to jump through a lot of hoops to basically unwrap and rewrap as a Ti.UI.View
-				auto context = get_context();
-
-				JSValue Titanium_property = context.get_global_object().GetProperty("Titanium");
-				TITANIUM_ASSERT(Titanium_property.IsObject());  // precondition
-				JSObject Titanium = static_cast<JSObject>(Titanium_property);
-
-				JSValue UI_property = Titanium.GetProperty("UI");
-				TITANIUM_ASSERT(UI_property.IsObject());  // precondition
-				JSObject UI = static_cast<JSObject>(UI_property);
-
-				JSValue View_property = UI.GetProperty("View");
-				TITANIUM_ASSERT(View_property.IsObject());  // precondition
-				JSObject View = static_cast<JSObject>(View_property);
-
-				auto windows_view = View.GetPrivate<::TitaniumWindows::UI::View>();
-
-				auto rewrapped = windows_view->native_wrapper_hook__(context, view);
-				ui_view = rewrapped.GetPrivate<::Titanium::UI::View>();
+			if (ui_view) {
+				Titanium::UI::View::add(view);
+				return;
 			}
-			Titanium::UI::View::add(ui_view);
+			
+			// If this is a native wrapper, we need to jump through a lot of hoops to basically unwrap and rewrap as a Ti.UI.View
+			auto context = get_context();
+
+			JSValue Titanium_property = context.get_global_object().GetProperty("Titanium");
+			TITANIUM_ASSERT(Titanium_property.IsObject());  // precondition
+			JSObject Titanium = static_cast<JSObject>(Titanium_property);
+
+			JSValue UI_property = Titanium.GetProperty("UI");
+			TITANIUM_ASSERT(UI_property.IsObject());  // precondition
+			JSObject UI = static_cast<JSObject>(UI_property);
+
+			JSValue View_property = UI.GetProperty("View");
+			TITANIUM_ASSERT(View_property.IsObject());  // precondition
+			JSObject View = static_cast<JSObject>(View_property);
+
+			auto windows_view = View.GetPrivate<::TitaniumWindows::UI::View>();
+
+			auto rewrapped = windows_view->native_wrapper_hook__(context, view);
+			Titanium::UI::View::add(rewrapped);
 		}
 
 		void View::registerNativeUIWrapHook(std::function<JSObject(const JSContext&, const JSObject&)> requireHook)


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-19394

Not sure if we want to merge this immediately. Need more direction on whether we truly want to expand the API for other platforms like this and update our docs; or keep as-is and drop support in iOS; or further expand API to also support a single or array of objects holding a "view" and "position" key like iOS supports (but is not mentioned in the ticket or docs).