### PR TITLE
Fix: building Windows 10 Store app

### DIFF
--- a/cli/commands/_build/config/wpSDK.js
+++ b/cli/commands/_build/config/wpSDK.js
@@ -16,6 +16,6 @@ module.exports = function configOptionWPSDK(order) {
 		desc: __('the Windows Phone SDK version; only used when target is %s, %s, or %s', 'wp-emulator'.cyan, 'wp-device'.cyan, 'dist-phonestore'.cyan),
 		hint: __('version'),
 		order: order,
-		values: ['8.1', '10']
+		values: ['8.1', '10.0']
 	};
 };

--- a/cli/commands/_build/generate.js
+++ b/cli/commands/_build/generate.js
@@ -192,9 +192,16 @@ function generateCmakeList(next) {
 		return 'Assets/' + filename;  // cmake likes unix separators
 	});
 
+	var isBuildForWindowsStore = (this.cmakePlatform == 'WindowsStore');
+
 	// Generate source groups!
 	// go through the asset list, and basically generate a group for each folder
 	assetList.forEach(function (filepath) {
+		// Skip scale-xx.png assets because WindowsStore doesn't need it
+		// TODO: we don't even need to copy these resources for WindowsStore
+		if (isBuildForWindowsStore && /.scale-\d+.png$/.test(filepath)) {
+			return;
+		}
 		// lop off Assets/
 		var truncatedPath = filepath.substring(7);
 		// drop the file basename?

--- a/templates/build/CMakeLists.txt.ejs
+++ b/templates/build/CMakeLists.txt.ejs
@@ -75,7 +75,7 @@ set(PHONE_PUBLISHER_ID "<%= phonePublisherId %>")
 # Generate the app manifest.
 if(${CMAKE_SYSTEM_VERSION} STREQUAL "10.0")
 configure_file(
-  src/Package.win10.appxmanifest.in
+  Package.win10.appxmanifest.in
   ${CMAKE_CURRENT_BINARY_DIR}/${APP_MANIFEST_NAME}
   @ONLY)
 else()

--- a/templates/build/Package.store.appxmanifest.in.ejs
+++ b/templates/build/Package.store.appxmanifest.in.ejs
@@ -57,7 +57,6 @@
 <% for(var i = 0; i < manifest.Capabilities.length; i++) { -%>
     <%- manifest.Capabilities[i] %>
 <% } -%>
-    <m3:Capability Name="contacts" />
   </Capabilities>
   
 </Package>


### PR DESCRIPTION
Fix for [TIMOB-19689](https://jira.appcelerator.org/browse/TIMOB-19689).

- Ignore scaled image assets with `scale-xx` when building for Store
- Remove invalid capability entry

Make sure to update [windowslib](https://github.com/appcelerator/windowslib/pull/24) too.