### PR TITLE
Fix :CLI doesn't exit on parse error

### DIFF
--- a/cli/commands/_build/copy.js
+++ b/cli/commands/_build/copy.js
@@ -446,7 +446,7 @@ function copyResources(next) {
 					var toplevel = UglifyJS.parse(fromContent);
 				} catch (E) {
 					t_.logger.error(reportJSErrors(from, fromContent, E));
-					return;
+					return next('Failed to parse JavaScript files.');
 				}
 
 				var walker = new UglifyJS.TreeWalker(function (node) {


### PR DESCRIPTION
Fix for [TIMOB-19698](https://jira.appcelerator.org/browse/TIMOB-19698)