### PR TITLE
Fix: MSBuild process remains after "ti build"

### DIFF
--- a/cli/commands/_build/compile.js
+++ b/cli/commands/_build/compile.js
@@ -76,7 +76,7 @@ function compileApp(next) {
 
 		// Use spawn directly so we can pipe output as we go
 		p = spawn(vsInfo.vcvarsall, [
-			'&&', 'MSBuild', '/m', '/p:Platform=' + _t.cmakeArch, '/p:Configuration=' + _t.buildConfiguration, slnFile
+			'&&', 'MSBuild', '/p:Platform=' + _t.cmakeArch, '/p:Configuration=' + _t.buildConfiguration, slnFile
 		]);
 		p.stdout.on('data', function (data) {
 			var line = data.toString().trim();

--- a/cli/commands/_buildModule.js
+++ b/cli/commands/_buildModule.js
@@ -173,7 +173,7 @@ WindowsModuleBuilder.prototype.compileModule = function compileModule(next) {
 		}
 
 		var p = spawn(_t.windowsInfo.selectedVisualStudio.vcvarsall, [
-			'&&', 'MSBuild', '/m', '/p:Platform=' + arch, '/p:Configuration=' + config, sln
+			'&&', 'MSBuild', '/p:Platform=' + arch, '/p:Configuration=' + config, sln
 		]);
 		p.stdout.on('data', function (data) {
 			var line = data.toString().trim();


### PR DESCRIPTION
Fix for [TIMOB-19646](https://jira.appcelerator.org/browse/TIMOB-19646).

`MSBuild` process remains after `ti build`. For some reason `/m` (`/maxcpucount[:number]`) option didn't work well, it lefts zombie process even after build is finished.