### PR TITLE
Disable AudioCategory on Windows 10

### DIFF
--- a/Source/Media/src/Media/AudioPlayer.cpp
+++ b/Source/Media/src/Media/AudioPlayer.cpp
@@ -38,7 +38,11 @@ namespace TitaniumWindows
 			Titanium::Media::AudioPlayer::postCallAsConstructor(js_context, arguments);
 
 			player__ = ref new Windows::UI::Xaml::Controls::MediaElement();
+#pragma warning(push)
+#pragma warning(disable : 4973)
+			// Note: BackgroundCapableMedia is deprecated in Windows 10
 			player__->AudioCategory = AudioCategory::BackgroundCapableMedia;
+#pragma warning(pop)
 			player__->AreTransportControlsEnabled = true;
 			player__->Visibility = Windows::UI::Xaml::Visibility::Collapsed; // Hide UI
 			player__->AutoPlay = false;


### PR DESCRIPTION
Fix compiler warning on Windows 10.

Although it's not quite clear which values are deprecated, VS 2015 compiler produces warning on use of `AudioCategory::BackgroundCapableMedia`. 

The document from MS says:

[MediaElement class](https://msdn.microsoft.com/library/windows/apps/windows.ui.xaml.controls.mediaelement.aspx)
> To let audio continue to play when your app is in the background, set the AudioCategory property to BackgroundCapableMedia. This also requires declaring the "Audio" background task capability in the app manifest. **These values are deprecated in Windows 10**.

But what does "*Those values*" exactly mean?

In their API document, MS says it's *supported* in Windows 10. See [AudioCategory enumeration](https://msdn.microsoft.com/en-us/library/windows/apps/windows.ui.xaml.media.audiocategory.aspx) and [AudioCategory property](https://msdn.microsoft.com/en-us/library/windows/apps/windows.ui.xaml.controls.mediaelement.audiocategory.aspx).

Mystery.
