### PR TITLE
Fix: wrong behavior for touch events

### DIFF
--- a/Source/UI/src/View.cpp
+++ b/Source/UI/src/View.cpp
@@ -121,16 +121,16 @@ namespace TitaniumWindows
 					this->fireEvent("touchmove", eventArgs);
 				});
 			} else if (event_name == "touchstart") {
-				component->ManipulationMode = ManipulationModes::All;
-				component->ManipulationStarted += ref new ManipulationStartedEventHandler([ctx, this](Platform::Object^ sender, ManipulationStartedRoutedEventArgs^ e) {
+				component->PointerPressed += ref new PointerEventHandler([ctx, this](Platform::Object^ sender, PointerRoutedEventArgs^ e) {
 					const auto component = safe_cast<FrameworkElement^>(sender);
-					firePositionEvent("touchstart", component, e->Position);
+					const auto point = Windows::UI::Input::PointerPoint::GetCurrentPoint(e->Pointer->PointerId);
+					firePositionEvent("touchstart", component, point->Position);
 				});
 			} else if (event_name == "touchend") {
-				component->ManipulationMode = ManipulationModes::All;
-				component->ManipulationCompleted += ref new ManipulationCompletedEventHandler([ctx, this](Platform::Object^ sender, ManipulationCompletedRoutedEventArgs^ e) {
+				component->PointerReleased += ref new PointerEventHandler([ctx, this](Platform::Object^ sender, PointerRoutedEventArgs^ e) {
 					const auto component = safe_cast<FrameworkElement^>(sender);
-					firePositionEvent("touchend", component, e->Position);
+					const auto point = Windows::UI::Input::PointerPoint::GetCurrentPoint(e->Pointer->PointerId);
+					firePositionEvent("touchend", component, point->Position);
 				});
 			} else if (event_name == "click") {
 				click_event__ = component->Tapped += ref new TappedEventHandler([this, ctx](Platform::Object^ sender, TappedRoutedEventArgs^ e) {
@@ -154,8 +154,11 @@ namespace TitaniumWindows
 				});
 			} else if (event_name == "longpress") {
 				longpress_event__ = component->Holding += ref new HoldingEventHandler([this, ctx](Platform::Object^ sender, HoldingRoutedEventArgs^ e) {
-					const auto component = safe_cast<FrameworkElement^>(sender);
-					firePositionEvent("longpress", component, e->GetPosition(component));
+					// fires event only when it started
+					if (e->HoldingState == Windows::UI::Input::HoldingState::Started) {
+						const auto component = safe_cast<FrameworkElement^>(sender);
+						firePositionEvent("longpress", component, e->GetPosition(component));
+					}
 				});
 			} else if (event_name == "focus") {
 				focus_event__ = component->GotFocus += ref new RoutedEventHandler([this, ctx](Platform::Object^ sender, RoutedEventArgs^ e) {


### PR DESCRIPTION
Fix for [TIMOB-19502](https://jira.appcelerator.org/browse/TIMOB-19502) originated from [TIMOB-19401](https://jira.appcelerator.org/browse/TIMOB-19401)

- Fix: touchstart and touchend not fired
- Fix: longpress fired twice
