### PR TITLE
Fix TIMOB-19517 Windows: Native stub generation fails on 'float32' when requiring StackPanel

### DIFF
--- a/cli/lib/stub.js
+++ b/cli/lib/stub.js
@@ -150,8 +150,22 @@ function addNewTypes(rawTypeName, existingTypes) {
 		types = expandTypes(rawTypeName);
 		for (var i = 0; i < types.length; i++) {
 			// skip template names, primitives
-			if (types[i].indexOf("!") == 0 || types[i] == 'bool' ||
-				types[i] == 'uint32' || types[i] == 'float64' || types[i] == 'string' ||
+			if (types[i].indexOf("!") == 0 ||
+				// primitives
+				types[i] == 'bool' ||
+				types[i] == 'char' ||
+				types[i] == 'int64' ||
+				types[i] == 'int32' ||
+				types[i] == 'int16' ||
+				types[i] == 'int' ||
+				types[i] == 'uint64' ||
+				types[i] == 'uint32' ||
+				types[i] == 'uint16' ||
+				types[i] == 'uint8' ||
+				types[i] == 'float64' ||
+				types[i] == 'float32' ||
+				types[i] == 'double' ||
+				types[i] == 'string' ||
 				types[i] == 'Windows.Storage.StorageProvider') { // FIXME A Windows Store-only API!
 				continue;
 			}

--- a/cli/lib/templates/js_to_native.cpp
+++ b/cli/lib/templates/js_to_native.cpp
@@ -24,13 +24,22 @@ else if (type.indexOf('class ') == 0) {
 <%- include('js_to_native_class.cpp', {type: type, metadata: metadata, to_assign: to_assign, argument_name: argument_name}) -%>
 <%
 }
-// TODO Any other primitive types?
-else if (type == 'bool' || type == 'int32' || type == 'uint32' || 
-		type == 'double' || type == 'uint16' || type == 'uint8' ||
-		type == 'int16' || type == 'int' || type == 'string' ||
-		type == 'float32' || type == 'float64' || type == 'int64' ||
-		type == 'int64' || type == 'uint64' || type == 'single' ||
-		type == 'char16' || type == 'Platform.String') {
+// primitives
+else if (type == 'bool' ||
+		type == 'char' ||
+		type == 'int64' ||
+		type == 'int32' ||
+		type == 'int16' ||
+		type == 'int' ||
+		type == 'uint64' ||
+		type == 'uint32' ||
+		type == 'uint16' ||
+		type == 'uint8' ||
+		type == 'float64' ||
+		type == 'float32' ||
+		type == 'double' ||
+		type == 'string' ||
+		type == 'Platform.String') {
 -%>
 <%- include('js_to_native_primitive.cpp', {to_assign: to_assign, argument_name: argument_name}) -%>
 <%

--- a/cli/lib/templates/js_to_native_primitive.cpp
+++ b/cli/lib/templates/js_to_native_primitive.cpp
@@ -3,13 +3,12 @@
 // to_assign: the name of the native variable to assign the resulting value to
 // argument_name: the name of the JS variable we're converting from
 
-// TODO single, char16
 if (type == 'bool') {
 -%> 
 			TITANIUM_ASSERT_AND_THROW(<%= argument_name %>.IsBoolean(), "Expected boolean");
 			auto <%= to_assign %> = static_cast<bool>(<%= argument_name %>);
 <%
-} else if (type == 'int32' || type == 'int16' || type == 'int') {
+} else if (type == 'int32' || type == 'int16' || type == 'int' || type == 'char') {
 -%> 
 			TITANIUM_ASSERT_AND_THROW(<%= argument_name %>.IsNumber(), "Expected Number");
 			auto <%= to_assign %> = static_cast<int32_t>(<%= argument_name %>);

--- a/cli/lib/templates/native_primitive_to_js.cpp
+++ b/cli/lib/templates/native_primitive_to_js.cpp
@@ -4,7 +4,6 @@
 // argument_name: the name of the native variable we're converting from
 // context_name: name of the JSContext var to use. typically 'context'
 
-// TODO single, char16
 if (type == 'bool') {
 -%> 
 			auto <%= to_assign %> = <%- context_name %>.CreateBoolean(<%- argument_name %>); 
@@ -17,7 +16,7 @@ if (type == 'bool') {
 -%>
 			auto <%= to_assign %> = <%- context_name %>.CreateNumber(static_cast<uint32_t>(<%- argument_name %>));
 <%
-} else if (type == 'int16' || type == 'int') {
+} else if (type == 'int16' || type == 'int' || type == 'char') {
 -%>
 			auto <%= to_assign %> = <%- context_name %>.CreateNumber(static_cast<int32_t>(<%- argument_name %>));
 <%

--- a/cli/lib/templates/native_to_js.cpp
+++ b/cli/lib/templates/native_to_js.cpp
@@ -27,13 +27,21 @@ else if (type.indexOf('class ') == 0) {
 <%- include('native_class_to_js.cpp', {type: type, metadata: metadata, to_assign: to_assign, argument_name: argument_name, context_name: context_name}) -%>
 <%
 }
-// TODO Any other primtive types?
-else if (type == 'bool' || type == 'int32' || type == 'uint32' || 
-		type == 'double' || type == 'uint16' || type == 'uint8' ||
-		type == 'int16' || type == 'int' || type == 'string' ||
-		type == 'float32' || type == 'float64' || type == 'int64' ||
-		type == 'int64' || type == 'uint64' || type == 'single' ||
-		type == 'char16') {
+// primitives
+else if (type == 'bool' ||
+		type == 'char' ||
+		type == 'int64' ||
+		type == 'int32' ||
+		type == 'int16' ||
+		type == 'int' ||
+		type == 'uint64' ||
+		type == 'uint32' ||
+		type == 'uint16' ||
+		type == 'uint8' ||
+		type == 'float64' ||
+		type == 'float32' ||
+		type == 'double' ||
+		type == 'string') {
 -%>
 <%- include('native_primitive_to_js.cpp', {to_assign: to_assign, argument_name: argument_name, context_name: context_name}) -%>
 <%


### PR DESCRIPTION
Handle all primitives found in metabase wherever we need to filter them out/convert them.

https://jira.appcelerator.org/browse/TIMOB-19517

Basically we need to avoid including primitives in the dependency tree for generating wrappers, and we  need to make sure we can convert primitives back and forth from JS.