### PR TITLE
[TIMOB-19927] Implement Titanium.Blob width and height

### DIFF
--- a/Examples/NMocha/src/Assets/ti.blob.test.js
+++ b/Examples/NMocha/src/Assets/ti.blob.test.js
@@ -79,15 +79,15 @@ describe("Titanium.Blob", function () {
         finish();
     });
     it("width", function (finish) {
-        var blob = Ti.Filesystem.getFile('app.js').read();
+        var blob = Ti.Filesystem.getFile('Logo.png').read();
         should(blob.width).be.a.Number;
-        should(blob.width).be.eql(0);
+        should(blob.width).be.eql(150);
         finish();
     });
     it("height", function (finish) {
-        var blob = Ti.Filesystem.getFile('app.js').read();
+        var blob = Ti.Filesystem.getFile('Logo.png').read();
         should(blob.height).be.a.Number;
-        should(blob.height).be.eql(0);
+        should(blob.height).be.eql(150);
         finish();
     });
     it("file", function (finish) {

--- a/Source/Titanium/include/TitaniumWindows/Blob.hpp
+++ b/Source/Titanium/include/TitaniumWindows/Blob.hpp
@@ -23,9 +23,6 @@ namespace TitaniumWindows
 	class TITANIUMWINDOWS_EXPORT Blob final : public Titanium::Blob, public JSExport<Blob>
 	{
 	public:
-		TITANIUM_PROPERTY_UNIMPLEMENTED(width);
-		TITANIUM_PROPERTY_UNIMPLEMENTED(height);
-
 		::Platform::Guid getImageEncoder();
 
 		void construct(Windows::Storage::StorageFile^ file);


### PR DESCRIPTION
- Implemented ```Titanium.Blob.width``` and ```Titanium.Blob.height``` functionality
- Updated NMocha ```ti.blob.test.js``` to test ```width``` and ```height``` of ```Logo.png```

###### TEST CASE
```Javascript
var blob = Ti.Filesystem.getFile('Logo.png').read();
Ti.API.info('Blob->width: ' + blob.width);
Ti.API.info('Blob->height: ' + blob.height);
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-19927)