### PR TITLE
Fix: TextField.passwordMask doesn't work

### DIFF
--- a/Examples/NMocha/src/Assets/ti.ui.textfield.test.js
+++ b/Examples/NMocha/src/Assets/ti.ui.textfield.test.js
@@ -50,6 +50,22 @@ describe("Titanium.UI.TextField", function () {
         finish();
     });
 
+    it("passwordMask", function (finish) {
+        var text = 'this is some text';
+        var textfield = Ti.UI.createTextField({
+            value: text
+        });
+        should(function () {
+            // passwordMask should default to false
+            should(textfield.passwordMask).be.false;
+            textfield.passwordMask = true;
+            should(textfield.passwordMask).be.true;
+            // it should have same text before
+            should(textfield.value).be.eql(text);
+        }).not.throw();
+        finish();
+    });
+
     // TODO Add tests for:
     // autocapitalize
     // autocorrect
@@ -62,7 +78,6 @@ describe("Titanium.UI.TextField", function () {
     // hintText
     // keyboardType
     // maxLength
-    // passwordMask
     // returnKeyType
     // selection
     // suppressReturn

--- a/Source/UI/include/TitaniumWindows/UI/TextField.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/TextField.hpp
@@ -52,7 +52,7 @@ namespace TitaniumWindows
 			virtual void set_keyboardType(const Titanium::UI::KEYBOARD& keyboardType) TITANIUM_NOEXCEPT override final;
 //			virtual void set_leftButtonMode(const Titanium::UI::INPUT_BUTTONMODE& leftButtonMode) TITANIUM_NOEXCEPT override final;
 			virtual void set_maxLength(const int32_t& maxLength) TITANIUM_NOEXCEPT override final;
-//			virtual void set_passwordMask(const bool& passwordMask) TITANIUM_NOEXCEPT override final;
+			virtual void set_passwordMask(const bool& passwordMask) TITANIUM_NOEXCEPT override final;
 //			virtual void set_returnKeyType(const Titanium::UI::RETURNKEY& returnKeyType) TITANIUM_NOEXCEPT override final;
 //			virtual void set_rightButtonMode(const Titanium::UI::INPUT_BUTTONMODE& rightButtonMode) TITANIUM_NOEXCEPT override final;
 //			virtual void set_suppressReturn(const bool& suppressReturn) TITANIUM_NOEXCEPT override final;
@@ -70,7 +70,11 @@ namespace TitaniumWindows
 			virtual bool js_set_width_min(const JSValue& argument) TITANIUM_NOEXCEPT final;
 
 		private:
-			Windows::UI::Xaml::Controls::TextBox^ text_box__;
+			void initTextComponent();
+
+			Windows::UI::Xaml::Controls::Grid^ parent__{ nullptr };
+			Windows::UI::Xaml::Controls::TextBox^ text_box__{ nullptr };
+			Windows::UI::Xaml::Controls::PasswordBox^ password_box__{ nullptr };
 
 			// Event handlers
 			Windows::Foundation::EventRegistrationToken blur_event_;

--- a/Source/UI/src/TextField.cpp
+++ b/Source/UI/src/TextField.cpp
@@ -235,6 +235,7 @@ namespace TitaniumWindows
 			} else if (password_box__) {
 				return TitaniumWindows::Utility::ConvertUTF8String(password_box__->Password);
 			}
+			return "";
 		}
 
 		void TextField::set_value(const std::string& value) TITANIUM_NOEXCEPT

