### PR TITLE
[5_1_X] Fix MSBuild warnings

### DIFF
--- a/Source/UI/src/TextField.cpp
+++ b/Source/UI/src/TextField.cpp
@@ -235,6 +235,7 @@ namespace TitaniumWindows
 			} else if (password_box__) {
 				return TitaniumWindows::Utility::ConvertUTF8String(password_box__->Password);
 			}
+			return "";
 		}
 
 		void TextField::set_value(const std::string& value) TITANIUM_NOEXCEPT


### PR DESCRIPTION
- Cherry-pick of [7cbf311](https://github.com/appcelerator/titanium_mobile_windows/commit/7cbf31170706675d43a9d33cc0fd3feb086605ae)