### PR TITLE
Fix: Windows 10 mobile emulator should not show up in selection

### DIFF
--- a/cli/commands/_build/config/deviceID.js
+++ b/cli/commands/_build/config/deviceID.js
@@ -58,12 +58,6 @@ module.exports = function configOptionDeviceID(order) {
 				}.bind(this));
 		} else {
 			// must be emulator then
-
-			// Windows 10 mobile emulator is not supported yet
-			if (/Mobile\ Emulator\ 10\./.test(dev.name)) {
-				return callback(new Error(__('Invalid device id "%s": Windows 10 Mobile Emulator is not supported', value)));
-			}
-			
 			callback(null, value);
 		}
 	}

--- a/cli/commands/_build/utils.js
+++ b/cli/commands/_build/utils.js
@@ -33,8 +33,12 @@ function getTargetDevices() {
 		wpsdk = this.cli.argv['wp-sdk'];
 
 	if (target === 'wp-emulator' && this.windowsInfo.emulators && Array.isArray(this.windowsInfo.emulators[wpsdk])) {
-		return this.deviceCache = this.windowsInfo.emulators[wpsdk];
+		// Windows 10 mobile emulator is not supported
+		var emulators = this.windowsInfo.emulators[wpsdk].filter(function(emu) {
+			return !(/Mobile\ Emulator\ 10\./.test(emu.name));
+		});
 
+		return this.deviceCache = emulators;
 	} else if (target === 'wp-device' && Array.isArray(this.windowsInfo.devices)) {
 		return this.deviceCache = this.windowsInfo.devices;
 	}


### PR DESCRIPTION
Fix for [TIMOB-19811](https://jira.appcelerator.org/browse/TIMOB-19811).

Emulators that are not supported should not be shown as an option to build to.

```
﻿﻿PS > ti build --platform windows --vs-target 12.0 --target wp-emulator --win-publisher-id 00AFB000-00F0-0F00-0000-C00000EDBD00 --wp-sdk 8.1
Titanium Command-Line Interface, CLI version 5.0.1, Titanium SDK version 5.2.0.v20151102141226
Copyright (c) 2012-2015, Appcelerator, Inc.  All Rights Reserved.

Please report bugs to http://jira.appcelerator.org/

Which emulator do you want to install your app on?
   1)  Emulator 8.1 WVGA 4 inch 512MB  (udid: 8-1-6)
   2)  Emulator 8.1 WVGA 4 inch        (udid: 8-1-7)
   3)  Emulator 8.1 WXGA 4.5 inch      (udid: 8-1-8)
   4)  Emulator 8.1 720P 4.7 inch      (udid: 8-1-9)
   5)  Emulator 8.1 1080P 5.5 inch     (udid: 8-1-10)
   6)  Emulator 8.1 1080P 6 inch       (udid: 8-1-11)
Select by number or name [Emulator 8.1 WVGA 4 inch 512MB]:
```