### PR TITLE
Fix: Ti.Codec.encodeNumber hangs on Windows 10

### DIFF
--- a/Examples/NMocha/src/Assets/ti.buffer.test.js
+++ b/Examples/NMocha/src/Assets/ti.buffer.test.js
@@ -352,8 +352,7 @@ describe("buffer", function() {
 	    finish();
 	});
 
-	// Skip on Windows 10 for now, it hangs
-	(Ti.Platform.version.indexOf('10.0' == 0) ? it.skip : it)("testAutoEncodeUTF-16", function (finish) {
+	it("testAutoEncodeUTF-16", function (finish) {
 	    // 8 Byte long in Big Endian (most significant byte first)
 	    var buffer = Ti.createBuffer({
 	        value: 305419896,
@@ -370,8 +369,7 @@ describe("buffer", function() {
 	    finish();
 	});
 
-    // Skip on Windows 10 for now, it hangs
-	(Ti.Platform.version.indexOf('10.0' == 0) ? it.skip : it)("testAutoEncodeUTF-16", function (finish) {
+	it("testAutoEncodeUTF-16", function (finish) {
 		// 4 byte int in Little Endian (least significant byte first)
 		var buffer = Ti.createBuffer({
 			value: 305419896,

--- a/Examples/NMocha/src/Assets/ti.codec.test.js
+++ b/Examples/NMocha/src/Assets/ti.codec.test.js
@@ -30,8 +30,7 @@ describe("codec", function() {
 		should([ Ti.Codec.BIG_ENDIAN, Ti.Codec.LITTLE_ENDIAN ]).containEql(Ti.Codec.getNativeByteOrder());
 		finish();
 	});
-    // Skip on Windows 10 for now, it hangs
-	(Ti.Platform.version.indexOf('10.0' == 0) ? it.skip : it)("testEncodeIntegers", function (finish) {
+	it("testEncodeIntegers", function (finish) {
 		var buffer = Ti.createBuffer({
 			length: 8
 		});
@@ -136,8 +135,7 @@ describe("codec", function() {
 		should(n).eql(30874);
 		finish();
 	});
-    // Skip on Windows 10 for now, it hangs
-	(Ti.Platform.version.indexOf('10.0' == 0) ? it.skip : it)("testEncodeFloatingPoint", function (finish) {
+	it("testEncodeFloatingPoint", function (finish) {
 		var buffer = Ti.createBuffer({
 			length: 8
 		});


### PR DESCRIPTION
Fix for [TIMOB-20155](https://jira.appcelerator.org/browse/TIMOB-20155)

I'm not very sure what's happening there, but use of ` task_continuation_context::use_arbitrary()` for async function fixed the issue. Seems like something has been changing regarding threading as of Window 10.

```javascript
var buffer = Ti.createBuffer({
    length: 8
});
Ti.Codec.encodeNumber({
    source: 78187493530,
    dest: buffer,
    type: Ti.Codec.TYPE_LONG
});
```

