### PR TITLE
Add VS 2015 and Windows 10 SDK option for CLI

### DIFF
--- a/Tools/Scripts/generate_project.js
+++ b/Tools/Scripts/generate_project.js
@@ -34,7 +34,9 @@ program
 	.usage('COMMAND [ARGS] [OPTIONS]')
 	.option('-a, --arch <arch>', '"ARM" (device) or "Win32" (emulator)')
 	.option('-o, --outputPath <outputPath>', 'Output path for generated code')
-	.option('-p, --platform <platform>', '"WindowsPhone" or "WindowsStore"');
+	.option('-p, --platform <platform>', '"WindowsPhone" or "WindowsStore"')
+	.option('-t, --target <platform target>', '"8.1" or "10"')
+	.option('-m, --msdev <msbuild version>', '"12" (VS 2013) or "14" (VS 2015)');
 
 program.command('new'.blue+' <example_name>'.white)
 		.description('    create a new project from the packaged examples'.grey);
@@ -79,7 +81,9 @@ if (!fs.existsSync(dest)) {
 	// Make the directory structure!
 	wrench.mkdirSyncRecursive(dest);
 }
-var generator = 'Visual Studio 12 2013';
+var generator = program.msdev == '14' ? 'Visual Studio 14 2015' : 'Visual Studio 12 2013';
+var generator_target = program.target || '8.1';
+
 if (arch == 'ARM') {
 	generator += ' ARM';
 }
