### PR TITLE
Implement missing events for Label, Button, TextField and TextArea

### DIFF
--- a/Source/TitaniumKit/include/Titanium/UI/TextArea.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/TextArea.hpp
@@ -20,6 +20,21 @@ namespace Titanium
 		using namespace HAL;
 
 		/*!
+		@struct
+		@discussion Dictionary object of parameters for the Titanium.UI.TextArea.
+		selected event and Titanium.UI.TextArea.selection property that describes position and length of the selected text.
+		See http://docs.appcelerator.com/platform/latest/#!/api/textAreaSelectedParams
+		*/
+		struct TextAreaSelectedParams
+		{
+			std::uint32_t length  { 0 };
+			std::uint32_t location{ 0 };
+		};
+
+		TITANIUMKIT_EXPORT TextAreaSelectedParams js_to_TextAreaSelectedParams(const JSObject& object);
+		TITANIUMKIT_EXPORT JSObject TextAreaSelectedParams_to_js(const JSContext& js_context, const TextAreaSelectedParams& params);
+
+		/*!
 		  @class
 		  @discussion This is the Titanium TextArea Module.
 		  See http://docs.appcelerator.com/titanium/latest/#!/api/Titanium.UI.TextArea
@@ -193,7 +208,7 @@ namespace Titanium
 			  @abstract selection
 			  @discussion Returns the currently selected text of the text area.
 			*/
