### PR TITLE
Implement ImageView properties

### DIFF
--- a/Source/TitaniumKit/include/Titanium/UI/ImageView.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/ImageView.hpp
@@ -88,11 +88,13 @@ namespace Titanium
 
 			  @abstract toBlob() : Titanium.Blob
 
+			  @param callback <optional> Function to be invoked upon completion. If non-null, this method will be performed asynchronously. If null, it will be performed immediately.
+
 			  @discussion Returns the image as a Blob object.
 
 			  @result Titanium.Blob
 			*/
-			virtual std::shared_ptr<Titanium::Blob> toBlob() TITANIUM_NOEXCEPT;
+			virtual std::shared_ptr<Titanium::Blob> toBlob(JSValue callback) TITANIUM_NOEXCEPT;
 
 			/*!
 			  @method

--- a/Source/TitaniumKit/src/UI/ImageView.cpp
+++ b/Source/TitaniumKit/src/UI/ImageView.cpp
@@ -50,12 +50,11 @@ namespace Titanium
 			TITANIUM_LOG_DEBUG("ImageView::resume unimplemented");
 		}
 
-		std::shared_ptr<Titanium::Blob> ImageView::toBlob() TITANIUM_NOEXCEPT
+		std::shared_ptr<Titanium::Blob> ImageView::toBlob(JSValue callback) TITANIUM_NOEXCEPT
 		{
 			TITANIUM_LOG_DEBUG("ImageView::toBlob unimplemented");
 			return nullptr;
 		}
-
 
 		TITANIUM_PROPERTY_READ(ImageView, bool, animating)
 		TITANIUM_PROPERTY_READWRITE(ImageView, bool, autorotate)
@@ -166,12 +165,14 @@ namespace Titanium
 
 		TITANIUM_FUNCTION(ImageView, toBlob)
 		{
-			TITANIUM_ASSERT(arguments.empty());
-			auto blob = toBlob();
-			if (blob == nullptr) {
+			ENSURE_OPTIONAL_OBJECT_AT_INDEX(callback, 0);
+			const auto image = toBlob(callback);
+			if (image) {
+				return image->get_object();
+			}
+			else {
 				return get_context().CreateNull();
 			}
-			return blob->get_object();
 		}
 
 		TITANIUM_PROPERTY_GETTER(ImageView, animating)

--- a/Source/UI/include/TitaniumWindows/UI/ImageView.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/ImageView.hpp
@@ -42,10 +42,8 @@ namespace TitaniumWindows
 		{
 		public:
 
-			TITANIUM_FUNCTION_UNIMPLEMENTED(toBlob);
 			TITANIUM_PROPERTY_UNIMPLEMENTED(autorotate);
 			TITANIUM_PROPERTY_UNIMPLEMENTED(decodeRetries);
-			TITANIUM_PROPERTY_UNIMPLEMENTED(defaultImage);
 			TITANIUM_PROPERTY_UNIMPLEMENTED(enableZoomControls);
 			TITANIUM_PROPERTY_UNIMPLEMENTED(hires);
 			TITANIUM_PROPERTY_UNIMPLEMENTED(preventDefaultImage);
@@ -69,15 +67,24 @@ namespace TitaniumWindows
 			virtual void resume() TITANIUM_NOEXCEPT override final;
 			virtual void start() TITANIUM_NOEXCEPT override final;
 			virtual void stop() TITANIUM_NOEXCEPT override final;
+			virtual std::shared_ptr<Titanium::Blob> toBlob(JSValue callback) TITANIUM_NOEXCEPT override final;
+			virtual std::shared_ptr<Titanium::Blob> toImage(JSValue callback, const bool& honorScaleFactor) TITANIUM_NOEXCEPT override;
 
 			// properties
 			virtual void set_image(const std::string& image) TITANIUM_NOEXCEPT override final;
 			virtual void set_images(const std::vector<std::string>& images) TITANIUM_NOEXCEPT override final;
+			virtual void set_defaultImage(const std::string&) TITANIUM_NOEXCEPT override final;
 
 		private:
-			Windows::Foundation::EventRegistrationToken internal_load_event_;
+
+			void loadContentFromData(std::vector<std::uint8_t>& data);
+
+			Windows::Foundation::EventRegistrationToken layout_event__;
+			Windows::Foundation::EventRegistrationToken loaded_event__;
 			Windows::UI::Xaml::Controls::Image^ image__;
 			Windows::UI::Xaml::Media::Animation::Storyboard^ storyboard__;
+			bool loaded__;
+			bool loaded_event_set__;
 		};
 	} // namespace UI
 } // namespace TitaniumWindow

--- a/Source/UI/include/TitaniumWindows/UI/View.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/View.hpp
@@ -55,7 +55,6 @@ namespace TitaniumWindows
 			TITANIUM_PROPERTY_UNIMPLEMENTED(viewShadowOffset);
 			TITANIUM_PROPERTY_UNIMPLEMENTED(horizontalWrap);
 			TITANIUM_PROPERTY_UNIMPLEMENTED(keepScreenOn);
-			TITANIUM_FUNCTION_UNIMPLEMENTED(toImage);
 			TITANIUM_FUNCTION_UNIMPLEMENTED(convertPointToView);
 
 			// Implemented, works with some components which uses Xaml.Controls.Control
@@ -74,8 +73,11 @@ namespace TitaniumWindows
 
 			static void JSExportInitialize();
 			static Windows::UI::Xaml::Media::FontFamily^ LookupFont(const JSContext& js_context, const std::string& family);
+			static void ToImage(Windows::UI::Xaml::FrameworkElement^, JSValue, JSObject);
 
 			virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;
+			virtual std::shared_ptr<Titanium::Blob> toImage(JSValue callback, const bool& honorScaleFactor) TITANIUM_NOEXCEPT override;
+
 			virtual void registerNativeUIWrapHook(const std::function<JSObject(const JSContext&, const JSObject&)>& requireCallback);
 			virtual Windows::UI::Xaml::FrameworkElement^ getComponent() TITANIUM_NOEXCEPT;
 

--- a/Source/UI/src/ImageView.cpp
+++ b/Source/UI/src/ImageView.cpp
@@ -9,7 +9,8 @@
 #include "TitaniumWindows/UI/ImageView.hpp"
 #include "TitaniumWindows/Utility.hpp"
 #include "LayoutEngine/LayoutEngine.hpp"
-
+#include "TitaniumWindows/UI/View.hpp"
+#include "Titanium/Blob.hpp"
 #include <ppltasks.h>
 
 namespace TitaniumWindows
@@ -18,6 +19,9 @@ namespace TitaniumWindows
 	{
 		using namespace Windows::UI::Xaml;
 		using namespace Windows::UI::Xaml::Controls;
+		using namespace Windows::UI::Xaml::Media::Imaging;
+		using namespace Windows::Storage;
+		using namespace Windows::Storage::Streams;
 
 		WindowsImageViewLayoutDelegate::WindowsImageViewLayoutDelegate() TITANIUM_NOEXCEPT
 			: WindowsViewLayoutDelegate()
@@ -56,19 +60,18 @@ namespace TitaniumWindows
 
 		ImageView::ImageView(const JSContext& js_context) TITANIUM_NOEXCEPT
 			  : Titanium::UI::ImageView(js_context)
+			  , loaded__(false)
+			  , loaded_event_set__(false)
 		{
 		}
 
 		void ImageView::postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments)
 		{
-			using namespace Windows::UI::Xaml;
-			using namespace Windows::UI::Xaml::Controls;
-
 			Titanium::UI::ImageView::postCallAsConstructor(js_context, arguments);	
 
 			image__ = ref new Windows::UI::Xaml::Controls::Image();
 
-			internal_load_event_ = image__->ImageOpened += ref new RoutedEventHandler([this](::Platform::Object^ sender, RoutedEventArgs^ e) {
+			layout_event__ = image__->ImageOpened += ref new RoutedEventHandler([this](::Platform::Object^ sender, RoutedEventArgs^ e) {
 				const auto layout = getViewLayoutDelegate<WindowsImageViewLayoutDelegate>();
 				auto rect = layout->computeRelativeSize(
 					Canvas::GetLeft(this->image__),
@@ -77,8 +80,6 @@ namespace TitaniumWindows
 					this->image__->ActualHeight
 				);
 				layout->onComponentSizeChange(rect);
-
-				this->fireEvent("load", this->get_context().CreateObject());
 			});
 
 			Titanium::UI::ImageView::setLayoutDelegate<WindowsImageViewLayoutDelegate>();
@@ -125,7 +126,7 @@ namespace TitaniumWindows
 				Windows::Foundation::TimeSpan key_time;
 				key_time.Duration = timer_interval_ticks.count() * i;
 				keyFrame->KeyTime = key_time;
-				keyFrame->Value = ref new Windows::UI::Xaml::Media::Imaging::BitmapImage(uri);
+				keyFrame->Value = ref new BitmapImage(uri);
 				animation->KeyFrames->Append(keyFrame);
 			}
 			storyboard__->Children->Append(animation);
@@ -178,12 +179,57 @@ namespace TitaniumWindows
 			}
 		}
 
+		void ImageView::loadContentFromData(std::vector<std::uint8_t>& data)
+		{
+			const auto stream = ref new InMemoryRandomAccessStream();
+			const auto writer = ref new DataWriter(stream);
+
+			writer->WriteBytes(Platform::ArrayReference<std::uint8_t>(&data[0], data.size()));
+
+			concurrency::create_task(writer->StoreAsync()).then([this, stream, writer](std::uint32_t) {
+				auto bitmap = ref new BitmapImage();
+				writer->DetachStream();
+				stream->Seek(0);
+				bitmap->SetSourceAsync(stream);
+				this->image__->Source = bitmap;
+			});
+		}
+
 		void ImageView::set_image(const std::string& path) TITANIUM_NOEXCEPT
 		{
 			Titanium::UI::ImageView::set_image(path);
-			auto uri = TitaniumWindows::Utility::GetUriFromPath(path);
-			auto image = ref new Windows::UI::Xaml::Media::Imaging::BitmapImage(uri);
-			image__->Source = image;
+
+			// lazy load image event so it doesn't fire load event for defaultImage
+			if (!loaded_event_set__) {
+				loaded_event__ = image__->ImageOpened += ref new RoutedEventHandler([this](::Platform::Object^ sender, RoutedEventArgs^ e) {
+					loaded__ = true;
+					this->fireEvent("load", this->get_context().CreateObject());
+				});
+				loaded_event_set__ = true;
+			}
+
+			const auto uri = TitaniumWindows::Utility::GetUriFromPath(path);
+			// check if we're loading from local file
+			if (uri->SchemeName == "ms-appx") {
+				concurrency::create_task(StorageFile::GetFileFromApplicationUriAsync(uri)).then([this](concurrency::task<StorageFile^> task){
+					try {
+						auto file = task.get();
+						loadContentFromData(TitaniumWindows::Utility::GetContentFromFile(file));
+					} catch (Platform::COMException^ ex) {
+						TITANIUM_LOG_WARN("ImageView.image: ", TitaniumWindows::Utility::ConvertString(ex->Message));
+					}
+				}, concurrency::task_continuation_context::use_current());
+			} else {
+				Windows::Web::Http::HttpClient^ httpClient = ref new Windows::Web::Http::HttpClient();
+				concurrency::create_task(httpClient->GetBufferAsync(uri)).then([this](concurrency::task<IBuffer^> task){
+					try {
+						auto buffer = task.get();
+						loadContentFromData(TitaniumWindows::Utility::GetContentFromBuffer(buffer));
+					} catch (Platform::COMException^ ex) {
+						TITANIUM_LOG_WARN("ImageView.image: ", TitaniumWindows::Utility::ConvertString(ex->Message));
+					}
+				}, concurrency::task_continuation_context::use_current());
+			}
 		}
 
 		void ImageView::set_images(const std::vector<std::string>& images) TITANIUM_NOEXCEPT
@@ -193,5 +239,31 @@ namespace TitaniumWindows
 			set_image(images.at(0));
 		}
 
+		void ImageView::set_defaultImage(const std::string& path) TITANIUM_NOEXCEPT
+		{
+			Titanium::UI::ImageView::set_defaultImage(path);
+
+			// do nothing when image is already loaded
+			// otherwise start loading defaultImage
+			if (!loaded__) {
+				image__->Source = ref new BitmapImage(TitaniumWindows::Utility::GetUriFromPath(path));
+			}
+		}
+
+		std::shared_ptr<Titanium::Blob> ImageView::toBlob(JSValue callback) TITANIUM_NOEXCEPT
+		{
+			return this->toImage(callback, false);
+		}
+
+		std::shared_ptr<Titanium::Blob> ImageView::toImage(JSValue callback, const bool& honorScaleFactor) TITANIUM_NOEXCEPT
+		{
+			if (callback.IsObject() && static_cast<JSObject>(callback).IsFunction()) {
+				TitaniumWindows::UI::View::ToImage(image__, callback, get_object());
+			} else {
+				HAL::detail::ThrowRuntimeError("ImageView.toImage", "ImageView.toImage only works with callback");
+			}
+
+			return nullptr;
+		}
 	} // namespace UI
 } // namespace TitaniumWindows

--- a/Source/Utility/src/Utility.cpp
+++ b/Source/Utility/src/Utility.cpp
@@ -92,6 +92,9 @@ namespace TitaniumWindows
 
 		std::vector<std::uint8_t> GetContentFromBuffer(Windows::Storage::Streams::IBuffer^ buffer) 
 		{
+			if (buffer == nullptr) {
+				return std::vector<std::uint8_t>();
+			}
 			const auto reader = Windows::Storage::Streams::DataReader::FromBuffer(buffer);
 			std::vector<std::uint8_t> data(reader->UnconsumedBufferLength);
 			if (!data.empty()) {


### PR DESCRIPTION
Fix for [TIMOB-19954](https://jira.appcelerator.org/browse/TIMOB-19954)

- Implement `ImageView.defaultImage`, which enables to place placeholder image while waiting `image` loaded. especially useful when you need to grab `image` from network. 
- Implement `ImageView.toBlob` (but it does not work)
- Implement `View.toImage` (but it does not work)

Currently `toBlob` and `toImage` is always returning empty data. The problem is that they are using `Windows::UI::Xaml::Media::Imaging::RenderTargetBitmap::RenderAsync` to capture images from the component, but it always return `nullptr` when you call  `GetPixelsAsync`. I'm not sure if this API is actually implemented or working.

```javascript
var win = Ti.UI.createWindow({background:'black'});

var view = Ti.UI.createImageView({
    defaultImage: 'Logo.png', /* placeholder until image is loaded */
    image: 'http://api.randomuser.me/portraits/women/2.jpg'
});
win.add(view);

view.addEventListener('load', function () {
    Ti.API.info('image loaded');
});
var button = Ti.UI.createButton({ title: 'toBlob', top: 0, left: 0 });
button.addEventListener('click', function () {
    view.toImage(function () {
        Ti.API.info('toImage callback?');
    });
});
win.add(button);
win.open();
```