### PR TITLE
Improve compile time of WindowsNativeModuleLoader for Native API access

### DIFF
--- a/cli/lib/TODO.md
+++ b/cli/lib/TODO.md
@@ -1,9 +1,6 @@
 = TODO =
-- Async methods
-	- We skip them entirely. We need to convert to a Promise like object like WInJS does
-- Avoid recompiling everything on every rebuild
-	- Shouldn't need to recompile anything if no new native types are added
-	- Only compile new types and RequireHook/WindowsNativeModuleLoader if new types/modules added!
+- Filter down list of includes in cpp files and WindowsNativeModuleLoader.cpp
+	- We have the type dependency tree, we can likely eliminate many includes knowing that Type X includes Type Y, which includes Type Z, etc.
 	
 == Improvements to Metadata ==
 - Consistently use "class Name.Of.Class" or "Name.Of.Class" for types. Probably the former.

--- a/templates/build/Native/src/WindowsNativeModuleLoader.cpp.ejs
+++ b/templates/build/Native/src/WindowsNativeModuleLoader.cpp.ejs
@@ -9,8 +9,8 @@
 #include "TitaniumWindows/UI/UIElement.hpp"
 
 // INSERT_INCLUDES
-<% for (class_name in classes) { -%>
-#include "<%= class_name %>.hpp"
+<% for (var x = 0; x < unique_classes.length; x++) { -%>
+#include "<%= unique_classes[x] %>.hpp"
 <% } -%>
 // END_INCLUDES
 


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-19414

Basically we whittle down the set of headers to include in Plaftorm.Object.cpp and WindowsNativeModuleLoader based on the knowledge that we have about the inheritance tree and that a given type will include it's parent header in it's own.

The effects don't seem to be all to great. In a first-time build from scratch I saw a reduction in the compile/link time from about 5:35 to 5:29. We could do the same thing in the individual proxy/wrapper cpp files too, but generally speaking the list of includes there is much smaller, and it's slightly more work to filter there right now. Given the small reduction in time for the two files with the largest set of includes, it probably isn't worth it right now.