-			TITANIUM_PROPERTY_IMPL_READONLY_DEF(JSValue, selection);
+			TITANIUM_PROPERTY_IMPL_READONLY_DEF(TextAreaSelectedParams, selection);
 
 			/*!
 			  @property

--- a/Source/TitaniumKit/src/UI/TextArea.cpp
+++ b/Source/TitaniumKit/src/UI/TextArea.cpp
@@ -13,6 +13,25 @@ namespace Titanium
 {
 	namespace UI
 	{
+		TextAreaSelectedParams js_to_TextAreaSelectedParams(const JSObject& object)
+		{
+			TextAreaSelectedParams params;
+			if (object.HasProperty("length")) {
+				params.length = static_cast<std::uint32_t>(object.GetProperty("length"));
+			}
+			if (object.HasProperty("location")) {
+				params.location = static_cast<std::uint32_t>(object.GetProperty("location"));
+			}
+			return params;
+		};
+
+		JSObject TextAreaSelectedParams_to_js(const JSContext& js_context, const TextAreaSelectedParams& params)
+		{
+			auto object = js_context.CreateObject();
+			object.SetProperty("length",   js_context.CreateNumber(params.length));
+			object.SetProperty("location", js_context.CreateNumber(params.location));
+			return object;
+		}
 
 		TextArea::TextArea(const JSContext& js_context, const std::vector<JSValue>& arguments) TITANIUM_NOEXCEPT
 			: View(js_context, "Titanium.UI.TextArea"),
@@ -67,13 +86,11 @@ namespace Titanium
 		TITANIUM_PROPERTY_READWRITE(TextArea, std::string, value)
 		TITANIUM_PROPERTY_READWRITE(TextArea, bool, scrollable)
 
-		JSValue TextArea::get_selection() const TITANIUM_NOEXCEPT
+		TextAreaSelectedParams TextArea::get_selection() const TITANIUM_NOEXCEPT
 		{
-			auto context = get_context();
-			auto object = context.CreateObject();
-			object.SetProperty("location", context.CreateNumber(0));
-			object.SetProperty("length", context.CreateNumber(0));
-			return object;
+			TITANIUM_LOG_WARN("TextArea::get_selection: Unimplemented");
+			TextAreaSelectedParams params;
+			return params;
 		}
 
 		TITANIUM_PROPERTY_READWRITE(TextArea, TEXT_ALIGNMENT, textAlign)
@@ -308,7 +325,7 @@ namespace Titanium
 
 		TITANIUM_PROPERTY_GETTER(TextArea, selection)
 		{
-			return get_selection();
+			return TextAreaSelectedParams_to_js(get_context(), get_selection());
 		}
 
 		TITANIUM_PROPERTY_GETTER(TextArea, returnKeyType)

--- a/Source/UI/include/TitaniumWindows/UI/Button.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/Button.hpp
@@ -52,6 +52,8 @@ namespace TitaniumWindows
 
 			static const std::uint32_t DefaultFontSize = 20;
 
+			virtual void enableEvent(const std::string& event_name)  TITANIUM_NOEXCEPT override final;
+
 		private:
 #pragma warning(push)
 #pragma warning(disable : 4251)

--- a/Source/UI/include/TitaniumWindows/UI/TextArea.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/TextArea.hpp
@@ -65,14 +65,15 @@ namespace TitaniumWindows
 			virtual void set_font(const Titanium::UI::Font& font) TITANIUM_NOEXCEPT override final;
 			virtual void set_keyboardType(const Titanium::UI::KEYBOARD& keyboardType) TITANIUM_NOEXCEPT override final;
 			virtual void set_hintText(const std::string&) TITANIUM_NOEXCEPT override final;
-			virtual JSValue get_selection() const TITANIUM_NOEXCEPT override final;
+			virtual Titanium::UI::TextAreaSelectedParams get_selection() const TITANIUM_NOEXCEPT override final;
 			virtual void set_maxLength(const int32_t&) TITANIUM_NOEXCEPT override final;
 			virtual void set_textAlign(const Titanium::UI::TEXT_ALIGNMENT& textAlign) TITANIUM_NOEXCEPT override final;
 			virtual std::string get_value() const TITANIUM_NOEXCEPT override final;
 			virtual void set_value(const std::string&) TITANIUM_NOEXCEPT override final;
 			virtual void set_verticalAlign(const Titanium::UI::TEXT_VERTICAL_ALIGNMENT& verticalAlign) TITANIUM_NOEXCEPT override final;
 
-			virtual void focus() TITANIUM_NOEXCEPT override final;
+			virtual void enableEvent(const std::string& event_name) TITANIUM_NOEXCEPT override final;
+			virtual void disableEvent(const std::string& event_name) TITANIUM_NOEXCEPT override final;
 
 		private:
 #pragma warning(push)
@@ -82,10 +83,9 @@ namespace TitaniumWindows
 			Windows::UI::Xaml::Controls::TextBox^ text_box__;
 
 			// Event handlers
-			Windows::Foundation::EventRegistrationToken blur_event_;
-			Windows::Foundation::EventRegistrationToken change_event_;
-			Windows::Foundation::EventRegistrationToken focus_event_;
-			Windows::Foundation::EventRegistrationToken return_event_;
+			Windows::Foundation::EventRegistrationToken change_event__;
+			Windows::Foundation::EventRegistrationToken return_event__;
+			Windows::Foundation::EventRegistrationToken select_event__;
 
 		};
 	}  // namespace UI

--- a/Source/UI/include/TitaniumWindows/UI/TextField.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/TextField.hpp
@@ -77,6 +77,7 @@ namespace TitaniumWindows
 			virtual bool hasText() TITANIUM_NOEXCEPT override final;
 
 			virtual void enableEvent(const std::string& event_name) TITANIUM_NOEXCEPT override final;
+			virtual void disableEvent(const std::string& event_name) TITANIUM_NOEXCEPT override final;
 
 			virtual bool js_set_width_min(const JSValue& argument) TITANIUM_NOEXCEPT final;
 
@@ -88,10 +89,8 @@ namespace TitaniumWindows
 			Windows::UI::Xaml::Controls::PasswordBox^ password_box__{ nullptr };
 
 			// Event handlers
-			Windows::Foundation::EventRegistrationToken blur_event_;
-			Windows::Foundation::EventRegistrationToken change_event_;
-			Windows::Foundation::EventRegistrationToken focus_event_;
-			Windows::Foundation::EventRegistrationToken return_event_;
+			Windows::Foundation::EventRegistrationToken change_event__;
+			Windows::Foundation::EventRegistrationToken return_event__;
 		};
 	} // namespace UI
 } // namespace TitaniumWindows

--- a/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
@@ -426,12 +426,12 @@ namespace TitaniumWindows
 		protected:
 #pragma warning(push)
 #pragma warning(disable : 4251)
-
 			Windows::UI::Xaml::FrameworkElement^ component__ { nullptr };
 
 			Titanium::LayoutEngine::Node* layout_node__ { nullptr };
 
 			bool postlayout_listening__{ false };
+
 			Windows::Foundation::EventRegistrationToken size_change_event__;
 			Windows::Foundation::EventRegistrationToken loaded_event__;
 			Windows::Foundation::EventRegistrationToken update_background_event__;
@@ -441,15 +441,18 @@ namespace TitaniumWindows
 
 			// Titanium event handlers
 			Windows::Foundation::EventRegistrationToken click_event__;
-			Windows::Foundation::EventRegistrationToken doubleclick_event__;
+			Windows::Foundation::EventRegistrationToken dblclick_event__;
 			Windows::Foundation::EventRegistrationToken blur_event__;
 			Windows::Foundation::EventRegistrationToken focus_event__;
 			Windows::Foundation::EventRegistrationToken touchstart_event__;
 			Windows::Foundation::EventRegistrationToken touchend_event__;
+			Windows::Foundation::EventRegistrationToken touchcancel_event__;
+			Windows::Foundation::EventRegistrationToken touchcancel_lost_event__;
 			Windows::Foundation::EventRegistrationToken touchmove_event__;
 			Windows::Foundation::EventRegistrationToken singletap_event__;
 			Windows::Foundation::EventRegistrationToken doubletap_event__;
 			Windows::Foundation::EventRegistrationToken longpress_event__;
+			Windows::Foundation::EventRegistrationToken keypressed_event__;
 
 			bool is_width_size__{false};
 			bool is_height_size__{false};

--- a/Source/UI/src/Button.cpp
+++ b/Source/UI/src/Button.cpp
@@ -102,5 +102,15 @@ namespace TitaniumWindows
 			}
 			// TODO Windows supports stretch!
 		}
+
+		void Button::enableEvent(const std::string& event_name) TITANIUM_NOEXCEPT
+		{
+			//
+			// Disable some touch events because Xaml Button has a inconsistency on Pointer event handling.
+			//
+			getViewLayoutDelegate<WindowsViewLayoutDelegate>()->filterEvents({ "touchstart", "touchend", "touchcancel" });
+
+			Titanium::UI::Button::enableEvent(event_name);
+		}
 	} // namespace UI
 } // namespace TitaniumWindows

--- a/Source/UI/src/TextField.cpp
+++ b/Source/UI/src/TextField.cpp
@@ -291,6 +291,24 @@ namespace TitaniumWindows
 			return false;
 		}
 
+		void TextField::disableEvent(const std::string& event_name) TITANIUM_NOEXCEPT
+		{
+			Titanium::UI::TextField::disableEvent(event_name);
+			if (event_name == "change") {
+				if (text_box__) {
+					text_box__->TextChanged -= change_event__;
+				} else if (password_box__) {
+					password_box__->PasswordChanged -= change_event__;
+				}
+			} else if (event_name == "return") {
+				if (text_box__) {
+					text_box__->KeyDown -= return_event__;
+				} else if (password_box__) {
+					password_box__->KeyDown -= return_event__;
+				}
+			}
+		}
+
 		void TextField::enableEvent(const std::string& event_name) TITANIUM_NOEXCEPT
 		{
 			Titanium::UI::TextField::enableEvent(event_name);
@@ -299,14 +317,14 @@ namespace TitaniumWindows
 
 			if (event_name == "change") {
 				if (text_box__) {
-					change_event_ = text_box__->TextChanged += ref new Controls::TextChangedEventHandler([this, ctx](Platform::Object^ sender, Controls::TextChangedEventArgs^ e) {
+					change_event__ = text_box__->TextChanged += ref new Controls::TextChangedEventHandler([this, ctx](Platform::Object^ sender, Controls::TextChangedEventArgs^ e) {
 						JSObject eventArgs = ctx.CreateObject();
 						eventArgs.SetProperty("value", ctx.CreateString(this->get_value()));
 
 						this->fireEvent("change", eventArgs);
 					});
 				} else if (password_box__) {
-					change_event_ = password_box__->PasswordChanged += ref new RoutedEventHandler([this, ctx](Platform::Object^ sender, RoutedEventArgs^ e){
+					change_event__ = password_box__->PasswordChanged += ref new RoutedEventHandler([this, ctx](Platform::Object^ sender, RoutedEventArgs^ e){
 						JSObject eventArgs = ctx.CreateObject();
 						eventArgs.SetProperty("value", ctx.CreateString(this->get_value()));
 
@@ -323,9 +341,9 @@ namespace TitaniumWindows
 					}
 				});
 				if (text_box__) {
-					return_event_ = text_box__->KeyDown += keydown;
+					return_event__ = text_box__->KeyDown += keydown;
 				} else if (password_box__) {
-					return_event_ = password_box__->KeyDown += keydown;
+					return_event__ = password_box__->KeyDown += keydown;
 				}
 			}
 		}

--- a/apidoc/whitelist.txt
+++ b/apidoc/whitelist.txt
@@ -4,19 +4,30 @@
 C Titanium.UI.View
 E touchmove
 E touchstart
+E touchcancel
 E touchend
 E click
-E doubleclick
+E dblclick
 E singletap
 E doubletap
 E longpress
 E focus
 E blur
 E postlayout
+E keypressed
 
 C Titanium.UI.Animation
 E complete
 E start
+
+C Titanium.UI.TextField
+E change
+E return
+
+C Titanium.UI.TextArea
+E change
+E return
+E selected
 
 C Titanium.Accelerometer
 E update


### PR DESCRIPTION
Fix for [TIMOB-19953](https://jira.appcelerator.org/browse/TIMOB-19953), [TIMOB-19955](https://jira.appcelerator.org/browse/TIMOB-19955), [TIMOB-19963](https://jira.appcelerator.org/browse/TIMOB-19963) and [TIMOB-20078](https://jira.appcelerator.org/browse/TIMOB-20078)

Some events are not available depending on Windows xaml components. For instance, `touchstart/end` event doesn't work for Button and TextField/Area. Note that `pinch`, `swipe` and `twofingertap` are not implemented yet, because Xaml `GestureRecognizer` doesn't work for most of components unfortunately. In that sense we might want to invent our own gesture recognizer to introduce `swipe/pinch` and touch events with multiple fingers.

## View

| event        | supported  |
| ------------- |:-------------:|
| blur      | :x: |
| click      | :o: |
| dblclick      | :o: |
| doubletap      | :o: |
| focus      | :x:  |
| longclick      | :o: |
| longpress      | :o: |
| pinch     | :x: |
| swipe    | :x: |
| singletap    | :o: |
| touchstart     | :o: |
| touchmove    | :o: |
| touchend      | :o: |
| touchcancel  | :o: |
| keypressed   | :x: |
| twofingertap   | :x: |

## Label

| event        | supported  |
| ------------- |:-------------:|
| blur      | :x: |
| click      | :o: |
| dblclick      | :o: |
| doubletap      | :o: |
| focus      | :x:  |
| longclick      | :o: |
| longpress      | :o: |
| pinch     | :x: |
| swipe    | :x: |
| singletap    | :o: |
| touchstart     | :o: |
| touchmove     | :o: |
| touchend      | :o: |
| touchcancel  | :o: |
| keypressed   | :o: |
| twofingertap   | :x: |

## Button

| event        | supported  |
| ------------- |:-------------:|
| blur      | :o: |
| click      | :o: |
| dblclick      | :o: |
| doubletap      | :o: |
| focus      | :o:  |
| longclick      | :o: |
| longpress      | :o: |
| pinch     | :x: |
| swipe    | :x: |
| singletap    | :o: |
| touchstart     | :x: |
| touchmove     | :o: |
| touchend      | :x: |
| touchcancel  | :x: |
| keypressed   | :x: |
| twofingertap   | :x: |

## TextField

| event        | supported  |
| ------------- |:-------------:|
| blur      | :o: |
| click      | :o: |
| change      | :o: |
| dblclick      | :o: |
| doubletap      | :o: |
| focus      | :o:  |
| longclick      | :o: |
| longpress      | :o: |
| pinch     | :x: |
| return     | :o: |
| swipe    | :x: |
| singletap    | :o: |
| touchstart     | :x: |
| touchmove     | :o: |
| touchend      | :x: |
| touchcancel  | :x: |
| keypressed   | :o: |
| twofingertap   | :x: |


## TextArea

| event        | supported  |
| ------------- |:-------------:|
| blur      | :o: |
| click      | :o: |
| change      | :o: |
| dblclick      | :o: |
| doubletap      | :o: |
| focus      | :o:  |
| longclick      | :o: |
| longpress      | :o: |
| pinch     | :x: |
| return     | :o: |
| selected    | :o: |
| swipe    | :x: |
| singletap    | :o: |
| touchstart     | :x: |
| touchmove     | :o: |
| touchend      | :x: |
| touchcancel  | :x: |
| keypressed   | :o: |
| twofingertap   | :x: |


