### PR TITLE
[TIMOB-19644] Fix: CLI build error is ignored

### DIFF
--- a/cli/commands/_build/copy.js
+++ b/cli/commands/_build/copy.js
@@ -408,6 +408,11 @@ function copyResources(next) {
 	}.bind(this));
 
 	appc.async.series(this, tasks, function (err, results) {
+
+		if (err) {
+			return next(err);
+		}
+
 		var templateDir = path.join(this.platformPath, 'templates', 'app', 'default', 'template', 'Resources', 'windows');
 
 		// if an app icon hasn't been copied, copy the default one


### PR DESCRIPTION
[TIMOB-19644](https://jira.appcelerator.org/browse/TIMOB-19644) Related: [TIMOB-19643](https://jira.appcelerator.org/browse/TIMOB-19643)

When there's no DefaultIcon.png, CLI shows critical error on build but it does not stop build process.
