### PR TITLE
TIMOB-19804 Windows: Modify Windows SDK build process to grab and use JavaScriptCore from a URL

### DIFF
--- a/Tools/Scripts/build/test.js
+++ b/Tools/Scripts/build/test.js
@@ -42,9 +42,11 @@ function getSDKInstallDir(next) {
 			selectedSDK;
 		if (error !== null) {
 		  next('Failed to get SDK install dir: ' + error);
+		  return;
 		}
 
 		out = JSON.parse(stdout);
+		console.log(stdout);
 		selectedSDK = out['titaniumCLI']['selectedSDK'];
 
 		sdkPath = out['titanium'][selectedSDK]['path'];

--- a/Tools/Scripts/build/test.js
+++ b/Tools/Scripts/build/test.js
@@ -37,7 +37,7 @@ function installSDK(next) {
 }
 
 function getSDKInstallDir(next) {
-	var prc = exec('node "' + titanium + '" info -o json -t titanium', function (error, stdout, stderr) {
+	var prc = exec('node "' + titanium + '" info -o json', function (error, stdout, stderr) {
 		var out,
 			selectedSDK;
 		if (error !== null) {

--- a/Tools/Scripts/build/test.js
+++ b/Tools/Scripts/build/test.js
@@ -39,7 +39,8 @@ function installSDK(next) {
 function getSDKInstallDir(next) {
 	var prc = exec('node "' + titanium + '" info -o json', function (error, stdout, stderr) {
 		var out,
-			selectedSDK;
+			selectedSDK,
+			blah;
 		if (error !== null) {
 		  next('Failed to get SDK install dir: ' + error);
 		  return;
@@ -48,9 +49,25 @@ function getSDKInstallDir(next) {
 		out = JSON.parse(stdout);
 		console.log(stdout);
 		selectedSDK = out['titaniumCLI']['selectedSDK'];
-
 		sdkPath = out['titanium'][selectedSDK]['path'];
-		next();
+
+		//	
+		blah = spawn(out['windows']['windowsphone']['8.1']['deployCmd'], ['/EnumerateDevices']);
+		blah.stdout.on('data', function (data) {
+			console.log(data.toString());
+		});
+		blah.stderr.on('data', function (data) {
+			console.error(data.toString());
+		});
+		blah.on('close', function (code) {
+			if (code != 0) {
+				console.log(code);
+				next("Failed to create project");
+			} else {
+				next();
+			}
+		});
+		//next();
 	});
 }
 

--- a/Tools/Scripts/index.js
+++ b/Tools/Scripts/index.js
@@ -1,0 +1,14 @@
+
+/**
+ * @module index
+ *
+ * @copyright
+ * Copyright (c) 2015 by Appcelerator, Inc. All Rights Reserved.
+ *
+ * @license
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+module.setup = require('./setup');
+module.build = require('./build/build');
+module.test = require('./build/test');

--- a/Tools/Scripts/package.bat
+++ b/Tools/Scripts/package.bat
@@ -13,7 +13,11 @@ echo Exit Code = %ERRORLEVEL%
 cd ..
 robocopy apidoc\Titanium dist\windows\doc\Titanium /e
 
-cd Tools\Scripts\build
+cd Tools\Scripts
+call npm install .
+call node setup.js --no-color --no-progress-bars
+
+cd build
 call npm install .
 call node build.js
 call node test.js

--- a/Tools/Scripts/package.bat
+++ b/Tools/Scripts/package.bat
@@ -19,7 +19,7 @@ call node setup.js --no-color --no-progress-bars
 
 cd build
 call npm install .
-call node build.js
+call node build.js --only WindowsPhone-x86
 call node test.js
 rmdir node_modules /Q /S
 cd ..\..\..


### PR DESCRIPTION
This modifies package.bat to run Tools/Scripts/setup.js before running the build and test scripts.

This means that we'll attempt to set up the build environment before running the build, which allows us to modify the Boost/GTest/JSC used to build. For now I modified that setup.js script so that even if we find a directory where JavaScript_HOME env var is pointing at, we check for a SOURCE_URL file in the directory and compare it versus the URL we want to grab from. If they differ, we'll download the new JSC.