### PR TITLE
[TIMOB-19650] Skip generation of existing icons

### DIFF
--- a/cli/commands/_build/copy.js
+++ b/cli/commands/_build/copy.js
@@ -292,6 +292,16 @@ function copyResources(next) {
 
 			// TODO: Generate SplashScreen.scale-100.png?
 		];
+
+		// do not generate existing icons
+		for (i in missingIcons) {
+			var icon = missingIcons[i];
+			if (fs.existsSync(icon.file)) {
+				_t.logger.debug(__('%s already exists, skipping...', icon.file));
+				missingIcons.splice(i, 1);
+			}
+		}
+
 		this.generateAppIcons(missingIcons, next);
 	}
 


### PR DESCRIPTION
- Skip the generation of existing icons

###### TEST CASE
- Place a required icon into ```<project>/app/assets/windows/```, for example ```Square150x150Logo.png```
- This icon should not be overwritten by the ```DefaultIcon.png``` after the project has been generated using ```appc run```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-19650)