### PR TITLE
Add platform-specific (store or phone only) guard macros

### DIFF
--- a/Examples/NMocha/src/Assets/ti.platform.test.js
+++ b/Examples/NMocha/src/Assets/ti.platform.test.js
@@ -69,7 +69,8 @@ describe("Titanium.Platform", function () {
     });
     it("batteryMonitoring", function (finish) {
         should(Ti.Platform.batteryMonitoring).be.Boolean;
-        if (Ti.Platform.osname == 'windowsphone') {
+        // Note: Windows 10 Mobile doesn't support battery monitoring
+        if (Ti.Platform.osname == 'windowsphone' && Ti.Platform.version != '10.0') {
             should(Ti.Platform.batteryMonitoring).be.eql(true);
         } else if (Ti.Platform.osname == 'windowsstore') {
             should(Ti.Platform.batteryMonitoring).be.eql(false);

--- a/Source/Filesystem/src/Filesystem.cpp
+++ b/Source/Filesystem/src/Filesystem.cpp
@@ -6,8 +6,9 @@
 
 #include "TitaniumWindows/Filesystem.hpp"
 #include "Titanium/Filesystem/FileStream.hpp"
-#include "TitaniumWindows/Utility.hpp"
 #include "Titanium/detail/TiImpl.hpp"
+#include "TitaniumWindows/Utility.hpp"
+#include "TitaniumWindows/WindowsMacros.hpp"
 #include <iostream>
 #include <objbase.h>
 
@@ -43,13 +44,13 @@ namespace TitaniumWindows
 
 	std::string FilesystemModule::applicationCacheDirectory() const TITANIUM_NOEXCEPT
 	{
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
-		const auto value = Windows::Storage::ApplicationData::Current->LocalCacheFolder->Path;
-		return TitaniumWindows::Utility::ConvertString(value) + separator(); // FIXME Only append separator if not already there!
-#else
-		TITANIUM_LOG_WARN("Filesystem.applicationCacheDirectory is not supported on Windows Store.");
-		return "";
-#endif
+		if (TitaniumWindows::Utility::IsWindowsPhoneOrMobile()) {
+			const auto value = Windows::Storage::ApplicationData::Current->LocalCacheFolder->Path;
+			return TitaniumWindows::Utility::ConvertString(value) + separator(); // FIXME Only append separator if not already there!
+		} else {
+			TITANIUM_LOG_WARN("Filesystem.applicationCacheDirectory is not supported on Windows Store.");
+			return "";
+		}
 	}
 
 	std::string FilesystemModule::applicationDataDirectory() const TITANIUM_NOEXCEPT

--- a/Source/Filesystem/src/Filesystem.cpp
+++ b/Source/Filesystem/src/Filesystem.cpp
@@ -44,13 +44,14 @@ namespace TitaniumWindows
 
 	std::string FilesystemModule::applicationCacheDirectory() const TITANIUM_NOEXCEPT
 	{
-		if (TitaniumWindows::Utility::IsWindowsPhoneOrMobile()) {
-			const auto value = Windows::Storage::ApplicationData::Current->LocalCacheFolder->Path;
-			return TitaniumWindows::Utility::ConvertString(value) + separator(); // FIXME Only append separator if not already there!
-		} else {
-			TITANIUM_LOG_WARN("Filesystem.applicationCacheDirectory is not supported on Windows Store.");
-			return "";
-		}
+		// Windows 10 and Windows 8.1 phone support LocalCacheFolder
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
+		const auto value = Windows::Storage::ApplicationData::Current->LocalCacheFolder->Path;
+		return TitaniumWindows::Utility::ConvertString(value) + separator(); // FIXME Only append separator if not already there!
+#else
+		TITANIUM_LOG_WARN("Filesystem.applicationCacheDirectory is not supported on Windows Store.");
+		return "";
+#endif
 	}
 
 	std::string FilesystemModule::applicationDataDirectory() const TITANIUM_NOEXCEPT

--- a/Source/Map/include/TitaniumWindows/Map/Annotation.hpp
+++ b/Source/Map/include/TitaniumWindows/Map/Annotation.hpp
@@ -47,7 +47,7 @@ namespace TitaniumWindows
 
 			static void JSExportInitialize();
 
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			Windows::UI::Xaml::Controls::Grid^ GetMapIcon() {
 				return mapicon__;
 			}
@@ -56,7 +56,7 @@ namespace TitaniumWindows
 
 		private:
 
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			Windows::UI::Xaml::Controls::Grid^ mapicon__ = { nullptr };
 
 			Windows::UI::Xaml::Shapes::Line^ pin__ = { nullptr };

--- a/Source/Map/include/TitaniumWindows/Map/Annotation.hpp
+++ b/Source/Map/include/TitaniumWindows/Map/Annotation.hpp
@@ -11,6 +11,8 @@
 
 #include "TitaniumWindows_Map_EXPORT.h"
 #include "Titanium/Map/Annotation.hpp"
+#include "Titanium/detail/TiBase.hpp"
+#include "TitaniumWindows/WindowsMacros.hpp"
 
 namespace TitaniumWindows
 {
@@ -45,7 +47,7 @@ namespace TitaniumWindows
 
 			static void JSExportInitialize();
 
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			Windows::UI::Xaml::Controls::Grid^ GetMapIcon() {
 				return mapicon__;
 			}
@@ -54,7 +56,7 @@ namespace TitaniumWindows
 
 		private:
 
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			Windows::UI::Xaml::Controls::Grid^ mapicon__ = { nullptr };
 
 			Windows::UI::Xaml::Shapes::Line^ pin__ = { nullptr };

--- a/Source/Map/include/TitaniumWindows/Map/View.hpp
+++ b/Source/Map/include/TitaniumWindows/Map/View.hpp
@@ -14,11 +14,6 @@
 #include "Titanium/detail/TiBase.hpp"
 #include "TitaniumWindows/WindowsMacros.hpp"
 
-#if defined(IS_WINDOWS_PHONE)
-using namespace Windows::UI::Xaml::Controls::Maps;
-using namespace Windows::Services::Maps;
-#endif
-
 namespace TitaniumWindows
 {
 	namespace Map
@@ -76,8 +71,8 @@ namespace TitaniumWindows
 
 		private:
 
-#if defined(IS_WINDOWS_PHONE)
-			MapControl^ mapview__ = { nullptr };
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
+			Windows::UI::Xaml::Controls::Maps::MapControl^ mapview__ = { nullptr };
 #endif
 		};
 	} // namespace Map

--- a/Source/Map/include/TitaniumWindows/Map/View.hpp
+++ b/Source/Map/include/TitaniumWindows/Map/View.hpp
@@ -11,8 +11,10 @@
 
 #include "TitaniumWindows_Map_EXPORT.h"
 #include "Titanium/Map/View.hpp"
+#include "Titanium/detail/TiBase.hpp"
+#include "TitaniumWindows/WindowsMacros.hpp"
 
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 using namespace Windows::UI::Xaml::Controls::Maps;
 using namespace Windows::Services::Maps;
 #endif
@@ -74,7 +76,7 @@ namespace TitaniumWindows
 
 		private:
 
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			MapControl^ mapview__ = { nullptr };
 #endif
 		};

--- a/Source/Map/src/Annotation.cpp
+++ b/Source/Map/src/Annotation.cpp
@@ -12,7 +12,7 @@
 #include "Titanium/detail/TiImpl.hpp"
 #include "TitaniumWindows/WindowsMacros.hpp"
 
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 using namespace Windows::UI::Xaml::Controls::Maps;
 using namespace Windows::Devices::Geolocation;
 #endif
@@ -36,7 +36,7 @@ namespace TitaniumWindows
 
 		void Annotation::set_pincolor(const Titanium::Map::ANNOTATION_COLOR& pincolor) TITANIUM_NOEXCEPT
 		{
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			if (pincolor == Titanium::Map::ANNOTATION_COLOR::AZURE) {
 				icon__->Fill = ref new Windows::UI::Xaml::Media::SolidColorBrush(Windows::UI::Colors::Azure);
 			} else if (pincolor == Titanium::Map::ANNOTATION_COLOR::BLUE) {
@@ -64,7 +64,7 @@ namespace TitaniumWindows
 		}
 
 		void Annotation::updateGeoLocation() {
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			BasicGeoposition bgp = { get_latitude(), get_longitude() };
 			MapControl::SetLocation(mapicon__, ref new Geopoint(bgp));
 			MapControl::SetNormalizedAnchorPoint(mapicon__, Windows::Foundation::Point(0.5f, 0.75f));
@@ -74,7 +74,7 @@ namespace TitaniumWindows
 		void Annotation::set_title(const std::string& title) TITANIUM_NOEXCEPT
 		{
 			Titanium::Map::Annotation::set_title(title);
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			text__->Text = TitaniumWindows::Utility::ConvertString(title);
 #endif
 		}
@@ -83,7 +83,7 @@ namespace TitaniumWindows
 			: Titanium::Map::Annotation(js_context)
 		{
 			TITANIUM_LOG_DEBUG("Annotation::ctor Initialize");
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			mapicon__ = ref new Windows::UI::Xaml::Controls::Grid();
 
 			// Draw pin
@@ -122,7 +122,7 @@ namespace TitaniumWindows
 
 		Annotation::~Annotation()
 		{
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			mapicon__ = nullptr;
 #endif
 		}

--- a/Source/Map/src/Annotation.cpp
+++ b/Source/Map/src/Annotation.cpp
@@ -9,8 +9,10 @@
 #include "TitaniumWindows/Map/Annotation.hpp"
 #include "TitaniumWindows/Utility.hpp"
 #include "Titanium/detail/TiLogger.hpp"
+#include "Titanium/detail/TiImpl.hpp"
+#include "TitaniumWindows/WindowsMacros.hpp"
 
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 using namespace Windows::UI::Xaml::Controls::Maps;
 using namespace Windows::Devices::Geolocation;
 #endif
@@ -34,7 +36,7 @@ namespace TitaniumWindows
 
 		void Annotation::set_pincolor(const Titanium::Map::ANNOTATION_COLOR& pincolor) TITANIUM_NOEXCEPT
 		{
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			if (pincolor == Titanium::Map::ANNOTATION_COLOR::AZURE) {
 				icon__->Fill = ref new Windows::UI::Xaml::Media::SolidColorBrush(Windows::UI::Colors::Azure);
 			} else if (pincolor == Titanium::Map::ANNOTATION_COLOR::BLUE) {
@@ -62,7 +64,7 @@ namespace TitaniumWindows
 		}
 
 		void Annotation::updateGeoLocation() {
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			BasicGeoposition bgp = { get_latitude(), get_longitude() };
 			MapControl::SetLocation(mapicon__, ref new Geopoint(bgp));
 			MapControl::SetNormalizedAnchorPoint(mapicon__, Windows::Foundation::Point(0.5f, 0.75f));
@@ -72,7 +74,7 @@ namespace TitaniumWindows
 		void Annotation::set_title(const std::string& title) TITANIUM_NOEXCEPT
 		{
 			Titanium::Map::Annotation::set_title(title);
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			text__->Text = TitaniumWindows::Utility::ConvertString(title);
 #endif
 		}
@@ -81,7 +83,7 @@ namespace TitaniumWindows
 			: Titanium::Map::Annotation(js_context)
 		{
 			TITANIUM_LOG_DEBUG("Annotation::ctor Initialize");
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			mapicon__ = ref new Windows::UI::Xaml::Controls::Grid();
 
 			// Draw pin
@@ -120,7 +122,7 @@ namespace TitaniumWindows
 
 		Annotation::~Annotation()
 		{
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			mapicon__ = nullptr;
 #endif
 		}

--- a/Source/Map/src/View.cpp
+++ b/Source/Map/src/View.cpp
@@ -14,8 +14,8 @@
 #include "Titanium/detail/TiImpl.hpp"
 #include "TitaniumWindows/WindowsMacros.hpp"
 
-#if defined(IS_WINDOWS_PHONE)
-using namespace Windows::Devices::Geolocation;
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
+using namespace Windows::UI::Xaml::Controls::Maps;
 #endif
 
 namespace TitaniumWindows
@@ -30,7 +30,7 @@ namespace TitaniumWindows
 
 		View::~View()
 		{
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			mapview__ = nullptr;
 #endif
 		}
@@ -38,7 +38,7 @@ namespace TitaniumWindows
 		void View::postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) {
 			Titanium::Map::View::postCallAsConstructor(js_context, arguments);
 
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			mapview__ = ref new MapControl();
 
 			// Set service token
@@ -64,7 +64,7 @@ namespace TitaniumWindows
 
 		uint32_t View::get_maxZoomLevel() const TITANIUM_NOEXCEPT
 		{
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			return static_cast<uint32_t>(mapview__->MaxZoomLevel); // should be 20
 #else
 			return 20;
@@ -73,7 +73,7 @@ namespace TitaniumWindows
 
 		uint32_t View::get_minZoomLevel() const TITANIUM_NOEXCEPT
 		{
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			return static_cast<uint32_t>(mapview__->MinZoomLevel); // should be 1
 #else
 			return 1;
@@ -83,7 +83,7 @@ namespace TitaniumWindows
 		void View::set_mapType(const Titanium::Map::MAP_TYPE& mapType) TITANIUM_NOEXCEPT
 		{
 			Titanium::Map::View::set_mapType(mapType);
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			if (mapType == Titanium::Map::MAP_TYPE::HYBRID) {
 				mapview__->Style = MapStyle::AerialWithRoads;
 			} else if (mapType == Titanium::Map::MAP_TYPE::SATELLITE) {
@@ -99,6 +99,8 @@ namespace TitaniumWindows
 			Titanium::Map::View::set_region(region);
 
 #if defined(IS_WINDOWS_PHONE)
+			using namespace Windows::Devices::Geolocation;
+
 			// set center to supplied lat/long
 			BasicGeoposition location = { region.latitude, region.longitude };
 			auto gp = ref new Geopoint(location);
@@ -126,7 +128,7 @@ namespace TitaniumWindows
 		void View::set_showsBuildings(const bool& buildings) TITANIUM_NOEXCEPT
 		{
 			Titanium::Map::View::set_showsBuildings(buildings);
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			mapview__->LandmarksVisible = buildings;
 #endif
 		}
@@ -134,7 +136,7 @@ namespace TitaniumWindows
 		void View::set_traffic(const bool& traffic) TITANIUM_NOEXCEPT
 		{
 			Titanium::Map::View::set_traffic(traffic);
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			mapview__->TrafficFlowVisible = traffic;
 #endif
 		}
@@ -142,7 +144,7 @@ namespace TitaniumWindows
 		void View::addAnnotation(const Annotation_shared_ptr_t& annotation) TITANIUM_NOEXCEPT
 		{
 			Titanium::Map::View::addAnnotation(annotation);
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			auto native_annotation_ptr = annotation->get_object().GetPrivate<TitaniumWindows::Map::Annotation>();
 			if (native_annotation_ptr != nullptr) {
 				mapview__->Children->Append(native_annotation_ptr->GetMapIcon());
@@ -154,7 +156,7 @@ namespace TitaniumWindows
 		{
 			Titanium::Map::View::removeAnnotation(annotation);
 
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			for (size_t i = 0; i < mapview__->Children->Size; i++) {
 				auto element = mapview__->Children->GetAt(i);
 				Windows::UI::Xaml::Controls::Grid^ icon = dynamic_cast<Windows::UI::Xaml::Controls::Grid^>(element);
@@ -175,7 +177,7 @@ namespace TitaniumWindows
 		void View::zoom(const uint32_t& zoom) TITANIUM_NOEXCEPT
 		{
 			Titanium::Map::View::zoom(zoom);
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			if (zoom != 0) // no zoom specified in the region object?
 			{
 				// TODO Enforce min/max zoom levels?

--- a/Source/Map/src/View.cpp
+++ b/Source/Map/src/View.cpp
@@ -11,8 +11,10 @@
 #include "TitaniumWindows/Map/Annotation.hpp"
 #include "TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp"
 #include "Titanium/detail/TiLogger.hpp"
+#include "Titanium/detail/TiImpl.hpp"
+#include "TitaniumWindows/WindowsMacros.hpp"
 
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 using namespace Windows::Devices::Geolocation;
 #endif
 
@@ -28,7 +30,7 @@ namespace TitaniumWindows
 
 		View::~View()
 		{
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			mapview__ = nullptr;
 #endif
 		}
@@ -36,7 +38,7 @@ namespace TitaniumWindows
 		void View::postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) {
 			Titanium::Map::View::postCallAsConstructor(js_context, arguments);
 
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			mapview__ = ref new MapControl();
 
 			// Set service token
@@ -62,7 +64,7 @@ namespace TitaniumWindows
 
 		uint32_t View::get_maxZoomLevel() const TITANIUM_NOEXCEPT
 		{
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			return static_cast<uint32_t>(mapview__->MaxZoomLevel); // should be 20
 #else
 			return 20;
@@ -71,7 +73,7 @@ namespace TitaniumWindows
 
 		uint32_t View::get_minZoomLevel() const TITANIUM_NOEXCEPT
 		{
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			return static_cast<uint32_t>(mapview__->MinZoomLevel); // should be 1
 #else
 			return 1;
@@ -81,7 +83,7 @@ namespace TitaniumWindows
 		void View::set_mapType(const Titanium::Map::MAP_TYPE& mapType) TITANIUM_NOEXCEPT
 		{
 			Titanium::Map::View::set_mapType(mapType);
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			if (mapType == Titanium::Map::MAP_TYPE::HYBRID) {
 				mapview__->Style = MapStyle::AerialWithRoads;
 			} else if (mapType == Titanium::Map::MAP_TYPE::SATELLITE) {
@@ -96,7 +98,7 @@ namespace TitaniumWindows
 		{
 			Titanium::Map::View::set_region(region);
 
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			// set center to supplied lat/long
 			BasicGeoposition location = { region.latitude, region.longitude };
 			auto gp = ref new Geopoint(location);
@@ -124,7 +126,7 @@ namespace TitaniumWindows
 		void View::set_showsBuildings(const bool& buildings) TITANIUM_NOEXCEPT
 		{
 			Titanium::Map::View::set_showsBuildings(buildings);
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			mapview__->LandmarksVisible = buildings;
 #endif
 		}
@@ -132,7 +134,7 @@ namespace TitaniumWindows
 		void View::set_traffic(const bool& traffic) TITANIUM_NOEXCEPT
 		{
 			Titanium::Map::View::set_traffic(traffic);
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			mapview__->TrafficFlowVisible = traffic;
 #endif
 		}
@@ -140,7 +142,7 @@ namespace TitaniumWindows
 		void View::addAnnotation(const Annotation_shared_ptr_t& annotation) TITANIUM_NOEXCEPT
 		{
 			Titanium::Map::View::addAnnotation(annotation);
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			auto native_annotation_ptr = annotation->get_object().GetPrivate<TitaniumWindows::Map::Annotation>();
 			if (native_annotation_ptr != nullptr) {
 				mapview__->Children->Append(native_annotation_ptr->GetMapIcon());
@@ -152,7 +154,7 @@ namespace TitaniumWindows
 		{
 			Titanium::Map::View::removeAnnotation(annotation);
 
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			for (size_t i = 0; i < mapview__->Children->Size; i++) {
 				auto element = mapview__->Children->GetAt(i);
 				Windows::UI::Xaml::Controls::Grid^ icon = dynamic_cast<Windows::UI::Xaml::Controls::Grid^>(element);
@@ -173,7 +175,7 @@ namespace TitaniumWindows
 		void View::zoom(const uint32_t& zoom) TITANIUM_NOEXCEPT
 		{
 			Titanium::Map::View::zoom(zoom);
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			if (zoom != 0) // no zoom specified in the region object?
 			{
 				// TODO Enforce min/max zoom levels?

--- a/Source/Media/include/TitaniumWindows/Media.hpp
+++ b/Source/Media/include/TitaniumWindows/Media.hpp
@@ -175,8 +175,8 @@ namespace TitaniumWindows
 		Titanium::Media::PhotoGalleryOptionsType openPhotoGalleryOptionsState__;
 		Titanium::Media::MusicLibraryOptionsType openMusicLibraryOptionsState__;
 		JSFunction js_beep__;
-#if defined(IS_WINDOWS_PHONE)
-		bool screenCaptureStarted__ { false };
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
+		bool screenCaptureStarted__{ false };
 		bool cameraPreviewStarted__ { false };
 		JSFunction fileOpenForMusicLibraryCallback__;
 		JSFunction fileOpenForPhotoGalleryCallback__;

--- a/Source/Media/include/TitaniumWindows/Media.hpp
+++ b/Source/Media/include/TitaniumWindows/Media.hpp
@@ -11,6 +11,8 @@
 #include "Titanium/MediaModule.hpp"
 #include "Titanium/Media/PhotoGalleryOptionsType.hpp"
 #include "Titanium/Media/MusicLibraryOptionsType.hpp"
+#include "Titanium/detail/TiBase.hpp"
+#include "TitaniumWindows/WindowsMacros.hpp"
 #include <agile.h>
 #include <collection.h>
 
@@ -173,7 +175,7 @@ namespace TitaniumWindows
 		Titanium::Media::PhotoGalleryOptionsType openPhotoGalleryOptionsState__;
 		Titanium::Media::MusicLibraryOptionsType openMusicLibraryOptionsState__;
 		JSFunction js_beep__;
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 		bool screenCaptureStarted__ { false };
 		bool cameraPreviewStarted__ { false };
 		JSFunction fileOpenForMusicLibraryCallback__;
@@ -182,11 +184,7 @@ namespace TitaniumWindows
 		::Platform::Collections::Vector<Windows::UI::Xaml::DispatcherTimer^>^ vibrate_timers__;
 		Windows::UI::Xaml::Controls::CaptureElement^ captureElement__;
 		Windows::Foundation::EventRegistrationToken camera_navigated_event__;
-
-#else
-
 #endif
-
 #pragma warning(pop)
 	};
 

--- a/Source/Media/include/TitaniumWindows/Media/AudioPlayer.hpp
+++ b/Source/Media/include/TitaniumWindows/Media/AudioPlayer.hpp
@@ -9,6 +9,8 @@
 
 #include "TitaniumWindows_Media_EXPORT.h"
 #include "Titanium/Media/AudioPlayer.hpp"
+#include "Titanium/detail/TiBase.hpp"
+#include "TitaniumWindows/WindowsMacros.hpp"
 
 namespace TitaniumWindows
 {
@@ -61,7 +63,7 @@ namespace TitaniumWindows
 		protected:
 			Windows::Media::SystemMediaTransportControls^ controls__;
 			Windows::UI::Xaml::Controls::MediaElement^ player__;
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			Windows::Media::Playback::MediaPlayer^ background_player__;
 #endif
 			Windows::Foundation::EventRegistrationToken complete_event__;

--- a/Source/Media/include/TitaniumWindows/Media/AudioPlayer.hpp
+++ b/Source/Media/include/TitaniumWindows/Media/AudioPlayer.hpp
@@ -63,7 +63,7 @@ namespace TitaniumWindows
 		protected:
 			Windows::Media::SystemMediaTransportControls^ controls__;
 			Windows::UI::Xaml::Controls::MediaElement^ player__;
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			Windows::Media::Playback::MediaPlayer^ background_player__;
 #endif
 			Windows::Foundation::EventRegistrationToken complete_event__;

--- a/Source/Media/src/Media.cpp
+++ b/Source/Media/src/Media.cpp
@@ -13,6 +13,7 @@
 #include "TitaniumWindows/Utility.hpp"
 #include "Titanium/detail/TiImpl.hpp"
 #include "TitaniumWindows/AppModule.hpp"
+#include "TitaniumWindows/WindowsMacros.hpp"
 #include <ppltasks.h>
 #include <collection.h>
 #include <concrt.h>
@@ -102,7 +103,7 @@ namespace TitaniumWindows
 		openMusicLibraryOptionsState__ = options;
 		waitingForOpenMusicLibrary__ = true;
 
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 		// Start listening to "windows.fileOpenFromPicker" event
 		GET_TITANIUM_APP(App);
 		App->addEventListener("windows.fileOpenFromPicker", fileOpenForMusicLibraryCallback__, fileOpenForMusicLibraryCallback__);
@@ -239,7 +240,7 @@ namespace TitaniumWindows
 		openPhotoGalleryOptionsState__ = options;
 		waitingForOpenPhotoGallery__ = true;
 
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 		// Start listening to "windows.fileOpenFromPicker" event
 		GET_TITANIUM_APP(App);
 		App->addEventListener("windows.fileOpenFromPicker", fileOpenForPhotoGalleryCallback__, fileOpenForPhotoGalleryCallback__);
@@ -362,7 +363,7 @@ namespace TitaniumWindows
 
 	void MediaModule::hideCamera() TITANIUM_NOEXCEPT
 	{
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 		TITANIUM_ASSERT_AND_THROW(cameraPreviewStarted__, "Camera is not visiable. Use showCamera() to show camera.");
 		concurrency::create_task(mediaCapture__->StopPreviewAsync()).then([this](concurrency::task<void> stopTask) {
 			try {
@@ -380,7 +381,7 @@ namespace TitaniumWindows
 
 	void MediaModule::showCamera(const Titanium::Media::CameraOptionsType& options) TITANIUM_NOEXCEPT
 	{
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 
 		if (cameraPreviewStarted__) {
 			TITANIUM_LOG_WARN("Failed to showCamera(): Camera is already visible.");
@@ -485,7 +486,7 @@ namespace TitaniumWindows
 
 	void MediaModule::takePicture() TITANIUM_NOEXCEPT
 	{
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 		// CreationCollisionOption::GenerateUniqueName generates unique name such as "TiMediaPhoto (2).jpg"
 		concurrency::task<StorageFile^>(KnownFolders::VideosLibrary->CreateFileAsync("TiMediaPhoto.jpg", CreationCollisionOption::GenerateUniqueName)).then([this](concurrency::task<StorageFile^> fileTask) {
 			try {
@@ -513,7 +514,7 @@ namespace TitaniumWindows
 
 	void MediaModule::startVideoCapture() TITANIUM_NOEXCEPT
 	{
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 		concurrency::task<StorageFile^>(KnownFolders::VideosLibrary->CreateFileAsync("TiMediaVideo.mp4", CreationCollisionOption::GenerateUniqueName)).then([this](concurrency::task<StorageFile^> fileTask) {
 			try {
 				auto file = fileTask.get();
@@ -541,7 +542,7 @@ namespace TitaniumWindows
 
 	void MediaModule::stopVideoCapture() TITANIUM_NOEXCEPT
 	{
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 		TITANIUM_ASSERT_AND_THROW(cameraPreviewStarted__, "Camera is not visiable. Use showCamera() to show camera.");
 		concurrency::create_task(mediaCapture__->StopRecordAsync()).then([this](concurrency::task<void> stopTask) {
 			try {
@@ -572,7 +573,7 @@ namespace TitaniumWindows
 
 	void MediaModule::clearScreenshotResources()
 	{
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 		if (screenCaptureStarted__) {
 			delete(mediaCapture__.Get());
 			screenCaptureStarted__ = false;
@@ -583,7 +584,7 @@ namespace TitaniumWindows
 	// Create new storage and start capturing!
 	void MediaModule::takeScreenshotToFile(JSObject callback)
 	{
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 		// CreationCollisionOption::GenerateUniqueName generates unique name such as "TiMediaScreenCapture (2).jpg"
 		concurrency::task<StorageFile^>(KnownFolders::VideosLibrary->CreateFileAsync("TiMediaScreenCapture.jpg", CreationCollisionOption::GenerateUniqueName)).then([this, callback](concurrency::task<StorageFile^> fileTask) {
 			try {
@@ -614,7 +615,7 @@ namespace TitaniumWindows
 
 	void MediaModule::takeScreenshot(JSValue callback_value) TITANIUM_NOEXCEPT
 	{
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 
 		TITANIUM_ASSERT_AND_THROW(!cameraPreviewStarted__, "takeScreenshot() can't be used during camera preview");
 
@@ -665,7 +666,7 @@ namespace TitaniumWindows
 
 	void MediaModule::vibrate(std::vector<std::chrono::milliseconds> pattern) TITANIUM_NOEXCEPT
 	{
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 		using namespace Windows::Phone::Devices::Notification;
 		const auto device = VibrationDevice::GetDefault();
 
@@ -713,7 +714,7 @@ namespace TitaniumWindows
 	MediaModule::MediaModule(const JSContext& js_context) TITANIUM_NOEXCEPT
 		: Titanium::MediaModule(js_context)
 		, js_beep__(createBeepFunction(js_context))
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 		, fileOpenForMusicLibraryCallback__(createFileOpenForMusicLibraryFunction(js_context))
 		, fileOpenForPhotoGalleryCallback__(createFileOpenForPhotoGalleryFunction(js_context))
 #endif
@@ -721,7 +722,7 @@ namespace TitaniumWindows
 		, openMusicLibraryOptionsState__(Titanium::Media::create_empty_MusicLibraryOptionsType(js_context))
 	{
 		TITANIUM_LOG_DEBUG("TitaniumWindows::MediaModule::ctor Initialize");
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 		vibrate_timers__ = ref new Vector<DispatcherTimer^>();
 		captureElement__ = ref new CaptureElement();
 #endif

--- a/Source/Media/src/Media.cpp
+++ b/Source/Media/src/Media.cpp
@@ -363,7 +363,7 @@ namespace TitaniumWindows
 
 	void MediaModule::hideCamera() TITANIUM_NOEXCEPT
 	{
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 		TITANIUM_ASSERT_AND_THROW(cameraPreviewStarted__, "Camera is not visiable. Use showCamera() to show camera.");
 		concurrency::create_task(mediaCapture__->StopPreviewAsync()).then([this](concurrency::task<void> stopTask) {
 			try {
@@ -381,7 +381,7 @@ namespace TitaniumWindows
 
 	void MediaModule::showCamera(const Titanium::Media::CameraOptionsType& options) TITANIUM_NOEXCEPT
 	{
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 
 		if (cameraPreviewStarted__) {
 			TITANIUM_LOG_WARN("Failed to showCamera(): Camera is already visible.");
@@ -486,7 +486,7 @@ namespace TitaniumWindows
 
 	void MediaModule::takePicture() TITANIUM_NOEXCEPT
 	{
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 		// CreationCollisionOption::GenerateUniqueName generates unique name such as "TiMediaPhoto (2).jpg"
 		concurrency::task<StorageFile^>(KnownFolders::VideosLibrary->CreateFileAsync("TiMediaPhoto.jpg", CreationCollisionOption::GenerateUniqueName)).then([this](concurrency::task<StorageFile^> fileTask) {
 			try {
@@ -514,7 +514,7 @@ namespace TitaniumWindows
 
 	void MediaModule::startVideoCapture() TITANIUM_NOEXCEPT
 	{
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 		concurrency::task<StorageFile^>(KnownFolders::VideosLibrary->CreateFileAsync("TiMediaVideo.mp4", CreationCollisionOption::GenerateUniqueName)).then([this](concurrency::task<StorageFile^> fileTask) {
 			try {
 				auto file = fileTask.get();
@@ -542,7 +542,7 @@ namespace TitaniumWindows
 
 	void MediaModule::stopVideoCapture() TITANIUM_NOEXCEPT
 	{
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 		TITANIUM_ASSERT_AND_THROW(cameraPreviewStarted__, "Camera is not visiable. Use showCamera() to show camera.");
 		concurrency::create_task(mediaCapture__->StopRecordAsync()).then([this](concurrency::task<void> stopTask) {
 			try {
@@ -573,7 +573,7 @@ namespace TitaniumWindows
 
 	void MediaModule::clearScreenshotResources()
 	{
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 		if (screenCaptureStarted__) {
 			delete(mediaCapture__.Get());
 			screenCaptureStarted__ = false;
@@ -584,7 +584,7 @@ namespace TitaniumWindows
 	// Create new storage and start capturing!
 	void MediaModule::takeScreenshotToFile(JSObject callback)
 	{
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 		// CreationCollisionOption::GenerateUniqueName generates unique name such as "TiMediaScreenCapture (2).jpg"
 		concurrency::task<StorageFile^>(KnownFolders::VideosLibrary->CreateFileAsync("TiMediaScreenCapture.jpg", CreationCollisionOption::GenerateUniqueName)).then([this, callback](concurrency::task<StorageFile^> fileTask) {
 			try {
@@ -714,7 +714,7 @@ namespace TitaniumWindows
 	MediaModule::MediaModule(const JSContext& js_context) TITANIUM_NOEXCEPT
 		: Titanium::MediaModule(js_context)
 		, js_beep__(createBeepFunction(js_context))
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 		, fileOpenForMusicLibraryCallback__(createFileOpenForMusicLibraryFunction(js_context))
 		, fileOpenForPhotoGalleryCallback__(createFileOpenForPhotoGalleryFunction(js_context))
 #endif
@@ -722,7 +722,7 @@ namespace TitaniumWindows
 		, openMusicLibraryOptionsState__(Titanium::Media::create_empty_MusicLibraryOptionsType(js_context))
 	{
 		TITANIUM_LOG_DEBUG("TitaniumWindows::MediaModule::ctor Initialize");
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 		vibrate_timers__ = ref new Vector<DispatcherTimer^>();
 		captureElement__ = ref new CaptureElement();
 #endif

--- a/Source/Media/src/Media/AudioPlayer.cpp
+++ b/Source/Media/src/Media/AudioPlayer.cpp
@@ -13,7 +13,7 @@
 using namespace Windows::UI::Xaml;
 using namespace Windows::UI::Xaml::Controls;
 using namespace Windows::UI::Xaml::Media;
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 using namespace Windows::Media::Playback;
 #endif
 using namespace Windows::Foundation;
@@ -31,7 +31,7 @@ namespace TitaniumWindows
 		AudioPlayer::~AudioPlayer()
 		{
 			TITANIUM_LOG_DEBUG("TitaniumWindows::Media::AudioPlayer::dtor");
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			BackgroundMediaPlayer::Shutdown();
 #endif
 		}
@@ -59,7 +59,7 @@ namespace TitaniumWindows
 		{
 			Titanium::Media::AudioPlayer::postCallAsConstructor(js_context, arguments);
 
-#if WINAPI_FAMILY != WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			// allow background audio on WindowsStore apps
 			// this still requires Package.appxmanifest background task
 			auto controls = Windows::Media::SystemMediaTransportControls::GetForCurrentView();
@@ -96,7 +96,7 @@ namespace TitaniumWindows
 					stateChanged();
 				}
 			);
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			background_player__ = BackgroundMediaPlayer::Current;
 			background_player__->AutoPlay = false;
 			background_player__->CurrentStateChanged += ref new TypedEventHandler<MediaPlayer^, Platform::Object^>(
@@ -144,7 +144,7 @@ namespace TitaniumWindows
 		void AudioPlayer::set_allowBackground(const bool& allowBackground) TITANIUM_NOEXCEPT
 		{
 			Titanium::Media::AudioPlayer::set_allowBackground(allowBackground);
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			if (get_playing()) {
 				if (allowBackground) {
 					background_player__->Position = player__->Position;
@@ -169,14 +169,14 @@ namespace TitaniumWindows
 			Titanium::Media::AudioPlayer::set_url(url);
 			auto uri = TitaniumWindows::Utility::GetUriFromPath(url);
 			player__->Source = uri;
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			background_player__->SetUriSource(uri);
 #endif
 		}
 
 		void AudioPlayer::pause() TITANIUM_NOEXCEPT
 		{
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			if (get_allowBackground()) {
 				background_player__->Pause();
 			} else {
@@ -189,7 +189,7 @@ namespace TitaniumWindows
 
 		void AudioPlayer::play() TITANIUM_NOEXCEPT
 		{
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			if (get_allowBackground()) {
 				background_player__->Play();
 			} else {
@@ -202,7 +202,7 @@ namespace TitaniumWindows
 
 		void AudioPlayer::start() TITANIUM_NOEXCEPT
 		{
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			if (get_allowBackground()) {
 				background_player__->Play();
 			} else {
@@ -215,7 +215,7 @@ namespace TitaniumWindows
 
 		void AudioPlayer::stop() TITANIUM_NOEXCEPT
 		{
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			if (get_allowBackground()) {
 				background_player__->Pause();
 
@@ -247,7 +247,7 @@ namespace TitaniumWindows
 						mediaEnded();
 					}
 				);
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 				background_complete_event__ = background_player__->MediaEnded += ref new TypedEventHandler<MediaPlayer^, Platform::Object^>(
 					[=](MediaPlayer^ sender, Platform::Object^ e){
 						mediaEnded();
@@ -267,7 +267,7 @@ namespace TitaniumWindows
 						mediaFailed();
 					}
 				);
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 				background_failed_event__ = background_player__->MediaFailed += ref new TypedEventHandler<MediaPlayer^, MediaPlayerFailedEventArgs^>(
 					[=](MediaPlayer^ sender, MediaPlayerFailedEventArgs^ e) {
 						mediaFailed();
@@ -282,12 +282,12 @@ namespace TitaniumWindows
 			Titanium::Media::AudioPlayer::disableEvent(event_name);
 			if (event_name == "complete") {
 				player__->MediaEnded -= complete_event__;
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 				background_player__->MediaEnded -= background_complete_event__;
 #endif
 			} else if (event_name == "error") {
 				player__->MediaFailed -= failed_event__;
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 				background_player__->MediaFailed -= background_failed_event__;
 #endif
 			}

--- a/Source/Media/src/Media/AudioPlayer.cpp
+++ b/Source/Media/src/Media/AudioPlayer.cpp
@@ -7,11 +7,13 @@
 #include "TitaniumWindows/Media/AudioPlayer.hpp"
 #include "Titanium/detail/TiLogger.hpp"
 #include "TitaniumWindows/Utility.hpp"
+#include "Titanium/detail/TiImpl.hpp"
+#include "TitaniumWindows/WindowsMacros.hpp"
 
 using namespace Windows::UI::Xaml;
 using namespace Windows::UI::Xaml::Controls;
 using namespace Windows::UI::Xaml::Media;
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 using namespace Windows::Media::Playback;
 #endif
 using namespace Windows::Foundation;
@@ -29,7 +31,7 @@ namespace TitaniumWindows
 		AudioPlayer::~AudioPlayer()
 		{
 			TITANIUM_LOG_DEBUG("TitaniumWindows::Media::AudioPlayer::dtor");
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			BackgroundMediaPlayer::Shutdown();
 #endif
 		}
@@ -94,7 +96,7 @@ namespace TitaniumWindows
 					stateChanged();
 				}
 			);
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			background_player__ = BackgroundMediaPlayer::Current;
 			background_player__->AutoPlay = false;
 			background_player__->CurrentStateChanged += ref new TypedEventHandler<MediaPlayer^, Platform::Object^>(
@@ -142,7 +144,7 @@ namespace TitaniumWindows
 		void AudioPlayer::set_allowBackground(const bool& allowBackground) TITANIUM_NOEXCEPT
 		{
 			Titanium::Media::AudioPlayer::set_allowBackground(allowBackground);
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			if (get_playing()) {
 				if (allowBackground) {
 					background_player__->Position = player__->Position;
@@ -167,14 +169,14 @@ namespace TitaniumWindows
 			Titanium::Media::AudioPlayer::set_url(url);
 			auto uri = TitaniumWindows::Utility::GetUriFromPath(url);
 			player__->Source = uri;
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			background_player__->SetUriSource(uri);
 #endif
 		}
 
 		void AudioPlayer::pause() TITANIUM_NOEXCEPT
 		{
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			if (get_allowBackground()) {
 				background_player__->Pause();
 			} else {
@@ -187,7 +189,7 @@ namespace TitaniumWindows
 
 		void AudioPlayer::play() TITANIUM_NOEXCEPT
 		{
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			if (get_allowBackground()) {
 				background_player__->Play();
 			} else {
@@ -200,7 +202,7 @@ namespace TitaniumWindows
 
 		void AudioPlayer::start() TITANIUM_NOEXCEPT
 		{
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			if (get_allowBackground()) {
 				background_player__->Play();
 			} else {
@@ -213,7 +215,7 @@ namespace TitaniumWindows
 
 		void AudioPlayer::stop() TITANIUM_NOEXCEPT
 		{
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			if (get_allowBackground()) {
 				background_player__->Pause();
 
@@ -245,7 +247,7 @@ namespace TitaniumWindows
 						mediaEnded();
 					}
 				);
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 				background_complete_event__ = background_player__->MediaEnded += ref new TypedEventHandler<MediaPlayer^, Platform::Object^>(
 					[=](MediaPlayer^ sender, Platform::Object^ e){
 						mediaEnded();
@@ -265,7 +267,7 @@ namespace TitaniumWindows
 						mediaFailed();
 					}
 				);
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 				background_failed_event__ = background_player__->MediaFailed += ref new TypedEventHandler<MediaPlayer^, MediaPlayerFailedEventArgs^>(
 					[=](MediaPlayer^ sender, MediaPlayerFailedEventArgs^ e) {
 						mediaFailed();
@@ -280,12 +282,12 @@ namespace TitaniumWindows
 			Titanium::Media::AudioPlayer::disableEvent(event_name);
 			if (event_name == "complete") {
 				player__->MediaEnded -= complete_event__;
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 				background_player__->MediaEnded -= background_complete_event__;
 #endif
 			} else if (event_name == "error") {
 				player__->MediaFailed -= failed_event__;
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 				background_player__->MediaFailed -= background_failed_event__;
 #endif
 			}

--- a/Source/Ti/include/TitaniumWindows/Contacts/Group.hpp
+++ b/Source/Ti/include/TitaniumWindows/Contacts/Group.hpp
@@ -11,6 +11,7 @@
 
 #include "TitaniumWindows_Ti_EXPORT.h"
 #include "Titanium/Contacts/Group.hpp"
+#include "TitaniumWindows/WindowsMacros.hpp"
 #include <sdkddkver.h>
 
 namespace TitaniumWindows
@@ -43,8 +44,7 @@ namespace TitaniumWindows
 
 			virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;
 
-#if (WINVER >= 0x0A00)
-// Windows 10+ API!
+#if defined(IS_WINDOWS_10)
 			void construct(Windows::ApplicationModel::Contacts::ContactList^ list);
 #endif
 
@@ -61,8 +61,7 @@ namespace TitaniumWindows
 			virtual void set_recordId(const uint32_t&) TITANIUM_NOEXCEPT override final;
 
 		private:
-#if (WINVER >= 0x0A00)
-// Windows 10+ API!
+#if defined(IS_WINDOWS_10)
 			Windows::ApplicationModel::Contacts::ContactList^ contact_list__;
 #endif
 		};

--- a/Source/Ti/include/TitaniumWindows/Contacts/Person.hpp
+++ b/Source/Ti/include/TitaniumWindows/Contacts/Person.hpp
@@ -11,6 +11,7 @@
 
 #include "TitaniumWindows_Ti_EXPORT.h"
 #include "Titanium/Contacts/Person.hpp"
+#include "TitaniumWindows/WindowsMacros.hpp"
 #include <sdkddkver.h>
 
 namespace TitaniumWindows
@@ -96,8 +97,7 @@ namespace TitaniumWindows
 			virtual void set_url(const Titanium::Contacts::Urls&) TITANIUM_NOEXCEPT override final;
 
 			void remove();
-#if (WINVER >= 0x0A00)
-// Windows 10+ API
+#if defined(IS_WINDOWS_10)
 			Windows::ApplicationModel::Contacts::Contact^ GetContact();
 			void removeFromList(Windows::ApplicationModel::Contacts::ContactList^ list);
 #endif

--- a/Source/Ti/src/Contacts.cpp
+++ b/Source/Ti/src/Contacts.cpp
@@ -13,6 +13,7 @@
 #include "TitaniumWindows/Contacts/Group.hpp"
 #include "TitaniumWindows/Contacts/Person.hpp"
 #include "TitaniumWindows/Utility.hpp"
+#include "TitaniumWindows/WindowsMacros.hpp"
 #include <ppltasks.h>
 #include <collection.h>
 #include <concrt.h>
@@ -34,7 +35,7 @@ namespace TitaniumWindows
 		JSExport<ContactsModule>::SetParent(JSExport<Titanium::ContactsModule>::Class());
 	}
 
-#if (WINVER >= 0x0A00)
+#if defined(IS_WINDOWS_10)
 	// Windows 10+ API!
 	static std::shared_ptr<Titanium::Contacts::Group> listToGroup(const JSContext& context, Windows::ApplicationModel::Contacts::ContactList^ contact_list) TITANIUM_NOEXCEPT
 	{
@@ -60,7 +61,7 @@ namespace TitaniumWindows
 
 	std::vector<std::shared_ptr<Titanium::Contacts::Group>> ContactsModule::getAllGroups() TITANIUM_NOEXCEPT
 	{
-#if (WINVER >= 0x0A00)
+#if defined(IS_WINDOWS_10)
 		// Windows 10+ API!
 		std::vector<std::shared_ptr<Titanium::Contacts::Group>> result;
 		// FIXME Should we grab the contact store during requestAuthorization?
@@ -92,7 +93,7 @@ namespace TitaniumWindows
 	std::vector<std::shared_ptr<Titanium::Contacts::Person>> ContactsModule::getAllPeople(const uint32_t& limit) TITANIUM_NOEXCEPT
 	{
 		std::vector<std::shared_ptr<Titanium::Contacts::Person>> result;
-#if (WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP) && (WINVER >= 0x0A00)
+#if defined(IS_WINDOWS_10)
 		// FIXME Should we grab the contact store during requestAuthorization?
 		try {
 			const auto ctx = get_context();
@@ -107,30 +108,23 @@ namespace TitaniumWindows
 					for (auto contact : contacts) {
 						result.push_back(contactToPerson(ctx, contact));
 					}
-				}
-				catch (Platform::AccessDeniedException^ ade) {
+				} catch (Platform::AccessDeniedException^ ade) {
 					TITANIUM_LOG_ERROR("Ti.Contacts.getAllPeople: Access denied: ", ade->Message->Data());
-				}
-				catch (Platform::COMException^ e) {
+				} catch (Platform::COMException^ e) {
 					TITANIUM_LOG_ERROR("Ti.Contacts.getAllPeople: ", e->Message->Data());
-				}
-				catch (const std::exception& e) {
+				} catch (const std::exception& e) {
 					TITANIUM_LOG_ERROR("Ti.Contacts.getAllPeople: ", e.what());
-				}
-				catch (...) {
+				} catch (...) {
 					TITANIUM_LOG_ERROR("i.Contacts.getAllPeople: Unknown error");
 				}
 				event.set();
 			}, concurrency::task_continuation_context::use_arbitrary());
 			event.wait();
-		}
-		catch (Platform::AccessDeniedException^ ade) {
+		} catch (Platform::AccessDeniedException^ ade) {
 			TITANIUM_LOG_ERROR("Ti.Contacts.getAllPeople: Access denied: ", ade->Message->Data());
-		}
-		catch (const std::exception& e) {
+		} catch (const std::exception& e) {
 			TITANIUM_LOG_ERROR("Ti.Contacts.getAllPeople: ", e.what());
-		}
-		catch (...) {
+		} catch (...) {
 			TITANIUM_LOG_ERROR("Ti.Contacts.getAllPeople: Unknown error");
 		}
 #else
@@ -141,7 +135,7 @@ namespace TitaniumWindows
 
 	std::shared_ptr<Titanium::Contacts::Group> ContactsModule::getGroupByIdentifier(const JSValue& id) TITANIUM_NOEXCEPT
 	{
-#if (WINVER >= 0x0A00)
+#if defined(IS_WINDOWS_10)
 		// Windows 10+ API!
 		TITANIUM_ASSERT(id.IsString());
 		const auto identifier = TitaniumWindows::Utility::ConvertUTF8String(static_cast<std::string>(id));
@@ -175,7 +169,7 @@ namespace TitaniumWindows
 	std::vector<std::shared_ptr<Titanium::Contacts::Person>> ContactsModule::getPeopleWithName(const std::string& name) TITANIUM_NOEXCEPT
 	{
 		std::vector<std::shared_ptr<Titanium::Contacts::Person>> result;
-#if (WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP) && (WINVER >= 0x0A00)
+#if defined(IS_WINDOWS_10)
 		// FIXME Should we grab the contact store during requestAuthorization?
 		const auto ctx = get_context();
 		const auto query = TitaniumWindows::Utility::ConvertUTF8String(name);
@@ -215,7 +209,7 @@ namespace TitaniumWindows
 	std::shared_ptr<Titanium::Contacts::Person> ContactsModule::getPersonByIdentifier(const JSValue& id) TITANIUM_NOEXCEPT
 	{
 		std::shared_ptr<Titanium::Contacts::Person> result = nullptr;
-#if (WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP) && (WINVER >= 0x0A00)
+#if defined(IS_WINDOWS_10)
 		// FIXME Should we grab the contact store during requestAuthorization?
 		TITANIUM_ASSERT(id.IsString());
 		const auto identifier = TitaniumWindows::Utility::ConvertUTF8String(static_cast<std::string>(id));
@@ -281,25 +275,19 @@ namespace TitaniumWindows
 						auto person = getPersonByIdentifier(params.callbacks.selectedPerson.get_context().CreateString(TitaniumWindows::Utility::ConvertUTF8String(contact->Id)));
 						params.callbacks.onselectedPerson(person);
 					}
-				}
-				catch (Platform::COMException^ ce) {
+				} catch (Platform::COMException^ ce) {
 					TITANIUM_LOG_ERROR("Ti.Contacts.showContacts: ", ce->Message->Data());
-				}
-				catch (const std::exception& e) {
+				} catch (const std::exception& e) {
 					TITANIUM_LOG_ERROR("Ti.Contacts.showContacts: ", e.what());
-				}
-				catch (...) {
+				} catch (...) {
 					TITANIUM_LOG_ERROR("Ti.Contacts.showContacts: Unknown error in selecting a contact.");
 				}
 			});
-		}
-		catch (Platform::COMException^ ce) {
+		} catch (Platform::COMException^ ce) {
 			TITANIUM_LOG_ERROR("Ti.Contacts.showContacts: ", ce->Message->Data());
-		}
-		catch (const std::exception& e) {
+		} catch (const std::exception& e) {
 			TITANIUM_LOG_ERROR("Ti.Contacts.showContacts: ", e.what());
-		}
-		catch (...) {
+		} catch (...) {
 			TITANIUM_LOG_ERROR("Ti.Contacts.showContacts: Unknown error in selecting a contact.");
 		}
 	}
@@ -309,7 +297,7 @@ namespace TitaniumWindows
 		Titanium::ErrorResponse e;
 		e.code = 0;
 		e.error = "";
-#if (WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP) && (WINVER >= 0x0A00)
+#if defined(IS_WINDOWS_10)
 		if (Titanium::Contacts::AUTHORIZATION::UNKNOWN == contactsAuthorization__) {
 			concurrency::event event;
 			concurrency::create_task(ContactManager::RequestStoreAsync(), concurrency::task_continuation_context::use_arbitrary())

--- a/Source/Ti/src/Contacts/Group.cpp
+++ b/Source/Ti/src/Contacts/Group.cpp
@@ -28,8 +28,7 @@ namespace TitaniumWindows
 			Titanium::Contacts::Group::postCallAsConstructor(js_context, arguments);
 		}
 
-#if (WINVER >= 0x0A00)
-		// Windows 10+ API!
+#if defined(IS_WINDOWS_10)
 		void Group::construct(Windows::ApplicationModel::Contacts::ContactList^ list)
 		{
 			contact_list__ = list;
@@ -43,8 +42,7 @@ namespace TitaniumWindows
 
 		void Group::add(const std::shared_ptr<Titanium::Contacts::Person>& person) TITANIUM_NOEXCEPT
 		{
-#if (WINVER >= 0x0A00)
-			// Windows 10+ API!
+#if defined(IS_WINDOWS_10)
 			if (contact_list__) {
 				// TODO Do we need to make this sync? i.e. wait for it to finish before we return? Seems like we shouldn't...
 				std::shared_ptr<TitaniumWindows::Contacts::Person> win_person = std::dynamic_pointer_cast<::TitaniumWindows::Contacts::Person>(person);
@@ -55,7 +53,7 @@ namespace TitaniumWindows
 
 		std::vector<std::shared_ptr<Titanium::Contacts::Person>> Group::members() TITANIUM_NOEXCEPT
 		{
-#if (WINVER >= 0x0A00)
+#if defined(IS_WINDOWS_10)
 			// Windows 10+ API!
 			if (contact_list__) {
 				std::vector<std::shared_ptr<Titanium::Contacts::Person>> people;
@@ -86,7 +84,7 @@ namespace TitaniumWindows
 
 		void Group::remove(const std::shared_ptr<Titanium::Contacts::Person>& person) TITANIUM_NOEXCEPT
 		{
-#if (WINVER >= 0x0A00)
+#if defined(IS_WINDOWS_10)
 			// Windows 10+ API!
 			if (contact_list__) {
 				std::shared_ptr<TitaniumWindows::Contacts::Person> win_person = std::dynamic_pointer_cast<::TitaniumWindows::Contacts::Person>(person);
@@ -107,8 +105,7 @@ namespace TitaniumWindows
 
 		JSValue Group::get_identifier() const TITANIUM_NOEXCEPT
 		{
-#if (WINVER >= 0x0A00)
-			// Windows 10+ API!
+#if defined(IS_WINDOWS_10)
 			if (contact_list__) {
 				return get_context().CreateString(TitaniumWindows::Utility::ConvertUTF8String(contact_list__->Id));
 			}
@@ -118,8 +115,7 @@ namespace TitaniumWindows
 
 		std::string Group::get_name() const TITANIUM_NOEXCEPT
 		{
-#if (WINVER >= 0x0A00)
-			// Windows 10+ API!
+#if defined(IS_WINDOWS_10)
 			if (contact_list__) {
 				return TitaniumWindows::Utility::ConvertUTF8String(contact_list__->DisplayName);
 			}
@@ -130,8 +126,7 @@ namespace TitaniumWindows
 		void Group::set_name(const std::string& name) TITANIUM_NOEXCEPT
 		{
 			Titanium::Contacts::Group::set_name(name);
-#if (WINVER >= 0x0A00)
-			// Windows 10+ API!
+#if defined(IS_WINDOWS_10)
 			if (contact_list__) {
 				contact_list__->DisplayName = TitaniumWindows::Utility::ConvertUTF8String(name);
 			}
@@ -148,8 +143,7 @@ namespace TitaniumWindows
 
 		void Group::removeList()
 		{
-#if (WINVER >= 0x0A00)
-			// Windows 10+ API!
+#if defined(IS_WINDOWS_10)
 			// Do we need to make this sync? I don't think we do...
 			if (contact_list__) {
 				contact_list__->DeleteAsync();

--- a/Source/Ti/src/Contacts/Person.cpp
+++ b/Source/Ti/src/Contacts/Person.cpp
@@ -330,7 +330,7 @@ namespace TitaniumWindows
 
 		std::string Person::get_fullName() const TITANIUM_NOEXCEPT
 		{
-#if (WINVER >= 0x0A00) 
+#if defined(IS_WINDOWS_10)
 			// Windows 10+
 			return TitaniumWindows::Utility::ConvertUTF8String(contact__->FullName);
 #else
@@ -479,8 +479,7 @@ namespace TitaniumWindows
 
 		std::string Person::get_nickname() const TITANIUM_NOEXCEPT
 		{
-#if (WINVER >= 0x0A00) 
-			// Windows 10+
+#if defined(IS_WINDOWS_10)
 			return TitaniumWindows::Utility::ConvertUTF8String(contact__->Nickname);
 #else
 			return Titanium::Contacts::Person::get_nickname();
@@ -490,8 +489,7 @@ namespace TitaniumWindows
 		void Person::set_nickname(const std::string& nickname) TITANIUM_NOEXCEPT
 		{
 			Titanium::Contacts::Person::set_nickname(nickname);
-#if (WINVER >= 0x0A00) 
-			// Windows 10+
+#if defined(IS_WINDOWS_10)
 			contact__->Nickname = TitaniumWindows::Utility::ConvertUTF8String(nickname);
 #else
 			TITANIUM_LOG_WARN("Person::set_nickname: Unimplemented");
@@ -570,8 +568,7 @@ namespace TitaniumWindows
 				} else {
 					// Ok we didn't populate the Description, or it's changed since...
 					switch (phone->Kind) {
-#if (WINVER >= 0x0A00) 
-					// Windows 10+ enum values
+#if defined(IS_WINDOWS_10)
 					case ContactPhoneKind::Pager:
 						phones.pager.push_back(number);
 						break;
@@ -625,8 +622,7 @@ namespace TitaniumWindows
 				contact__->Phones->Append(p);
 			}
 			for (auto ad : phones.pager) {
-#if (WINVER >= 0x0A00) 
-				// Windows 10+
+#if defined(IS_WINDOWS_10)
 				auto kind = ContactPhoneKind::Pager;
 #else
 				auto kind = ContactPhoneKind::Other;
@@ -635,8 +631,7 @@ namespace TitaniumWindows
 				contact__->Phones->Append(p);
 			}
 			for (auto ad : phones.workFax) {
-#if (WINVER >= 0x0A00) 
-				// Windows 10+
+#if defined(IS_WINDOWS_10)
 				auto kind = ContactPhoneKind::BusinessFax;
 #else
 				auto kind = ContactPhoneKind::Other;
@@ -645,8 +640,7 @@ namespace TitaniumWindows
 				contact__->Phones->Append(p);
 			}
 			for (auto ad : phones.homeFax) {
-#if (WINVER >= 0x0A00) 
-				// Windows 10+
+#if defined(IS_WINDOWS_10)
 				auto kind = ContactPhoneKind::HomeFax;
 #else
 				auto kind = ContactPhoneKind::Other;
@@ -655,7 +649,7 @@ namespace TitaniumWindows
 				contact__->Phones->Append(p);
 			}
 			for (auto ad : phones.main) {
-#if (WINVER >= 0x0A00) 
+#if defined(IS_WINDOWS_10)
 				// Windows 10+
 				auto kind = ContactPhoneKind::Company;
 #else
@@ -724,7 +718,7 @@ namespace TitaniumWindows
 					names.manager.push_back(name);
 				} else {
 
-#if (WINVER >= 0x0A00)
+#if defined(IS_WINDOWS_10)
 					// Windows 10+ enum values
 					// Ok we didn't populate the Description, or it's changed since...
 					switch (so->Relationship) {
@@ -815,8 +809,7 @@ namespace TitaniumWindows
 			other->Name = TitaniumWindows::Utility::ConvertUTF8String(name);
 			// store Titanium key in Description, since we actually lose info about relationship using Windows 10+ enum
 			other->Description = TitaniumWindows::Utility::ConvertUTF8String(type);
-#if (WINVER >= 0x0A00) 
-			// Windows 10+
+#if defined(IS_WINDOWS_10)
 			auto relationship = ContactRelationship::Other;
 			if (type == "spouse") {
 				relationship = ContactRelationship::Spouse;
@@ -940,7 +933,7 @@ namespace TitaniumWindows
 			return website;
 		}
 
-#if (WINVER >= 0x0A00) 
+#if defined(IS_WINDOWS_10)
 		Windows::ApplicationModel::Contacts::Contact^ Person::GetContact()
 		{
 			TITANIUM_LOG_WARN("Person::GetContact: Unimplemented");
@@ -950,8 +943,7 @@ namespace TitaniumWindows
 
 		void Person::remove()
 		{
-#if (WINVER >= 0x0A00) 
-			// Windows 10+
+#if defined(IS_WINDOWS_10)
 			auto list_id = contact__->ContactListId;
 			// Pull up the contact list associated with this contact...
 			ContactList^ result;
@@ -971,8 +963,7 @@ namespace TitaniumWindows
 #endif
 		}
 
-#if (WINVER >= 0x0A00) 
-// Windows 10+ API
+#if defined(IS_WINDOWS_10)
 		void Person::removeFromList(ContactList^ list)
 		{
 			list->DeleteContactAsync(contact__);

--- a/Source/Ti/src/DisplayCaps.cpp
+++ b/Source/Ti/src/DisplayCaps.cpp
@@ -37,7 +37,7 @@ namespace TitaniumWindows
 	{
 		auto display = Windows::Graphics::Display::DisplayInformation::GetForCurrentView();
 		if (display) {
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			return display->RawPixelsPerViewPixel;
 #else
 			return static_cast<int>(display->ResolutionScale) / 100.0;

--- a/Source/Ti/src/DisplayCaps.cpp
+++ b/Source/Ti/src/DisplayCaps.cpp
@@ -6,7 +6,6 @@
 
 #include "TitaniumWindows/DisplayCaps.hpp"
 #include "Titanium/detail/TiLogger.hpp"
-#include "TitaniumWindows/Utility.hpp"
 #include "TitaniumWindows/WindowsMacros.hpp"
 #include <iostream>
 #include <objbase.h>

--- a/Source/Ti/src/DisplayCaps.cpp
+++ b/Source/Ti/src/DisplayCaps.cpp
@@ -6,6 +6,8 @@
 
 #include "TitaniumWindows/DisplayCaps.hpp"
 #include "Titanium/detail/TiLogger.hpp"
+#include "TitaniumWindows/Utility.hpp"
+#include "TitaniumWindows/WindowsMacros.hpp"
 #include <iostream>
 #include <objbase.h>
 
@@ -36,7 +38,7 @@ namespace TitaniumWindows
 	{
 		auto display = Windows::Graphics::Display::DisplayInformation::GetForCurrentView();
 		if (display) {
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			return display->RawPixelsPerViewPixel;
 #else
 			return static_cast<int>(display->ResolutionScale) / 100.0;

--- a/Source/Ti/src/Platform.cpp
+++ b/Source/Ti/src/Platform.cpp
@@ -89,11 +89,11 @@ namespace TitaniumWindows
 	
 	std::uint64_t Platform::availableMemory() const TITANIUM_NOEXCEPT
 	{
-		if (TitaniumWindows::Utility::IsWindowsPhoneOrMobile()) {
-			return Windows::System::MemoryManager::AppMemoryUsageLimit - Windows::System::MemoryManager::AppMemoryUsage;
-		} else {
-			return 0;
-		}
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
+		return Windows::System::MemoryManager::AppMemoryUsageLimit - Windows::System::MemoryManager::AppMemoryUsage;
+#else
+		return 0;
+#endif
 	}
 
 	double Platform::batteryLevel() const TITANIUM_NOEXCEPT

--- a/Source/UI/include/TitaniumWindows/UI/AlertDialog.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/AlertDialog.hpp
@@ -11,6 +11,8 @@
 
 #include "TitaniumWindows_UI_EXPORT.h"
 #include "Titanium/UI/AlertDialog.hpp"
+#include "Titanium/detail/TiBase.hpp"
+#include "TitaniumWindows/WindowsMacros.hpp"
 #include <functional>
 #include <agile.h>
 
@@ -54,7 +56,7 @@ namespace TitaniumWindows
 			static std::vector<std::shared_ptr<AlertDialog>> dialog_queue__;
 			std::function<void(Windows::UI::Popups::IUICommand^)> on_click__;
 
-#if WINAPI_FAMILY==WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			static const std::uint32_t MaxButtonCount = 2;
 #else
 			static const std::uint32_t MaxButtonCount = 3;

--- a/Source/UI/include/TitaniumWindows/UI/EmailDialog.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/EmailDialog.hpp
@@ -50,7 +50,7 @@ namespace TitaniumWindows
 
 		private:
 
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			void setRecipients(const std::vector<std::string>& arg, Windows::Foundation::Collections::IVector<Windows::ApplicationModel::Email::EmailRecipient^>^ recipients);
 #endif
 

--- a/Source/UI/include/TitaniumWindows/UI/EmailDialog.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/EmailDialog.hpp
@@ -11,6 +11,8 @@
 
 #include "TitaniumWindows_UI_EXPORT.h"
 #include "Titanium/UI/EmailDialog.hpp"
+#include "Titanium/detail/TiBase.hpp"
+#include "TitaniumWindows/WindowsMacros.hpp"
 #include <Windows.h>
 
 namespace TitaniumWindows
@@ -48,7 +50,7 @@ namespace TitaniumWindows
 
 		private:
 
-#if WINAPI_FAMILY==WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			void setRecipients(const std::vector<std::string>& arg, Windows::Foundation::Collections::IVector<Windows::ApplicationModel::Email::EmailRecipient^>^ recipients);
 #endif
 

--- a/Source/UI/include/TitaniumWindows/UI/OptionDialog.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/OptionDialog.hpp
@@ -11,7 +11,8 @@
 
 #include "TitaniumWindows_UI_EXPORT.h"
 #include "Titanium/UI/OptionDialog.hpp"
-#include <Windows.h>
+#include "Titanium/detail/TiBase.hpp"
+#include "TitaniumWindows/WindowsMacros.hpp"
 
 namespace TitaniumWindows
 {
@@ -51,7 +52,7 @@ namespace TitaniumWindows
 
 			virtual void show(const Titanium::UI::OptionDialogShowParams& params) TITANIUM_NOEXCEPT override;
 
-#if WINAPI_FAMILY==WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			static const std::uint32_t MaxButtonCount = 2;
 #else
 			static const std::uint32_t MaxButtonCount = 3;

--- a/Source/UI/include/TitaniumWindows/UI/Tab.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/Tab.hpp
@@ -11,6 +11,8 @@
 
 #include "TitaniumWindows_UI_EXPORT.h"
 #include "Titanium/UI/Tab.hpp"
+#include "Titanium/detail/TiBase.hpp"
+#include "TitaniumWindows/WindowsMacros.hpp"
 
 namespace TitaniumWindows
 {
@@ -62,7 +64,7 @@ namespace TitaniumWindows
 			virtual void focus() override;
 
 		private:
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			Windows::UI::Xaml::Controls::PivotItem^ pivotItem__;
 #else
 			Windows::UI::Xaml::Controls::Grid^  grid__;

--- a/Source/UI/include/TitaniumWindows/UI/TabGroup.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/TabGroup.hpp
@@ -11,6 +11,8 @@
 
 #include "TitaniumWindows_UI_EXPORT.h"
 #include "Titanium/UI/TabGroup.hpp"
+#include "Titanium/detail/TiBase.hpp"
+#include "TitaniumWindows/WindowsMacros.hpp"
 #include <collection.h>
 
 namespace TitaniumWindows
@@ -80,7 +82,7 @@ namespace TitaniumWindows
 			std::shared_ptr<TitaniumWindows::UI::Window> window__;
 			Windows::UI::Xaml::Controls::Grid^  grid__;
 
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			Windows::UI::Xaml::Controls::Pivot^ pivot__;
 #else
 			//

--- a/Source/UI/src/EmailDialog.cpp
+++ b/Source/UI/src/EmailDialog.cpp
@@ -30,7 +30,7 @@ namespace TitaniumWindows
 
 		bool EmailDialog::isSupported() TITANIUM_NOEXCEPT
 		{
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			return true;
 #else
 			return false;
@@ -39,7 +39,7 @@ namespace TitaniumWindows
 
 		void EmailDialog::open(const bool& animated) TITANIUM_NOEXCEPT
 		{
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			Windows::ApplicationModel::Email::EmailMessage^ email_message = ref new Windows::ApplicationModel::Email::EmailMessage();
 
 			// Set up all the fields!
@@ -81,7 +81,7 @@ namespace TitaniumWindows
 
 		// Common code for getting/setting recipients on To/Bcc/Cc
 
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 		void EmailDialog::setRecipients(const std::vector<std::string>& arg, Windows::Foundation::Collections::IVector<Windows::ApplicationModel::Email::EmailRecipient^>^ recipients) {
 			// clear out an existing entries so we fully replace with new
 			recipients->Clear();

--- a/Source/UI/src/EmailDialog.cpp
+++ b/Source/UI/src/EmailDialog.cpp
@@ -9,6 +9,8 @@
 #include "TitaniumWindows/UI/EmailDialog.hpp"
 #include "TitaniumWindows/Utility.hpp"
 #include "Titanium/detail/TiLogger.hpp"
+#include "Titanium/detail/TiImpl.hpp"
+#include "TitaniumWindows/WindowsMacros.hpp"
 
 namespace TitaniumWindows
 {
@@ -28,7 +30,7 @@ namespace TitaniumWindows
 
 		bool EmailDialog::isSupported() TITANIUM_NOEXCEPT
 		{
-#if WINAPI_FAMILY==WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			return true;
 #else
 			return false;
@@ -37,7 +39,7 @@ namespace TitaniumWindows
 
 		void EmailDialog::open(const bool& animated) TITANIUM_NOEXCEPT
 		{
-#if WINAPI_FAMILY==WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			Windows::ApplicationModel::Email::EmailMessage^ email_message = ref new Windows::ApplicationModel::Email::EmailMessage();
 
 			// Set up all the fields!
@@ -79,7 +81,7 @@ namespace TitaniumWindows
 
 		// Common code for getting/setting recipients on To/Bcc/Cc
 
-#if WINAPI_FAMILY==WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 		void EmailDialog::setRecipients(const std::vector<std::string>& arg, Windows::Foundation::Collections::IVector<Windows::ApplicationModel::Email::EmailRecipient^>^ recipients) {
 			// clear out an existing entries so we fully replace with new
 			recipients->Clear();

--- a/Source/UI/src/Notification.cpp
+++ b/Source/UI/src/Notification.cpp
@@ -7,8 +7,9 @@
  */
 
 #include "TitaniumWindows/UI/Notification.hpp"
-#include "Titanium/detail/TiBase.hpp"
 #include "TitaniumWindows/Utility.hpp"
+#include "Titanium/detail/TiImpl.hpp"
+#include "TitaniumWindows/WindowsMacros.hpp"
 
 namespace TitaniumWindows
 {
@@ -33,7 +34,7 @@ namespace TitaniumWindows
 			// TODO Should we auto split the message so first line gets inserted in as first text node (bold) and any others get in the second?
 			textNodes->GetAt(0)->AppendChild(xml->CreateTextNode(TitaniumWindows::Utility::ConvertUTF8String(get_message())));
 			textNodes->GetAt(1)->AppendChild(xml->CreateTextNode(""));
-#if WINAPI_FAMILY != WINAPI_FAMILY_PHONE_APP
+#if !defined(IS_WINDOWS_PHONE)
 			// Specifying duration length is only supported on WinStore, phone always does short
 			auto toast_node = xml->SelectSingleNode("/toast");
 			auto attr = xml->CreateAttribute("duration");

--- a/Source/UI/src/Tab.cpp
+++ b/Source/UI/src/Tab.cpp
@@ -9,6 +9,8 @@
 #include "TitaniumWindows/UI/Tab.hpp"
 #include "TitaniumWindows/UI/Window.hpp"
 #include "TitaniumWindows/Utility.hpp"
+#include "Titanium/detail/TiImpl.hpp"
+#include "TitaniumWindows/WindowsMacros.hpp"
 
 namespace TitaniumWindows
 {
@@ -27,7 +29,7 @@ namespace TitaniumWindows
 		{
 			Titanium::UI::Tab::postCallAsConstructor(js_context, arguments);	
 
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			pivotItem__ = ref new PivotItem();
 
 			Titanium::UI::Tab::setLayoutDelegate<WindowsViewLayoutDelegate>();
@@ -42,7 +44,7 @@ namespace TitaniumWindows
 		void Tab::set_title(const std::string& title) TITANIUM_NOEXCEPT
 		{
 			Titanium::UI::Tab::set_title(title);
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			pivotItem__->Header = TitaniumWindows::Utility::ConvertUTF8String(title);
 #else
 
@@ -54,7 +56,7 @@ namespace TitaniumWindows
 			if (window != window__) {
 				const auto windows_window = dynamic_cast<TitaniumWindows::UI::Window*>(window.get());
 				const auto view = windows_window->getComponent();
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 				pivotItem__->Content = view;
 #else
 				if (grid__->Children->Size > 0) {

--- a/Source/UI/src/TabGroup.cpp
+++ b/Source/UI/src/TabGroup.cpp
@@ -11,6 +11,8 @@
 #include "TitaniumWindows/UI/Tab.hpp"
 #include "TitaniumWindows/UI/Window.hpp"
 #include "TitaniumWindows/Utility.hpp"
+#include "Titanium/detail/TiImpl.hpp"
+#include "TitaniumWindows/WindowsMacros.hpp"
 
 namespace TitaniumWindows
 {
@@ -35,7 +37,7 @@ namespace TitaniumWindows
 
 			grid__  = ref new Grid();
 
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			pivot__ = ref new Pivot();
 
 			pivot__->SelectionChanged += ref new SelectionChangedEventHandler([this](Platform::Object^ sender, SelectionChangedEventArgs^ e) {
@@ -109,7 +111,7 @@ namespace TitaniumWindows
 		{
 			Titanium::UI::TabGroup::set_barColor(value);
 			const auto brush = ref new Media::SolidColorBrush(WindowsViewLayoutDelegate::ColorForName(value));
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			pivot__->Background = brush;
 #else
 			sectionView__->Background = brush;
@@ -125,7 +127,7 @@ namespace TitaniumWindows
 		{
 			if (updateUI && activeTab != activeTab__) {
 				const auto tabview = activeTab->getViewLayoutDelegate<WindowsViewLayoutDelegate>()->getComponent();
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 				pivot__->SelectedItem = tabview;
 #else
 				if (grid__->Children->Size > 1) {
@@ -155,7 +157,7 @@ namespace TitaniumWindows
 		void TabGroup::set_tabs(const std::vector<std::shared_ptr<Titanium::UI::Tab>>& tabs) TITANIUM_NOEXCEPT
 		{
 			Titanium::UI::TabGroup::set_tabs(tabs);
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			pivot__->Items->Clear();
 #else
 			sectionViewItems__->Clear();
@@ -176,7 +178,7 @@ namespace TitaniumWindows
 			const auto windows_tab = dynamic_cast<TitaniumWindows::UI::Tab*>(tab.get());
 			const auto tabview = windows_tab->getViewLayoutDelegate<WindowsViewLayoutDelegate>()->getComponent();
 			if (windows_tab) {
-#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 				pivot__->Items->Append(tabview);
 #else
 				sectionViewItems__->Append(Utility::ConvertUTF8String(windows_tab->get_title()));

--- a/Source/UI/src/Window.cpp
+++ b/Source/UI/src/Window.cpp
@@ -20,11 +20,7 @@ namespace TitaniumWindows
 {
 	namespace UI
 	{
-
-#if defined(IS_WINDOWS_PHONE)
 		using namespace Windows::Foundation;
-		using namespace Windows::Phone::UI::Input;
-#endif
 
 		std::vector<std::shared_ptr<Window>> Window::window_stack__;
 
@@ -47,6 +43,8 @@ namespace TitaniumWindows
 			getViewLayoutDelegate<WindowsViewLayoutDelegate>()->setComponent(canvas__);
 
 #if defined(IS_WINDOWS_PHONE)
+			using namespace Windows::Phone::UI::Input;
+
 			backpressed_event__ = HardwareButtons::BackPressed += ref new EventHandler<BackPressedEventArgs^>([this](Platform::Object ^sender, BackPressedEventArgs ^e) {
 				if (is_window_event_active__) {
 					// close current window when there's no back button listener
@@ -64,7 +62,7 @@ namespace TitaniumWindows
 		Window::~Window() 
 		{
 #if defined(IS_WINDOWS_PHONE)
-			HardwareButtons::BackPressed -= backpressed_event__;
+			Windows::Phone::UI::Input::HardwareButtons::BackPressed -= backpressed_event__;
 #endif
 		}
 
@@ -255,6 +253,8 @@ namespace TitaniumWindows
 #if defined(IS_WINDOWS_PHONE)
 			auto statusBar = Windows::UI::ViewManagement::StatusBar::GetForCurrentView();
 			fullscreen ? statusBar->HideAsync() : statusBar->ShowAsync();
+#elif defined(IS_WINDOWS_10)
+			TITANIUM_LOG_WARN("set_fullscreen is not implemented on Windows 10");
 #endif
 		}
 

--- a/Source/UI/src/Window.cpp
+++ b/Source/UI/src/Window.cpp
@@ -13,6 +13,7 @@
 #include "Titanium/App.hpp"
 #include "Titanium/detail/TiImpl.hpp"
 #include "Titanium/UIModule.hpp"
+#include "TitaniumWindows/WindowsMacros.hpp"
 #include <windows.h>
 
 namespace TitaniumWindows
@@ -20,7 +21,7 @@ namespace TitaniumWindows
 	namespace UI
 	{
 
-#if WINAPI_FAMILY==WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 		using namespace Windows::Foundation;
 		using namespace Windows::Phone::UI::Input;
 #endif
@@ -45,7 +46,7 @@ namespace TitaniumWindows
 
 			getViewLayoutDelegate<WindowsViewLayoutDelegate>()->setComponent(canvas__);
 
-#if WINAPI_FAMILY==WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			backpressed_event__ = HardwareButtons::BackPressed += ref new EventHandler<BackPressedEventArgs^>([this](Platform::Object ^sender, BackPressedEventArgs ^e) {
 				if (is_window_event_active__) {
 					// close current window when there's no back button listener
@@ -62,7 +63,7 @@ namespace TitaniumWindows
 
 		Window::~Window() 
 		{
-#if WINAPI_FAMILY==WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			HardwareButtons::BackPressed -= backpressed_event__;
 #endif
 		}
@@ -251,7 +252,7 @@ namespace TitaniumWindows
 		void Window::set_fullscreen(const bool& fullscreen) TITANIUM_NOEXCEPT
 		{
 			Titanium::UI::Window::set_fullscreen(fullscreen);
-#if WINAPI_FAMILY==WINAPI_FAMILY_PHONE_APP
+#if defined(IS_WINDOWS_PHONE)
 			auto statusBar = Windows::UI::ViewManagement::StatusBar::GetForCurrentView();
 			fullscreen ? statusBar->HideAsync() : statusBar->ShowAsync();
 #endif

--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -1328,24 +1328,24 @@ namespace TitaniumWindows
 
 			auto info = Windows::Graphics::Display::DisplayInformation::GetForCurrentView();
 			double ppi = info->LogicalDpi;
-			if (TitaniumWindows::Utility::IsWindowsPhoneOrMobile()) {
-				switch (name) {
-				case Titanium::LayoutEngine::ValueName::CenterX:
-				case Titanium::LayoutEngine::ValueName::Left:
-				case Titanium::LayoutEngine::ValueName::Right:
-				case Titanium::LayoutEngine::ValueName::Width:
-				case Titanium::LayoutEngine::ValueName::MinWidth:
-					ppi = info->RawDpiX / info->RawPixelsPerViewPixel;
-					break;
-				case Titanium::LayoutEngine::ValueName::CenterY:
-				case Titanium::LayoutEngine::ValueName::Top:
-				case Titanium::LayoutEngine::ValueName::Bottom:
-				case Titanium::LayoutEngine::ValueName::Height:
-				case Titanium::LayoutEngine::ValueName::MinHeight:
-					ppi = info->RawDpiY / info->RawPixelsPerViewPixel;
-					break;
-				}
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
+			switch (name) {
+			case Titanium::LayoutEngine::ValueName::CenterX:
+			case Titanium::LayoutEngine::ValueName::Left:
+			case Titanium::LayoutEngine::ValueName::Right:
+			case Titanium::LayoutEngine::ValueName::Width:
+			case Titanium::LayoutEngine::ValueName::MinWidth:
+				ppi = info->RawDpiX / info->RawPixelsPerViewPixel;
+				break;
+			case Titanium::LayoutEngine::ValueName::CenterY:
+			case Titanium::LayoutEngine::ValueName::Top:
+			case Titanium::LayoutEngine::ValueName::Bottom:
+			case Titanium::LayoutEngine::ValueName::Height:
+			case Titanium::LayoutEngine::ValueName::MinHeight:
+				ppi = info->RawDpiY / info->RawPixelsPerViewPixel;
+				break;
 			}
+#endif
 
 			// Get the defaultUnits from ti.ui.defaultUnit!
 			std::string defaultUnits = "px";

--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -22,6 +22,7 @@
 
 #include "TitaniumWindows/UI/View.hpp"
 #include "TitaniumWindows/Utility.hpp"
+#include "TitaniumWindows/WindowsMacros.hpp"
 
 #define _USE_MATH_DEFINES
 #include <math.h>
@@ -1320,14 +1321,15 @@ namespace TitaniumWindows
 
 			if (prop.value == Titanium::UI::Constants::to_string(Titanium::UI::LAYOUT::SIZE)) {
 				prop.value = "UI.SIZE";
-			} else if (prop.value == Titanium::UI::Constants::to_string(Titanium::UI::LAYOUT::FILL)) {
+			}
+			else if (prop.value == Titanium::UI::Constants::to_string(Titanium::UI::LAYOUT::FILL)) {
 				prop.value = "UI.FILL";
 			}
 
 			auto info = Windows::Graphics::Display::DisplayInformation::GetForCurrentView();
 			double ppi = info->LogicalDpi;
-#if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP)
-			switch (name) {
+			if (TitaniumWindows::Utility::IsWindowsPhoneOrMobile()) {
+				switch (name) {
 				case Titanium::LayoutEngine::ValueName::CenterX:
 				case Titanium::LayoutEngine::ValueName::Left:
 				case Titanium::LayoutEngine::ValueName::Right:
@@ -1342,8 +1344,9 @@ namespace TitaniumWindows
 				case Titanium::LayoutEngine::ValueName::MinHeight:
 					ppi = info->RawDpiY / info->RawPixelsPerViewPixel;
 					break;
+				}
 			}
-#endif
+
 			// Get the defaultUnits from ti.ui.defaultUnit!
 			std::string defaultUnits = "px";
 			auto event_delegate = event_delegate__.lock();

--- a/Source/Utility/CMakeLists.txt
+++ b/Source/Utility/CMakeLists.txt
@@ -46,6 +46,7 @@ endif()
 set(SOURCE_Utility
   include/TitaniumWindows/Utility.hpp
   src/Utility.cpp
+  include/TitaniumWindows/WindowsMacros.hpp
   )
 
 source_group(Titanium\\Utility FILES ${SOURCE_Utility})

--- a/Source/Utility/include/TitaniumWindows/Utility.hpp
+++ b/Source/Utility/include/TitaniumWindows/Utility.hpp
@@ -169,6 +169,11 @@ namespace TitaniumWindows
 		//
 		TITANIUMWINDOWS_UTILITY_EXPORT Titanium::ErrorResponse GetTiErrorResponse(::Platform::COMException^ e);
 
+		//
+		// Check if Titanium is running on Windws Phone
+		//
+		TITANIUMWINDOWS_UTILITY_EXPORT bool IsWindowsPhoneOrMobile();
+
 	}  // namespace Utility
 }  // namespace TitaniumWindows
 

--- a/Source/Utility/include/TitaniumWindows/WindowsMacros.hpp
+++ b/Source/Utility/include/TitaniumWindows/WindowsMacros.hpp
@@ -1,0 +1,28 @@
+/**
+ * Windows specific macros
+ *
+ * Copyright (c) 2015 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License.
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#ifndef _TITANIUMWINDOWS_WINDOWSMACROS_HPP_
+#define _TITANIUMWINDOWS_WINDOWSMACROS_HPP_
+
+#include <sdkddkver.h>
+
+/* 
+  - IS_WINDOWS_10     ... Windows 10
+  - IS_WINDOWS_MOBILE ... Windows 10 Mobile
+  - IS_WINDOWS_PHONE  ... Windows Phone
+*/
+#if (WINVER >= 0x0A00)
+#define IS_WINDOWS_10
+#define IS_WINDOWS_MOBILE (Windows::System::Profile::AnalyticsInfo::VersionInfo->DeviceFamily == "Windows.Mobile")
+#else
+#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#define IS_WINDOWS_PHONE
+#endif
+#endif
+
+#endif  // _TITANIUMWINDOWS_WINDOWSMACROS_HPP_

--- a/Source/Utility/src/Utility.cpp
+++ b/Source/Utility/src/Utility.cpp
@@ -11,6 +11,7 @@
 #include "HAL/HAL.hpp"
 #include <boost/algorithm/string/predicate.hpp>
 #include "Titanium/detail/TiImpl.hpp"
+#include "TitaniumWindows/WindowsMacros.hpp"
 #include <ctime>
 #include <concrt.h>
 
@@ -314,5 +315,15 @@ namespace TitaniumWindows
 			return response;
 		}
 
+		bool IsWindowsPhoneOrMobile()
+		{
+#if defined(IS_WINDOWS_10)
+			return IS_WINDOWS_MOBILE;
+#elif defined(IS_WINDOWS_PHONE)
+			return true;
+#else
+			return false;
+#endif
+		}
 	}  // namespace Utility
 }  // namespace TitaniumWindows


### PR DESCRIPTION
Fix for [TIMOB-20064](https://jira.appcelerator.org/browse/TIMOB-20064)

Add platform-specific (store or phone only) guard macros

## Definitions
```
#if (WINVER >= 0x0A00)
#define IS_WINDOWS_10
#define IS_WINDOWS_MOBILE (Windows::System::Profile::AnalyticsInfo::VersionInfo->DeviceFamily == "Windows.Mobile")
#else
#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
#define IS_WINDOWS_PHONE
#endif
#endif
```

## Usage
- `IS_WINDOWS_10`     ... Windows 10
- `IS_WINDOWS_MOBILE` ... Windows 10 Mobile
- `IS_WINDOWS_PHONE`  ... Windows Phone
- `TitaniumWindows::Utility::IsWindowsPhoneOrMobile()` ... Windows 10 Mobile or Windows 8.1 Phone

`#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP` -> `#if defined(IS_WINDOWS_PHONE)`
`#if (WINVER >= 0x0A00)` -> `#if defined(IS_WINDOWS_10)`

