### PR TITLE
[TIMOB-20035] Implement Ti.Media.AudioPlayer.allowBackground

### DIFF
--- a/Source/Media/CMakeLists.txt
+++ b/Source/Media/CMakeLists.txt
@@ -52,6 +52,7 @@ endif()
 
 set(SOURCE_Media
   include/TitaniumWindows/Media.hpp
+  include/TitaniumWindows/Media/AudioBackground.hpp
   include/TitaniumWindows/Media/AudioPlayer.hpp
   include/TitaniumWindows/Media/AudioRecorder.hpp
   include/TitaniumWindows/Media/Item.hpp
@@ -59,6 +60,7 @@ set(SOURCE_Media
   include/TitaniumWindows/Media/MusicPlayer.hpp
   include/TitaniumWindows/Media/VideoPlayer.hpp
   src/Media.cpp
+  src/Media/AudioBackground.cpp
   src/Media/AudioPlayer.cpp
   src/Media/AudioRecorder.cpp
   src/Media/Item.cpp

--- a/Source/Media/include/TitaniumWindows/Media/AudioBackground.hpp
+++ b/Source/Media/include/TitaniumWindows/Media/AudioBackground.hpp
@@ -1,0 +1,21 @@
+/**
+* Copyright (c) 2015 by Appcelerator, Inc. All Rights Reserved.
+* Licensed under the terms of the Apache Public License.
+* Please see the LICENSE included with this distribution for details.
+*/
+
+#ifndef _TITANIUMWINDOWS_MEDIA_AUDIOBACKGROUND_HPP_
+#define _TITANIUMWINDOWS_MEDIA_AUDIOBACKGROUND_HPP_
+
+namespace TitaniumWindows_Media
+{
+	using namespace Windows::ApplicationModel::Background;
+
+	[Windows::Foundation::Metadata::WebHostHidden]
+	public ref class AudioBackground sealed : IBackgroundTask
+	{
+	public:
+		virtual void Run(IBackgroundTaskInstance^ taskInstance);
+	};
+}
+#endif

--- a/Source/Media/include/TitaniumWindows/Media/AudioPlayer.hpp
+++ b/Source/Media/include/TitaniumWindows/Media/AudioPlayer.hpp
@@ -28,17 +28,19 @@ namespace TitaniumWindows
 
 			TITANIUM_FUNCTION_UNIMPLEMENTED(stateDescription);
 			TITANIUM_FUNCTION_UNIMPLEMENTED(release);
-			TITANIUM_PROPERTY_UNIMPLEMENTED(allowBackground);
 
 			virtual void set_paused(const bool& paused) TITANIUM_NOEXCEPT override;
 			virtual void set_url(const std::string& url) TITANIUM_NOEXCEPT override;
 			virtual void set_volume(const double& volume) TITANIUM_NOEXCEPT override;
+			virtual void set_allowBackground(const bool& allowBackground) TITANIUM_NOEXCEPT override;
 			virtual std::chrono::milliseconds get_time() const TITANIUM_NOEXCEPT override;
 
 			virtual void pause() TITANIUM_NOEXCEPT override;
 			virtual void play() TITANIUM_NOEXCEPT override;
 			virtual void start() TITANIUM_NOEXCEPT override;
 			virtual void stop() TITANIUM_NOEXCEPT override;
+
+			virtual void stateChanged() TITANIUM_NOEXCEPT;
 
 			AudioPlayer(const JSContext&) TITANIUM_NOEXCEPT;
 
@@ -57,9 +59,15 @@ namespace TitaniumWindows
 			virtual void disableEvent(const std::string& event_name) TITANIUM_NOEXCEPT override final;
 
 		protected:
-			Windows::UI::Xaml::Controls::MediaElement ^ player__;
+			Windows::Media::SystemMediaTransportControls^ controls__;
+			Windows::UI::Xaml::Controls::MediaElement^ player__;
+#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+			Windows::Media::Playback::MediaPlayer^ background_player__;
+#endif
 			Windows::Foundation::EventRegistrationToken complete_event__;
 			Windows::Foundation::EventRegistrationToken failed_event__;
+			Windows::Foundation::EventRegistrationToken background_complete_event__;
+			Windows::Foundation::EventRegistrationToken background_failed_event__;
 			Windows::Foundation::EventRegistrationToken navigated_event__;
 		};
 

--- a/Source/Media/src/Media/AudioBackground.cpp
+++ b/Source/Media/src/Media/AudioBackground.cpp
@@ -1,0 +1,23 @@
+/**
+* Copyright (c) 2015 by Appcelerator, Inc. All Rights Reserved.
+* Licensed under the terms of the Apache Public License.
+* Please see the LICENSE included with this distribution for details.
+*/
+
+#include "TitaniumWindows/Media/AudioBackground.hpp"
+
+// Entry point: TitaniumWindows_Media.AudioBackground
+
+namespace TitaniumWindows_Media
+{
+	using namespace Windows::ApplicationModel::Background;
+
+	void AudioBackground::Run(IBackgroundTaskInstance^ taskInstance)
+	{
+		taskInstance->Canceled += ref new BackgroundTaskCanceledEventHandler(
+			[=](IBackgroundTaskInstance^ sender, BackgroundTaskCancellationReason reason) {
+				taskInstance->GetDeferral()->Complete();
+			}
+		);
+	}
+}

--- a/cli/commands/_build/generate.js
+++ b/cli/commands/_build/generate.js
@@ -273,6 +273,7 @@ function generateAppxManifestForPlatform(target, properties) {
 	properties.Capabilities = properties.Capabilities || ['<Capability Name=\"internetClient\" />'];
 	properties.Prerequisites = properties.Prerequisites || [];
 	properties.Resources = properties.Resources || [];
+	properties.Extensions = properties.Extensions || [];
 
 	this.logger.info(__('Writing appxmanifest %s', dest));
 	fs.writeFileSync(dest, ejs.render(template, {

--- a/templates/build/Package.phone.appxmanifest.in.ejs
+++ b/templates/build/Package.phone.appxmanifest.in.ejs
@@ -54,6 +54,15 @@
         </m3:DefaultTile>
         <m3:SplashScreen BackgroundColor="#b41100" Image="SplashScreen480x800.png" />
       </m3:VisualElements>
+
+<% if (manifest.Extensions.length > 0) { -%>
+      <Extensions>
+<% for(var i = 0; i < manifest.Extensions.length; i++) { -%>
+      <%- manifest.Extensions[i] %>
+<% } -%>
+      </Extensions>
+<% } -%>
+
     </Application>
   </Applications>
   

--- a/templates/build/Package.store.appxmanifest.in.ejs
+++ b/templates/build/Package.store.appxmanifest.in.ejs
@@ -50,6 +50,15 @@
         </m2:DefaultTile>
         <m2:SplashScreen BackgroundColor="#b41100" Image="SplashScreen.png" />
       </m2:VisualElements>
+
+<% if (manifest.Extensions.length > 0) { -%>
+      <Extensions>
+<% for(var i = 0; i < manifest.Extensions.length; i++) { -%>
+      <%- manifest.Extensions[i] %>
+<% } -%>
+      </Extensions>
+<% } -%>
+
     </Application>
   </Applications>
   

--- a/templates/build/Package.win10.appxmanifest.in.ejs
+++ b/templates/build/Package.win10.appxmanifest.in.ejs
@@ -46,6 +46,15 @@
         <uap:DefaultTile Square71x71Logo="Square71x71Logo.png"/>
         <uap:SplashScreen Image="SplashScreen.png" />
       </uap:VisualElements>
+
+<% if (manifest.Extensions.length > 0) { -%>
+      <Extensions>
+<% for(var i = 0; i < manifest.Extensions.length; i++) { -%>
+      <%- manifest.Extensions[i] %>
+<% } -%>
+      </Extensions>
+<% } -%>
+
     </Application>
   </Applications>
 


### PR DESCRIPTION
- Implemented ```Titanium.Media.AudioPlayer.allowBackground``` functionality
- Added ```AudioBackground``` background task to ```TitaniumWindows_Media```
- Fixed ```CurrentStateChanged``` switch statement
- Added ```Extentions``` support into ```tiapp.xml``` to enable the audio background task

##### IMPORTANT NOTE
- Both Windows Phone and Windows Store apps require an ```Audio``` _BackgroundTask_ extension in the ```Package.appxmanifest```
- Background audio plays from a separate media player [BackgroundMediaPlayer](https://msdn.microsoft.com/en-us/library/windows/apps/windows.media.playback.backgroundmediaplayer.current.aspx) which means we need to switch between media players when setting the ```allowBackground``` property

###### tiapp.xml Background Audio Extention
```XML
<windows>
  <manifest>
    <Extentions>
      <Extension Category="windows.backgroundTasks" EntryPoint="TitaniumWindows_Media.AudioBackground">
        <BackgroundTasks>
          <Task Type="audio" />
        </BackgroundTasks>
      </Extension>
    </Extentions>
  </manifest>
</windows>
```

###### TEST CASE
```Javascript
var audioPlayer = Ti.Media.createAudioPlayer({url: 'http://media-the.musicradio.com:80/SmoothExtraMP3'}),
    win = Titanium.UI.createWindow({backgroundColor: 'red'}),
    play_btn = Titanium.UI.createButton({title: 'play/pause', top: '33%'}),
    background_btn = Titanium.UI.createButton({title: 'allowBackground: false', top: '66%'});

play_btn.addEventListener('click', function() {
    audioPlayer.isPlaying() ? audioPlayer.stop() : audioPlayer.start();
});
background_btn.addEventListener('click', function() {
    audioPlayer.setAllowBackground(!audioPlayer.allowBackground);
    background_btn.setTitle('allowBackground: ' + audioPlayer.allowBackground);
});

win.add(play_btn);
win.add(background_btn);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-20035)