--- a/Source/UI/src/TextField.cpp
+++ b/Source/UI/src/TextField.cpp
@@ -24,15 +24,34 @@ namespace TitaniumWindows
 		{
 			Titanium::UI::TextField::postCallAsConstructor(js_context, arguments);	
 			
+			Titanium::UI::TextField::setLayoutDelegate<WindowsViewLayoutDelegate>();
+
+			// Parent of the text box.
+			// TextField have to deal with multiple controls. (TextBox & PasswordBox)
+			parent__ = ref new Windows::UI::Xaml::Controls::Grid();
+
+			getViewLayoutDelegate<WindowsViewLayoutDelegate>()->setComponent(parent__);
+
 			text_box__ = ref new Windows::UI::Xaml::Controls::TextBox();
 			text_box__->AcceptsReturn = false;
 			text_box__->IsSpellCheckEnabled = true;
 
-			// TIMOB-19143: reset MinWidth to fix size issues
-			text_box__->MinWidth = 0;
+			parent__->Children->Append(text_box__);
+			parent__->SetColumn(text_box__, 0);
+			parent__->SetRow(text_box__, 0);
 
-			Titanium::UI::TextField::setLayoutDelegate<WindowsViewLayoutDelegate>();
-			getViewLayoutDelegate<WindowsViewLayoutDelegate>()->setComponent(text_box__);
+			initTextComponent();
+		}
+
+		void TextField::initTextComponent()
+		{
+			// TIMOB-19143: reset MinWidth to fix size issues
+			if (text_box__) {
+				text_box__->MinWidth = 0;
+			} else if (password_box__) {
+				password_box__->MinWidth = 0;
+			}
+
 		}
 
 		void TextField::JSExportInitialize()
@@ -43,124 +62,234 @@ namespace TitaniumWindows
 			JSExport<TextField>::AddValueProperty("width", std::mem_fn(&js_get_width), std::mem_fn(&js_set_width_min));
 		}
 