@@ -88,7 +92,7 @@ var example_folder = path.join(__dirname, '..', '..', 'Examples', example_name);
 // Now let's generate the solution
 var prc = spawn('cmake', ['-G', generator,
 	'-DCMAKE_SYSTEM_NAME=' + platform, 
-	'-DCMAKE_SYSTEM_VERSION=8.1',
+	'-DCMAKE_SYSTEM_VERSION=' + generator_target,
     '-DTitaniumWindows_DISABLE_TESTS=ON',
     '-DTitaniumWindows_Global_DISABLE_TESTS=ON',
     '-DTitaniumWindows_Ti_DISABLE_TESTS=ON',

--- a/cli/commands/_build/config.js
+++ b/cli/commands/_build/config.js
@@ -103,6 +103,7 @@ function config(logger, config, cli) {
 							hidden: true
 						},
 						'target': this.configOptionTarget(110),
+						'vs-target': this.configOptionVisualStudioTarget(120),
 						'win-publisher-id': this.configOptionWindowsPublisherID(210),
 						'wp-publisher-guid': this.configOptionWPPublisherGUID(220),
 						'wp-product-guid': this.configOptionWPProductID(230),

--- a/cli/commands/_build/config/_index.js
+++ b/cli/commands/_build/config/_index.js
@@ -8,3 +8,4 @@ exports.configOptionWPPublisherGUID = require('./wpPublisherGUID');
 exports.configOptionWPProductID = require('./wpProductId');
 exports.configOptionWPSDK = require('./wpSDK');
 exports.configOptionWSCert = require('./wsCert');
+exports.configOptionVisualStudioTarget = require('./vstarget');

--- a/cli/commands/_build/config/vstarget.js
+++ b/cli/commands/_build/config/vstarget.js
@@ -1,0 +1,28 @@
+var appc = require('node-appc'),
+	windowslib = require('windowslib'),
+	__ = appc.i18n(__dirname).__;
+
+/**
+ * Defines the --vs-target option.
+ *
+ * @param {Number} order - The order to apply to this option.
+ *
+ * @returns {Object}
+ */
+module.exports = function configOptionVisualStudioTarget(order) {
+	var defaultTarget = this.windowsInfo.selectedVisualStudio.version;
+
+	var vsTargets = [];
+	for (var version in this.windowsInfo.visualstudio) {
+		vsTargets.push(version);
+	}
+
+	return {
+		abbr: 'V',
+		default: defaultTarget,
+		desc: __('the Visual Studio target to build for'),
+		order: order,
+		required: true,
+		values: vsTargets
+	};
+};

--- a/cli/commands/_build/config/wpSDK.js
+++ b/cli/commands/_build/config/wpSDK.js
@@ -16,6 +16,6 @@ module.exports = function configOptionWPSDK(order) {
 		desc: __('the Windows Phone SDK version; only used when target is %s, %s, or %s', 'wp-emulator'.cyan, 'wp-device'.cyan, 'dist-phonestore'.cyan),
 		hint: __('version'),
 		order: order,
-		values: ['8.1']
+		values: ['8.1', '10']
 	};
 };

--- a/cli/commands/_build/initialize.js
+++ b/cli/commands/_build/initialize.js
@@ -49,6 +49,12 @@ function initialize(next) {
 	this.arch = this.cmakeArch == 'Win32' ? 'x86' : this.cmakeArch;
 	this.cmakeTarget = this.cmakePlatformAbbrev + '.' + this.arch;
 
+	if (argv['vs-target']) {
+		this.cmakeGeneratorName = argv['vs-target'] == '14' ? 'Visual Studio 14 2015' : 'Visual Studio 12 2013';
+	} else {
+		this.cmakeGeneratorName = 'Visual Studio 12 2013';
+	}
+
 	// directories
 	this.outputDir = argv['output-dir'] ? appc.fs.resolvePath(argv['output-dir']) : null;
 	this.wsCert = argv['ws-cert'] ? argv['ws-cert'] : null;

--- a/cli/commands/_build/initialize.js
+++ b/cli/commands/_build/initialize.js
@@ -49,11 +49,13 @@ function initialize(next) {
 	this.arch = this.cmakeArch == 'Win32' ? 'x86' : this.cmakeArch;
 	this.cmakeTarget = this.cmakePlatformAbbrev + '.' + this.arch;
 
-	if (argv['vs-target']) {
-		this.cmakeGeneratorName = argv['vs-target'] == '14' ? 'Visual Studio 14 2015' : 'Visual Studio 12 2013';
-	} else {
-		this.cmakeGeneratorName = 'Visual Studio 12 2013';
-	}
+	// Detect CMake generator name: e.g. 12.0 -> Visual Studio 12 2013
+	// because there's no specific way to auto-detect "year" component
+	var supportedCMakeGenerators = {
+		'12.0': 'Visual Studio 12 2013',
+		'14.0': 'Visual Studio 14 2015',
+	};
+	this.cmakeGeneratorName = supportedCMakeGenerators[argv['vs-target']];
 
 	// directories
 	this.outputDir = argv['output-dir'] ? appc.fs.resolvePath(argv['output-dir']) : null;

--- a/cli/commands/_build/logInfo.js
+++ b/cli/commands/_build/logInfo.js
@@ -59,6 +59,10 @@ function loginfo(next) {
 		this.logger.info(__('Performing build only'));
 	}
 
+	this.logger.debug(__('CMake generator name: %s', this.cmakeGeneratorName.cyan));
+	this.logger.debug(__('CMAKE_SYSTEM_NAME: %s', this.cmakePlatform.cyan));
+	this.logger.debug(__('CMAKE_SYSTEM_VERSION: %s', this.wpsdk.cyan));
+
 	this.logger.debug(__('Titanium SDK Windows directory: %s', this.platformPath.cyan));
 	this.logger.info(__('Deploy type: %s', this.deployType.cyan));
 

--- a/cli/commands/_build/run.js
+++ b/cli/commands/_build/run.js
@@ -82,7 +82,7 @@ function run(logger, config, cli, finished) {
 function runCmake(next) {
 	this.logger.info(__('Running cmake at %s in directory %s', this.cmake.cyan, this.cmakeTargetDir.cyan));
 	var _t = this,
-		generatorName = 'Visual Studio 12 2013',
+		generatorName = this.cmakeGeneratorName,
 		p;
 
 	if (this.cmakeArch == 'ARM') {


### PR DESCRIPTION
[TIMOB-19576](https://jira.appcelerator.org/browse/TIMOB-19576)

- Add `--vs-target` option to specify Visual Studio version
 - 12.0  ... Visual Studio 2013
 - 14.0 ... Visual Studio 2015
- Add Windows 10 sdk support  (`--wp-sdk 10`)

```
ti build --platform windows --vs-target 12.0 --target wp-emulator --device-id 8-1-1 --win-publisher-id 13AXB724-65X2-4X30-8994-C79399EDXX00 --wp-sdk 8.1
```

Note that although CLI accepts targeting to Windows 10 (`--wp-sdk 10`), it's failing for now because cmake doesn't support that yet. It's implemented for future release.
