### PR TITLE
[TIMOB-18531] Set default value for Windows Publisher ID prompt

### DIFF
--- a/cli/commands/_build/config/winPublisherId.js
+++ b/cli/commands/_build/config/winPublisherId.js
@@ -20,7 +20,7 @@ module.exports = function configOptionWindowsPublisherID(order) {
 
 	return {
 		abbr: 'I',
-		default: this.config.get('windows.publisherId'),
+		default: this.cli.argv['deploy-type'] !== 'production' ? '00000000-0000-1000-8000-000000000000' : this.config.get('windows.publisherId'),
 		desc: __('your Windows publisher ID, obtained from %s', 'https://dev.windows.com/en-us/Account/Management'.cyan),
 		hint: __('id'),
 		order: order,
@@ -29,8 +29,7 @@ module.exports = function configOptionWindowsPublisherID(order) {
 				promptLabel: __('What is your __Windows Publisher ID__?'),
 				validate: validate
 			}));
-		},
-		required: true,
+		}.bind(this),
 		validate: validate
 	};
 };


### PR DESCRIPTION
- Set a default value for the ```Windows Publisher ID``` prompt
- Do not set a default prompt value if ```--deploy-type``` is ```production```

###### TEST CASE
```
appc run -p windows
# builds project without prompting for 'Publisher ID'
```
```
appc run -p windows --deploy-type production
What is your Windows Publisher ID?:
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-18531)