### PR TITLE
[TIMOB-19925] Implement Ti.App.Properties 'change' event

### DIFF
--- a/Examples/NMocha/src/Assets/ti.app.properties.test.js
+++ b/Examples/NMocha/src/Assets/ti.app.properties.test.js
@@ -163,4 +163,26 @@ describe('Titanium.App.Properties', function () {
         should(Ti.App.Properties.hasProperty('presetString')).be.eql(true);
         finish();
     });
+
+    it('change events', function (finish) {
+        var eventCount = 0;
+        Ti.App.Properties.addEventListener('change', function (properties) {
+            should(properties.source).be.a.Object;
+            should(properties.type).be.eql('change');
+            eventCount++;
+        });
+        Ti.App.Properties.setBool('test_bool', true);
+        Ti.App.Properties.setDouble('test_double', 1.23);
+        Ti.App.Properties.setInt('test_int', 1);
+        Ti.App.Properties.setString('test_string', 'test');
+        Ti.App.Properties.setList('test_list', [1, 2, 3]);
+        Ti.App.Properties.setObject('test_object', {test: 'test'});
+
+        // verify all change events have fired
+        setTimeout(function () {
+            should(eventCount).be.eql(6);
+        }, 3000);
+
+        finish();
+    });
 });

--- a/Source/Ti/include/TitaniumWindows/App/Properties.hpp
+++ b/Source/Ti/include/TitaniumWindows/App/Properties.hpp
@@ -56,8 +56,9 @@ namespace TitaniumWindows
 			virtual void setInt(const std::string& property, int value) TITANIUM_NOEXCEPT override;
 			virtual void setString(const std::string& property, const std::string& value) TITANIUM_NOEXCEPT override;
 
-			ApplicationDataContainer^ local_settings_;
+			virtual void fireChangeEvent() TITANIUM_NOEXCEPT;
 
+			ApplicationDataContainer^ local_settings_;
 		};
 	} // namespace App
 }  // namespace TitaniumWindows

--- a/Source/Ti/src/Properties.cpp
+++ b/Source/Ti/src/Properties.cpp
@@ -119,7 +119,7 @@ namespace TitaniumWindows
 			auto values = local_settings_->Values;
 			values->Insert(Utility::ConvertString(property), dynamic_cast<PropertyValue^>(PropertyValue::CreateBoolean(value)));
 
-			//fireEvent
+			fireChangeEvent();
 		}
 
 		void Properties::setDouble(const std::string& property, double value) TITANIUM_NOEXCEPT
@@ -127,7 +127,7 @@ namespace TitaniumWindows
 			auto values = local_settings_->Values;
 			values->Insert(Utility::ConvertString(property), dynamic_cast<PropertyValue^>(PropertyValue::CreateDouble(value)));
 
-			//fireEvent
+			fireChangeEvent();
 		}
 
 		void Properties::setInt(const std::string& property, int value) TITANIUM_NOEXCEPT
@@ -135,7 +135,7 @@ namespace TitaniumWindows
 			auto values = local_settings_->Values;
 			values->Insert(Utility::ConvertString(property), dynamic_cast<PropertyValue^>(PropertyValue::CreateInt32(value)));
 
-			//fireEvent
+			fireChangeEvent();
 		}
 
 		void Properties::setString(const std::string& property, const std::string& value) TITANIUM_NOEXCEPT
@@ -143,7 +143,15 @@ namespace TitaniumWindows
 			auto values = local_settings_->Values;
 			values->Insert(Utility::ConvertString(property), dynamic_cast<PropertyValue^>(PropertyValue::CreateString(Utility::ConvertString(value))));
 
-			//fireEvent
+			fireChangeEvent();
+		}
+
+		void Properties::fireChangeEvent() TITANIUM_NOEXCEPT
+		{
+			JSObject changeEvent = get_context().CreateObject();
+			changeEvent.SetProperty("source", this->get_object());
+			changeEvent.SetProperty("type", get_context().CreateString("change"));
+			this->fireEvent("change", changeEvent);
 		}
 
 	} // namespace App

--- a/Source/TitaniumKit/src/App/Properties.cpp
+++ b/Source/TitaniumKit/src/App/Properties.cpp
@@ -154,7 +154,6 @@ namespace Titanium
 				get_context().JSEvaluateScript("Ti.API.warn('Cannot overwrite/delete read-only property: " + property + "');");
 				return;
 			}
-			
 		}
 
 		void Properties::setList(const std::string& property, std::vector<JSValue> value) TITANIUM_NOEXCEPT
@@ -162,15 +161,11 @@ namespace Titanium
 			std::vector<JSValue> arguments;
 			arguments.push_back(get_context().CreateArray(value));
 			setString(property, static_cast<std::string>(stringify_function__(arguments, get_context().get_global_object())));
-
-			//fireEvent
 		}
 
 		void Properties::setObject(const std::string& property, JSObject value) TITANIUM_NOEXCEPT
 		{
 			setString(property, static_cast<std::string>(stringify_function__({ value }, get_context().get_global_object())));
-
-			//fireEvent
 		}
 
 		void Properties::setString(const std::string& property, const std::string& value) TITANIUM_NOEXCEPT


### PR DESCRIPTION
- Implement the ```change``` event to be fired when properties are set

###### TEST CASE
```Javascript
Ti.App.Properties.addEventListener('change', function (properties) {
    Ti.API.info(JSON.stringify(properties));
});
Ti.App.Properties.setBool('BOOL', true);
Ti.App.Properties.setDouble('DOUBLE', 1.23);
Ti.App.Properties.setInt('INT', 1);
Ti.App.Properties.setString('STRING', 'test');
Ti.App.Properties.setList('LIST', [1, 2, 3]);
Ti.App.Properties.setObject('OBJECT', {test: 'test'});
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-19925)