### PR TITLE
Refactor & Allow mixing Windows UI component for View subclass

### DIFF
--- a/Source/TitaniumKit/include/Titanium/UI/ViewLayoutDelegate.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/ViewLayoutDelegate.hpp
@@ -440,6 +440,14 @@ namespace Titanium
 				event_delegate__ = event_delegate;
 			}
 
+			/*
+			 * For mixing Ti.Ui.View and native view
+			 */
+			virtual std::shared_ptr<View> rescueGetView(const JSObject& view) TITANIUM_NOEXCEPT
+			{
+				return nullptr;
+			}
+
 			ViewLayoutDelegate() TITANIUM_NOEXCEPT;
 			virtual ~ViewLayoutDelegate();
 

--- a/Source/TitaniumKit/src/UI/View.cpp
+++ b/Source/TitaniumKit/src/UI/View.cpp
@@ -54,7 +54,14 @@ namespace Titanium
 
 		void View::add(const JSObject& view) TITANIUM_NOEXCEPT
 		{
-			layoutDelegate__->add(view.GetPrivate<View>());
+			auto view_ptr = view.GetPrivate<View>();
+			
+			// For mixing Ti.Ui.View and native view.
+			if (view_ptr == nullptr) {
+				view_ptr = layoutDelegate__->rescueGetView(view);
+			}
+
+			layoutDelegate__->add(view_ptr);
 		}
 
 		void View::JSExportInitialize()

--- a/Source/UI/include/TitaniumWindows/UI/View.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/View.hpp
@@ -30,8 +30,6 @@ namespace TitaniumWindows
 		public:
 			View(const JSContext&) TITANIUM_NOEXCEPT;
 
-			virtual void add(const JSObject&) TITANIUM_NOEXCEPT override final;
-
 			virtual ~View();
 			View(const View&) = default;
 			View& operator=(const View&) = default;
@@ -46,14 +44,9 @@ namespace TitaniumWindows
 			virtual void enableEvent(const std::string& event_name) TITANIUM_NOEXCEPT override final;
 			virtual void disableEvent(const std::string& event_name) TITANIUM_NOEXCEPT override final;
 
-			virtual void registerNativeUIWrapHook(std::function<JSObject(const JSContext&, const JSObject&)> requireCallback);
+			virtual void registerNativeUIWrapHook(const std::function<JSObject(const JSContext&, const JSObject&)>& requireCallback);
 
 			virtual Windows::UI::Xaml::FrameworkElement^ getComponent() TITANIUM_NOEXCEPT;
-
-#pragma warning(push)
-#pragma warning(disable : 4251)
-			std::function<JSObject(const JSContext&, const JSObject&)> native_wrapper_hook__;
-#pragma warning(pop)
 
 		private:
 

--- a/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
@@ -378,9 +378,18 @@ namespace TitaniumWindows
 
 			void updateBackgroundImageSize() TITANIUM_NOEXCEPT;
 
+			virtual std::shared_ptr<Titanium::UI::View> rescueGetView(const JSObject& view) TITANIUM_NOEXCEPT override;
+			virtual void registerNativeUIWrapHook(const std::function<JSObject(const JSContext&, const JSObject&)>& requireCallback);
+
+#pragma warning(push)
+#pragma warning(disable : 4251)
+			std::function<JSObject(const JSContext&, const JSObject&)> native_wrapper_hook__;
+#pragma warning(pop)
+
 		protected:
 #pragma warning(push)
 #pragma warning(disable : 4251)
+
 			Windows::UI::Xaml::FrameworkElement^ component__ { nullptr };
 			Windows::UI::Xaml::Controls::Image^ backgroundImageControl__ { nullptr };
 

--- a/Source/UI/src/Window.cpp
+++ b/Source/UI/src/Window.cpp
@@ -215,31 +215,11 @@ namespace TitaniumWindows
 			const auto commandBar = viewObj.GetPrivate<TitaniumWindows::UI::WindowsXaml::CommandBar>();
 			if (commandBar == nullptr) {
 				// delegate to parent
-				auto ui_view = viewObj.GetPrivate<::Titanium::UI::View>();
-				if (ui_view) {
-					layoutDelegate__->add(ui_view);
-				} else {
-					// If this is a native wrapper, we need to jump thorugh a lot of hoops to basically unwrap and rewrap as a Ti.UI.View
-					auto context = get_context();
-
-					JSValue Titanium_property = context.get_global_object().GetProperty("Titanium");
-					TITANIUM_ASSERT(Titanium_property.IsObject());  // precondition
-					JSObject Titanium = static_cast<JSObject>(Titanium_property);
-
-					JSValue UI_property = Titanium.GetProperty("UI");
-					TITANIUM_ASSERT(UI_property.IsObject());  // precondition
-					JSObject UI = static_cast<JSObject>(UI_property);
-
-					JSValue View_property = UI.GetProperty("View");
-					TITANIUM_ASSERT(View_property.IsObject());  // precondition
-					JSObject View = static_cast<JSObject>(View_property);
-
-					auto windows_view = View.GetPrivate<::TitaniumWindows::UI::View>();
-
-					auto rewrapped = windows_view->native_wrapper_hook__(context, viewObj);
-					ui_view = rewrapped.GetPrivate<::Titanium::UI::View>();
-					layoutDelegate__->add(ui_view);
+				auto ui_view = viewObj.GetPrivate<Titanium::UI::View>();
+				if (ui_view == nullptr) {
+					ui_view = layoutDelegate__->rescueGetView(viewObj);
 				}
+				layoutDelegate__->add(ui_view);
 				return get_context().CreateUndefined();
 			}
 


### PR DESCRIPTION
Refactoring #419, which basically overrides `View.add` and `Window.add` only. This PR moves these native hook logic onto `WindowsViewLayoutDelegate` so that every View subclass supports mixing Windows UI components. Moving to layout delegate is also good for avoiding duplicate code across View subclasses.

- Refactor & Allow mixing Windows UI component for View subclass
- Move View::registerNativeUIWrapHook to layout delegate

```javascript
var win,
    TextBlock = require('Windows.UI.Xaml.Controls.TextBlock'),
	text = new TextBlock();

text.Text = "Hello, world!";
text.FontSize = 60;

win = Ti.UI.createWindow({});
win.add(text);
win.open();
```

```javascript
var Window = require('Windows.UI.Xaml.Window'),
    Canvas = require('Windows.UI.Xaml.Controls.Canvas'),
    window = Window.Current,
    canvas = new Canvas(),
    text;

text = Ti.UI.createLabel({
    text: "Hello, world!",
    font: {
        fontSize: 60
    }
});
canvas.Children.Append(text);

window.Content = canvas;
window.Activate();
```