### PR TITLE
Fix: DefaultLanguage property should be set (to "en") in manifest

### DIFF
--- a/cli/commands/_build/generate.js
+++ b/cli/commands/_build/generate.js
@@ -111,7 +111,11 @@ function addI18nVSResources(next) {
 
 	// add it after the first occurrence of </ItemGroup>
 	modified = modified.replace(/<\/ItemGroup>/, itemGroupContent.join('\r\n  '));
-	fs.writeFileSync(vcxproj, modified)
+
+	// DefaultLanguage (forcing to "en" for now)
+	modified = modified.replace(/<DefaultLanguage>[a-zA-Z]{2}(-[a-zA-Z]{2})*<\/DefaultLanguage>/, '<DefaultLanguage>en</DefaultLanguage>');
+
+	fs.writeFileSync(vcxproj, modified);
 
 	next();
 }


### PR DESCRIPTION
Fix for [TIMOB-19138](https://jira.appcelerator.org/browse/TIMOB-19138)

Set `DefaultLanguage` to `en` to suppress compiler warning.
Note: Would be nice to have platform-specific default language property, something like `ti.windows.defaultLanguage` FYI: [TIMOB-16356](https://jira.appcelerator.org/browse/TIMOB-16356)