+		void TextField::set_passwordMask(const bool& passwordMask) TITANIUM_NOEXCEPT
+		{
+			Titanium::UI::TextField::set_passwordMask(passwordMask);
+
+			// password mask is little bit tricky here, because Xaml uses different component for it.
+			// Now we need to dispose TextBox and inherit properties from it.
+			// Don't forget to update layout delegate too...
+			if (passwordMask && text_box__) {
+				password_box__ = ref new Windows::UI::Xaml::Controls::PasswordBox();
+				//password_box__->Foreground = ref new Windows::UI::Xaml::Media::SolidColorBrush(Windows::UI::Colors::Black);
+
+				// Remove existing text box
+				if (parent__->Children->Size > 0) {
+					parent__->Children->RemoveAt(0);
+				}
+
+				// Add password box
+				parent__->Children->Append(password_box__);
+				parent__->SetColumn(password_box__, 0);
+				parent__->SetRow(password_box__, 0);
+
+				// copy properties which we interested in
+				password_box__->PlaceholderText = text_box__->PlaceholderText;
+				password_box__->Password = text_box__->Text;
+				password_box__->MaxLength = text_box__->MaxLength;
+				password_box__->Width = text_box__->Width;
+				password_box__->Height = text_box__->Height;
+
+				password_box__->IsEnabled = !text_box__->IsReadOnly;
+				password_box__->VerticalAlignment = text_box__->VerticalAlignment;
+
+				// Update color based on property string
+				set_color(get_color());
+
+				text_box__ = nullptr;
+			} else if (!passwordMask && password_box__) {
+				text_box__ = ref new Windows::UI::Xaml::Controls::TextBox();
+				text_box__->AcceptsReturn = false;
+				text_box__->IsSpellCheckEnabled = true;
+
+				// Remove existing text box
+				if (parent__->Children->Size > 0) {
+					parent__->Children->RemoveAt(0);
+				}
+
+				// Add text box
+				parent__->Children->Append(text_box__);
+				parent__->SetColumn(text_box__, 0);
+				parent__->SetRow(text_box__, 0);
+
+				// copy properties which we interested in
+				text_box__->PlaceholderText = password_box__->PlaceholderText;
+				text_box__->Text = password_box__->Password;
+				text_box__->MaxLength = password_box__->MaxLength;
+				text_box__->Width = password_box__->Width;
+				text_box__->Height = password_box__->Height;
+				text_box__->IsReadOnly = !password_box__->IsEnabled;
+				text_box__->VerticalAlignment = password_box__->VerticalAlignment;
+
+				// Update color based on property string
+				set_color(get_color());
+
+				password_box__ = nullptr;
+			}
+
+			initTextComponent();
+		}
+
 		void TextField::set_color(const std::string& colorName) TITANIUM_NOEXCEPT
 		{
 			Titanium::UI::TextField::set_color(colorName);
 			const auto color_obj = WindowsViewLayoutDelegate::ColorForName(colorName);
-			text_box__->Foreground = ref new Windows::UI::Xaml::Media::SolidColorBrush(color_obj);
+			const auto color_brush = ref new Windows::UI::Xaml::Media::SolidColorBrush(color_obj);
+			if (text_box__) {
+				text_box__->Foreground = color_brush;
+			} else if (password_box__) {
+				password_box__->Foreground = color_brush;
+			}
 		}
 
 		void TextField::set_editable(const bool& editable) TITANIUM_NOEXCEPT
 		{
 			Titanium::UI::TextField::set_editable(editable);
-			text_box__->IsReadOnly = !editable;
+			if (text_box__) {
+				text_box__->IsReadOnly = !editable;
+			} else if (password_box__) {
+				// there's no IsReadOnly property in PasswordBox.
+				password_box__->IsEnabled = !editable;
+			}
 		}
 
 		void TextField::set_hintText(const std::string& hintText) TITANIUM_NOEXCEPT
 		{
 			Titanium::UI::TextField::set_hintText(hintText);
-			text_box__->PlaceholderText = TitaniumWindows::Utility::ConvertUTF8String(hintText);
+			if (text_box__) {
+				text_box__->PlaceholderText = TitaniumWindows::Utility::ConvertUTF8String(hintText);
+			} else if (password_box__) {
+				password_box__->PlaceholderText = TitaniumWindows::Utility::ConvertUTF8String(hintText);
+			}
 		}
 
 		void TextField::set_keyboardType(const Titanium::UI::KEYBOARD& keyboardType) TITANIUM_NOEXCEPT
 		{
 			Titanium::UI::TextField::set_keyboardType(keyboardType);
-			auto scope_name = ref new Windows::UI::Xaml::Input::InputScopeName();
-			if (keyboardType == Titanium::UI::KEYBOARD::ASCII) {
-				scope_name->NameValue = Windows::UI::Xaml::Input::InputScopeNameValue::Default;
+			if (text_box__) {
+				auto scope_name = ref new Windows::UI::Xaml::Input::InputScopeName();
+				if (keyboardType == Titanium::UI::KEYBOARD::ASCII) {
+					scope_name->NameValue = Windows::UI::Xaml::Input::InputScopeNameValue::Default;
+				} else if (keyboardType == Titanium::UI::KEYBOARD::DECIMAL_PAD) {
+					scope_name->NameValue = Windows::UI::Xaml::Input::InputScopeNameValue::Number;
+				} else if (keyboardType == Titanium::UI::KEYBOARD::DEFAULT) {
+					scope_name->NameValue = Windows::UI::Xaml::Input::InputScopeNameValue::Default;
+				} else if (keyboardType == Titanium::UI::KEYBOARD::EMAIL) {
+					scope_name->NameValue = Windows::UI::Xaml::Input::InputScopeNameValue::EmailSmtpAddress;
+				} else if (keyboardType == Titanium::UI::KEYBOARD::NAMEPHONE_PAD) {
+					scope_name->NameValue = Windows::UI::Xaml::Input::InputScopeNameValue::NameOrPhoneNumber;
+				} else if (keyboardType == Titanium::UI::KEYBOARD::NUMBERS_PUNCTUATION) {
+					scope_name->NameValue = Windows::UI::Xaml::Input::InputScopeNameValue::CurrencyAmountAndSymbol;
+				} else if (keyboardType == Titanium::UI::KEYBOARD::NUMBER_PAD) {
+					scope_name->NameValue = Windows::UI::Xaml::Input::InputScopeNameValue::Number;
+				} else if (keyboardType == Titanium::UI::KEYBOARD::PHONE_PAD) {
+					scope_name->NameValue = Windows::UI::Xaml::Input::InputScopeNameValue::TelephoneNumber;
+				} else if (keyboardType == Titanium::UI::KEYBOARD::URL) {
+					scope_name->NameValue = Windows::UI::Xaml::Input::InputScopeNameValue::Url;
+				} else {
+					return;
+				}
+				auto scope = text_box__->InputScope;
+				if (!scope) {
+					scope = ref new Windows::UI::Xaml::Input::InputScope();
+					text_box__->InputScope = scope;
+				}
+				text_box__->InputScope->Names->Clear();
+				text_box__->InputScope->Names->Append(scope_name);
+			} else {
+				TITANIUM_LOG_WARN("TextField.keyboardType can not be used with passwordMask");
 			}
-			else if (keyboardType == Titanium::UI::KEYBOARD::DECIMAL_PAD) {
-				scope_name->NameValue = Windows::UI::Xaml::Input::InputScopeNameValue::Number;
-			}
-			else if (keyboardType == Titanium::UI::KEYBOARD::DEFAULT) {
-				scope_name->NameValue = Windows::UI::Xaml::Input::InputScopeNameValue::Default;
-			}
-			else if (keyboardType == Titanium::UI::KEYBOARD::EMAIL) {
-				scope_name->NameValue = Windows::UI::Xaml::Input::InputScopeNameValue::EmailSmtpAddress;
-			}
-			else if (keyboardType == Titanium::UI::KEYBOARD::NAMEPHONE_PAD) {
-				scope_name->NameValue = Windows::UI::Xaml::Input::InputScopeNameValue::NameOrPhoneNumber;
-			}
-			else if (keyboardType == Titanium::UI::KEYBOARD::NUMBERS_PUNCTUATION) {
-				scope_name->NameValue = Windows::UI::Xaml::Input::InputScopeNameValue::CurrencyAmountAndSymbol;
-			}
-			else if (keyboardType == Titanium::UI::KEYBOARD::NUMBER_PAD) {
-				scope_name->NameValue = Windows::UI::Xaml::Input::InputScopeNameValue::Number;
-			}
-			else if (keyboardType == Titanium::UI::KEYBOARD::PHONE_PAD) {
-				scope_name->NameValue = Windows::UI::Xaml::Input::InputScopeNameValue::TelephoneNumber;
-			}
-			else if (keyboardType == Titanium::UI::KEYBOARD::URL) {
-				scope_name->NameValue = Windows::UI::Xaml::Input::InputScopeNameValue::Url;
-			}
-			else {
-				return;
-			}
-			auto scope = text_box__->InputScope;
-			if (!scope) {
-				scope = ref new Windows::UI::Xaml::Input::InputScope();
-				text_box__->InputScope = scope;
-			}
-			text_box__->InputScope->Names->Clear();
-			text_box__->InputScope->Names->Append(scope_name);
 		}
 
 		void TextField::set_maxLength(const int32_t& maxLength) TITANIUM_NOEXCEPT
 		{
 			Titanium::UI::TextField::set_maxLength(maxLength);
-			text_box__->MaxLength = maxLength;
+			if (text_box__) {
+				text_box__->MaxLength = maxLength;
+			} else if (password_box__) {
+				password_box__->MaxLength = maxLength;
+			}
 		}
 
 		void TextField::set_textAlign(const Titanium::UI::TEXT_ALIGNMENT& textAlign) TITANIUM_NOEXCEPT
 		{
 			Titanium::UI::TextField::set_textAlign(textAlign);
-			if (textAlign == Titanium::UI::TEXT_ALIGNMENT::CENTER) {
-				text_box__->TextAlignment = Windows::UI::Xaml::TextAlignment::Center;
-			} else if (textAlign == Titanium::UI::TEXT_ALIGNMENT::LEFT) {
-				text_box__->TextAlignment = Windows::UI::Xaml::TextAlignment::Left;
-			} else if (textAlign == Titanium::UI::TEXT_ALIGNMENT::RIGHT) {
-				text_box__->TextAlignment = Windows::UI::Xaml::TextAlignment::Right;
+			if (text_box__) {
+				if (textAlign == Titanium::UI::TEXT_ALIGNMENT::CENTER) {
+					text_box__->TextAlignment = Windows::UI::Xaml::TextAlignment::Center;
+				} else if (textAlign == Titanium::UI::TEXT_ALIGNMENT::LEFT) {
+					text_box__->TextAlignment = Windows::UI::Xaml::TextAlignment::Left;
+				} else if (textAlign == Titanium::UI::TEXT_ALIGNMENT::RIGHT) {
+					text_box__->TextAlignment = Windows::UI::Xaml::TextAlignment::Right;
+				}
+				// TODO Windows supports JUSTIFY!
+			} else {
+				TITANIUM_LOG_WARN("TexeField.textAlign can not be used with passwordMask");
 			}
-			// TODO Windows supports JUSTIFY!
 		}
 
 		std::string TextField::get_value() const TITANIUM_NOEXCEPT
 		{
-			return TitaniumWindows::Utility::ConvertUTF8String(text_box__->Text);
+			if (text_box__) {
+				return TitaniumWindows::Utility::ConvertUTF8String(text_box__->Text);
+			} else if (password_box__) {
+				return TitaniumWindows::Utility::ConvertUTF8String(password_box__->Password);
+			}
 		}
 
 		void TextField::set_value(const std::string& value) TITANIUM_NOEXCEPT
 		{
 			Titanium::UI::TextField::set_value(value);
-			text_box__->Text = TitaniumWindows::Utility::ConvertUTF8String(value);
+			if (text_box__) {
+				text_box__->Text = TitaniumWindows::Utility::ConvertUTF8String(value);
+			} else if (password_box__) {
+				password_box__->Password = TitaniumWindows::Utility::ConvertUTF8String(value);
+			}
 		}
 
 		void TextField::set_verticalAlign(const Titanium::UI::TEXT_VERTICAL_ALIGNMENT& verticalAlign) TITANIUM_NOEXCEPT
 		{
 			Titanium::UI::TextField::set_verticalAlign(verticalAlign);
+			auto align = Windows::UI::Xaml::VerticalAlignment::Center;
 			if (verticalAlign == Titanium::UI::TEXT_VERTICAL_ALIGNMENT::BOTTOM) {
-				text_box__->VerticalAlignment = Windows::UI::Xaml::VerticalAlignment::Bottom;
+				align = Windows::UI::Xaml::VerticalAlignment::Bottom;
 			} else if (verticalAlign == Titanium::UI::TEXT_VERTICAL_ALIGNMENT::CENTER) {
-				text_box__->VerticalAlignment = Windows::UI::Xaml::VerticalAlignment::Center;
+				align = Windows::UI::Xaml::VerticalAlignment::Center;
 			} else if (verticalAlign == Titanium::UI::TEXT_VERTICAL_ALIGNMENT::TOP) {
-				text_box__->VerticalAlignment = Windows::UI::Xaml::VerticalAlignment::Top;
+				align = Windows::UI::Xaml::VerticalAlignment::Top;
 			}
 			// TODO Windows supports stretch!
+
+			if (text_box__) {
+				text_box__->VerticalAlignment = align;
+			} else if (password_box__) {
+				password_box__->VerticalAlignment = align;
+			}
 		}
 
 		void TextField::blur() TITANIUM_NOEXCEPT
 		{
 			// TODO Windows doesn't allow forcibly losing focus, need to set focus on another control to achieve it! Can we set focus on the window or parent or something?
+			TITANIUM_LOG_WARN("TextField.blur() is not supported yet");
 		}
 
 		void TextField::focus() TITANIUM_NOEXCEPT
 		{
-			text_box__->Focus(Windows::UI::Xaml::FocusState::Programmatic);
+			if (text_box__) {
+				text_box__->Focus(Windows::UI::Xaml::FocusState::Programmatic);
+			} else if (password_box__) {
+				password_box__->Focus(Windows::UI::Xaml::FocusState::Programmatic);
+			}
 		}
 
 		bool TextField::hasText() TITANIUM_NOEXCEPT
 		{
-			return !text_box__->Text->IsEmpty();
+			if (text_box__) {
+				return !text_box__->Text->IsEmpty();
+			} else if (password_box__) {
+				return !password_box__->Password->IsEmpty();
+			}
+			return false;
 		}
 
 		void TextField::enableEvent(const std::string& event_name) TITANIUM_NOEXCEPT
@@ -173,31 +302,47 @@ namespace TitaniumWindows
 			using namespace Windows::UI::Xaml;
 
 			if (event_name == "blur") {
-				blur_event_ = text_box__->LostFocus += ref new RoutedEventHandler([this, ctx](Platform::Object^ sender, RoutedEventArgs^ e) {
+				const auto lostfocus = ref new RoutedEventHandler([this, ctx](Platform::Object^ sender, RoutedEventArgs^ e) {
 					JSObject eventArgs = ctx.CreateObject();
 					eventArgs.SetProperty("value", ctx.CreateString(this->get_value()));
 
 					this->fireEvent("blur", eventArgs);
 				});
-				return;
+				if (text_box__) {
+					blur_event_ = text_box__->LostFocus += lostfocus;
+				} else if (password_box__) {
+					blur_event_ = password_box__->LostFocus += lostfocus;
+				}
 			} else if (event_name == "change") {
-				change_event_ = text_box__->TextChanged += ref new Controls::TextChangedEventHandler([this, ctx](Platform::Object^ sender, Controls::TextChangedEventArgs^ e) {
-					JSObject eventArgs = ctx.CreateObject();
-					eventArgs.SetProperty("value", ctx.CreateString(this->get_value()));
+				if (text_box__) {
+					change_event_ = text_box__->TextChanged += ref new Controls::TextChangedEventHandler([this, ctx](Platform::Object^ sender, Controls::TextChangedEventArgs^ e) {
+						JSObject eventArgs = ctx.CreateObject();
+						eventArgs.SetProperty("value", ctx.CreateString(this->get_value()));
 
-					this->fireEvent("change", eventArgs);
-				});
-				return;
+						this->fireEvent("change", eventArgs);
+					});
+				} else if (password_box__) {
+					change_event_ = password_box__->PasswordChanged += ref new RoutedEventHandler([this, ctx](Platform::Object^ sender, RoutedEventArgs^ e){
+						JSObject eventArgs = ctx.CreateObject();
+						eventArgs.SetProperty("value", ctx.CreateString(this->get_value()));
+
+						this->fireEvent("change", eventArgs);
+					});
+				}
 			} else if (event_name == "focus") {
-				focus_event_ = text_box__->GotFocus += ref new RoutedEventHandler([this, ctx](Platform::Object^ sender, RoutedEventArgs^ e) {
+				const auto gotfocus = ref new RoutedEventHandler([this, ctx](Platform::Object^ sender, RoutedEventArgs^ e) {
 					JSObject eventArgs = ctx.CreateObject();
 					eventArgs.SetProperty("value", ctx.CreateString(this->get_value()));
 
 					this->fireEvent("focus", eventArgs);
 				});
-				return;
+				if (text_box__) {
+					focus_event_ = text_box__->GotFocus += gotfocus;
+				} else if (password_box__) {
+					focus_event_ = password_box__->GotFocus += gotfocus;
+				}
 			} else if (event_name == "return") {
-				return_event_ = text_box__->KeyDown += ref new KeyEventHandler([this, ctx](Platform::Object^ sender, KeyRoutedEventArgs^ e) {
+				const auto keydown = ref new KeyEventHandler([this, ctx](Platform::Object^ sender, KeyRoutedEventArgs^ e) {
 					if (e->Key == Windows::System::VirtualKey::Enter) {
 						JSObject eventArgs = ctx.CreateObject();
 						eventArgs.SetProperty("value", ctx.CreateString(this->get_value()));
@@ -205,7 +350,11 @@ namespace TitaniumWindows
 						this->fireEvent("return", eventArgs);
 					}
 				});
-				return;
+				if (text_box__) {
+					return_event_ = text_box__->KeyDown += keydown;
+				} else if (password_box__) {
+					return_event_ = password_box__->KeyDown += keydown;
+				}
 			}
 		}
 


### PR DESCRIPTION
Fix for [TIMOB-19894](https://jira.appcelerator.org/browse/TIMOB-19894).

Test Case: Following script should show password-masked TextField.

```javascript
var win = Ti.UI.createWindow({
    backgroundColor: 'blue'
});
var field = Ti.UI.createTextField({ width:200, passwordMask:true, value:'pa33w0rd'});

win.add(field);
win.open();
```