### PR TITLE
TIMOB-20158 Windows: Update generate_project.js script to handle Windows 10 appxmanifest

### DIFF
--- a/Examples/Corporate/CMakeLists.txt
+++ b/Examples/Corporate/CMakeLists.txt
@@ -5,7 +5,9 @@
 # Please see the LICENSE included with this distribution for details.
 cmake_minimum_required(VERSION 3.0.0)
 
-if(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsPhone")
+if (${CMAKE_SYSTEM_VERSION} STREQUAL "10.0")
+  set(PLATFORM win10)
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsPhone")
   set(PLATFORM wp)
   add_definitions("-DPHONE")
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsStore")
@@ -94,6 +96,11 @@ set(EXE_NAME ${PROJECT_NAME})
 set(APP_MANIFEST_NAME Package.appxmanifest)
 set(SHORT_NAME ${EXE_NAME})
 set(PACKAGE_GUID "f0473be1-c557-4f98-a103-4ba9f453b5b0")
+set(PUBLISHER_ID "CN=appcelerator")
+set(PUBLISHER_DISPLAY_NAME "Appcelerator")
+set(PHONE_PRODUCT_ID "f0473be1-c557-4f98-a103-4ba9f453b5b0")
+set(PHONE_PUBLISHER_ID "00000000-0000-0000-0000-000000000000")
+set(VERSION "1.1.0.0")
 
 # Generate the app manifest.
 configure_file(
@@ -138,7 +145,7 @@ set(SOURCE_alloy
       "src/Assets/alloy/underscore.js"
       "src/Assets/alloy/widget.js"
   )
-source_group("alloy" FILES 
+source_group("alloy" FILES
       "src/Assets/alloy/backbone.js"
       "src/Assets/alloy/CFG.js"
       "src/Assets/alloy/constants.js"
@@ -156,7 +163,7 @@ set(SOURCE_alloy_controllers
       "src/Assets/alloy/controllers/loader.js"
       "src/Assets/alloy/controllers/profile.js"
   )
-source_group("alloy/controllers" FILES 
+source_group("alloy/controllers" FILES
       "src/Assets/alloy/controllers/annotation.js"
       "src/Assets/alloy/controllers/BaseController.js"
       "src/Assets/alloy/controllers/directory.js"
@@ -170,7 +177,7 @@ set_property(SOURCE ${SOURCE_alloy_controllers} PROPERTY VS_DEPLOYMENT_CONTENT 1
 #set(SOURCE_alloy_models
 #      "src/Assets/alloy/models/Users.js"
 #  )
-#source_group("alloy/models" FILES 
+#source_group("alloy/models" FILES
 #      "src/Assets/alloy/models/Users.js"
 #  )
 #set_property(SOURCE ${SOURCE_alloy_models} PROPERTY VS_DEPLOYMENT_LOCATION "alloy\\models")
@@ -183,7 +190,7 @@ set(SOURCE_alloy_styles
       "src/Assets/alloy/styles/loader.js"
       "src/Assets/alloy/styles/profile.js"
   )
-source_group("alloy/styles" FILES 
+source_group("alloy/styles" FILES
       "src/Assets/alloy/styles/annotation.js"
       "src/Assets/alloy/styles/directory.js"
       "src/Assets/alloy/styles/index.js"
@@ -198,7 +205,7 @@ set(SOURCE_alloy_sync
       "src/Assets/alloy/sync/properties.js"
       "src/Assets/alloy/sync/sql.js"
   )
-source_group("alloy/sync" FILES 
+source_group("alloy/sync" FILES
       "src/Assets/alloy/sync/localStorage.js"
       "src/Assets/alloy/sync/properties.js"
       "src/Assets/alloy/sync/sql.js"
@@ -210,7 +217,7 @@ set(SOURCE_fonts
       "src/Assets/fonts/icomoon.ttf"
       "src/Assets/fonts/icomoon.woff"
   )
-source_group("fonts" FILES 
+source_group("fonts" FILES
       "src/Assets/fonts/icomoon.ttf"
       "src/Assets/fonts/icomoon.woff"
   )
@@ -244,7 +251,7 @@ set(SOURCE_images_RocketFlight
       "src/Assets/images/RocketFlight/RocketFlight24.png"
       "src/Assets/images/RocketFlight/RocketFlight25.png"
   )
-source_group("images/RocketFlight" FILES 
+source_group("images/RocketFlight" FILES
       "src/Assets/images/RocketFlight/RocketFlight01.png"
       "src/Assets/images/RocketFlight/RocketFlight02.png"
       "src/Assets/images/RocketFlight/RocketFlight03.png"
@@ -313,7 +320,7 @@ set(SOURCE_images_RocketSmoke
       "src/Assets/images/RocketSmoke/RocketSmoke36.png"
       "src/Assets/images/RocketSmoke/RocketSmoke37.png"
   )
-source_group("images/RocketSmoke" FILES 
+source_group("images/RocketSmoke" FILES
       "src/Assets/images/RocketSmoke/RocketSmoke01.png"
       "src/Assets/images/RocketSmoke/RocketSmoke02.png"
       "src/Assets/images/RocketSmoke/RocketSmoke03.png"
@@ -358,7 +365,7 @@ set_property(SOURCE ${SOURCE_images_RocketSmoke} PROPERTY VS_DEPLOYMENT_CONTENT 
 set(SOURCE_userData
       "src/Assets/userData/data.json"
   )
-source_group("userData" FILES 
+source_group("userData" FILES
       "src/Assets/userData/data.json"
   )
 set_property(SOURCE ${SOURCE_userData} PROPERTY VS_DEPLOYMENT_LOCATION "userData")

--- a/Examples/Corporate/src/Package.win10.appxmanifest.in
+++ b/Examples/Corporate/src/Package.win10.appxmanifest.in
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  IgnorableNamespaces="uap mp">
+
+  <Identity
+    Name="@PACKAGE_GUID@"
+    Publisher="@PUBLISHER_ID@"
+    Version="@VERSION@" />
+
+  <mp:PhoneIdentity PhoneProductId="@PHONE_PRODUCT_ID@" PhonePublisherId="@PHONE_PUBLISHER_ID@"/>
+
+  <Properties>
+    <DisplayName>@SHORT_NAME@</DisplayName>
+    <PublisherDisplayName>@PUBLISHER_DISPLAY_NAME@</PublisherDisplayName>
+    <Logo>StoreLogo.png</Logo>
+  </Properties>
+
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.0.0" MaxVersionTested="10.0.0.0" />
+  </Dependencies>
+
+  <Resources>
+    <Resource Language="x-generate" />
+  </Resources>
+
+  <Applications>
+    <Application Id="App"
+      Executable="$targetnametoken$.exe"
+      EntryPoint="@SHORT_NAME@.App">
+      <uap:VisualElements
+        DisplayName="@SHORT_NAME@"
+        Square150x150Logo="Square150x150Logo.png"
+        Square44x44Logo="Square44x44Logo.png"
+        Description="@SHORT_NAME@"
+        BackgroundColor="transparent">
+        <uap:DefaultTile Square71x71Logo="Square71x71Logo.png"/>
+        <uap:SplashScreen Image="SplashScreen.png" />
+      </uap:VisualElements>
+
+    </Application>
+  </Applications>
+
+  <Capabilities>
+	<Capability Name="internetClient" />
+  </Capabilities>
+</Package>

--- a/Examples/Geocoder/CMakeLists.txt
+++ b/Examples/Geocoder/CMakeLists.txt
@@ -5,7 +5,9 @@
 # Please see the LICENSE included with this distribution for details.
 cmake_minimum_required(VERSION 3.0.0)
 
-if(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsPhone")
+if (${CMAKE_SYSTEM_VERSION} STREQUAL "10.0")
+  set(PLATFORM win10)
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsPhone")
   set(PLATFORM wp)
   add_definitions("-DPHONE")
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsStore")
@@ -88,6 +90,11 @@ set(EXE_NAME ${PROJECT_NAME})
 set(APP_MANIFEST_NAME Package.appxmanifest)
 set(SHORT_NAME ${EXE_NAME})
 set(PACKAGE_GUID "f0473be1-c557-4f98-a103-4ba9f453b5b0")
+set(PUBLISHER_ID "CN=appcelerator")
+set(PUBLISHER_DISPLAY_NAME "Appcelerator")
+set(PHONE_PRODUCT_ID "f0473be1-c557-4f98-a103-4ba9f453b5b0")
+set(PHONE_PUBLISHER_ID "00000000-0000-0000-0000-000000000000")
+set(VERSION "1.1.0.0")
 
 configure_file(
   src/Package.${PLATFORM}.appxmanifest.in

--- a/Examples/Geocoder/src/Package.win10.appxmanifest.in
+++ b/Examples/Geocoder/src/Package.win10.appxmanifest.in
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  IgnorableNamespaces="uap mp">
+
+  <Identity
+    Name="@PACKAGE_GUID@"
+    Publisher="@PUBLISHER_ID@"
+    Version="@VERSION@" />
+
+  <mp:PhoneIdentity PhoneProductId="@PHONE_PRODUCT_ID@" PhonePublisherId="@PHONE_PUBLISHER_ID@"/>
+
+  <Properties>
+    <DisplayName>@SHORT_NAME@</DisplayName>
+    <PublisherDisplayName>@PUBLISHER_DISPLAY_NAME@</PublisherDisplayName>
+    <Logo>StoreLogo.png</Logo>
+  </Properties>
+
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.0.0" MaxVersionTested="10.0.0.0" />
+  </Dependencies>
+
+  <Resources>
+    <Resource Language="x-generate" />
+  </Resources>
+
+  <Applications>
+    <Application Id="App"
+      Executable="$targetnametoken$.exe"
+      EntryPoint="@SHORT_NAME@.App">
+      <uap:VisualElements
+        DisplayName="@SHORT_NAME@"
+        Square150x150Logo="Square150x150Logo.png"
+        Square44x44Logo="Square44x44Logo.png"
+        Description="@SHORT_NAME@"
+        BackgroundColor="transparent">
+        <uap:DefaultTile Square71x71Logo="Square71x71Logo.png"/>
+        <uap:SplashScreen Image="SplashScreen.png" />
+      </uap:VisualElements>
+
+    </Application>
+  </Applications>
+
+  <Capabilities>
+	<Capability Name="internetClient" />
+  </Capabilities>
+</Package>

--- a/Examples/Movies/CMakeLists.txt
+++ b/Examples/Movies/CMakeLists.txt
@@ -5,7 +5,9 @@
 # Please see the LICENSE included with this distribution for details.
 cmake_minimum_required(VERSION 3.0.0)
 
-if(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsPhone")
+if (${CMAKE_SYSTEM_VERSION} STREQUAL "10.0")
+  set(PLATFORM win10)
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsPhone")
   set(PLATFORM wp)
   add_definitions("-DPHONE")
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsStore")
@@ -94,6 +96,11 @@ set(EXE_NAME ${PROJECT_NAME})
 set(APP_MANIFEST_NAME Package.appxmanifest)
 set(SHORT_NAME ${EXE_NAME})
 set(PACKAGE_GUID "f0473be1-c557-4f98-a103-4ba9f453b5b0")
+set(PUBLISHER_ID "CN=appcelerator")
+set(PUBLISHER_DISPLAY_NAME "Appcelerator")
+set(PHONE_PRODUCT_ID "f0473be1-c557-4f98-a103-4ba9f453b5b0")
+set(PHONE_PUBLISHER_ID "00000000-0000-0000-0000-000000000000")
+set(VERSION "1.1.0.0")
 
 # Generate the app manifest.
 configure_file(
@@ -133,7 +140,7 @@ set(SOURCE_alloy
       "src/Assets/alloy/underscore.js"
       "src/Assets/alloy/widget.js"
   )
-source_group("alloy" FILES 
+source_group("alloy" FILES
       "src/Assets/alloy/animation.js"
       "src/Assets/alloy/backbone.js"
       "src/Assets/alloy/CFG.js"
@@ -154,7 +161,7 @@ set(SOURCE_alloy_controllers
       "src/Assets/alloy/controllers/movies_list.js"
       "src/Assets/alloy/controllers/settings.js"
   )
-source_group("alloy/controllers" FILES 
+source_group("alloy/controllers" FILES
       "src/Assets/alloy/controllers/BaseController.js"
       "src/Assets/alloy/controllers/about.js"
       "src/Assets/alloy/controllers/home.js"
@@ -173,7 +180,7 @@ set(SOURCE_alloy_controllers_views
       "src/Assets/alloy/controllers/views/movies_list_cell.js"
       "src/Assets/alloy/controllers/views/navbar.js"
   )
-source_group("alloy/controllers/views" FILES 
+source_group("alloy/controllers/views" FILES
       "src/Assets/alloy/controllers/views/list_cell.js"
       "src/Assets/alloy/controllers/views/list_static_cell.js"
       "src/Assets/alloy/controllers/views/movies_list_cell.js"
@@ -191,7 +198,7 @@ set(SOURCE_alloy_styles
       "src/Assets/alloy/styles/movies_list.js"
       "src/Assets/alloy/styles/settings.js"
   )
-source_group("alloy/styles" FILES 
+source_group("alloy/styles" FILES
       "src/Assets/alloy/styles/about.js"
       "src/Assets/alloy/styles/home.js"
       "src/Assets/alloy/styles/index.js"
@@ -209,7 +216,7 @@ set(SOURCE_alloy_styles_views
       "src/Assets/alloy/styles/views/movies_list_cell.js"
       "src/Assets/alloy/styles/views/navbar.js"
   )
-source_group("alloy/styles/views" FILES 
+source_group("alloy/styles/views" FILES
       "src/Assets/alloy/styles/views/list_cell.js"
       "src/Assets/alloy/styles/views/list_static_cell.js"
       "src/Assets/alloy/styles/views/movies_list_cell.js"
@@ -223,7 +230,7 @@ set(SOURCE_alloy_sync
       "src/Assets/alloy/sync/properties.js"
       "src/Assets/alloy/sync/sql.js"
   )
-source_group("alloy/sync" FILES 
+source_group("alloy/sync" FILES
       "src/Assets/alloy/sync/localStorage.js"
       "src/Assets/alloy/sync/properties.js"
       "src/Assets/alloy/sync/sql.js"
@@ -239,7 +246,7 @@ set(SOURCE_data
       "src/Assets/data/lists.json"
       "src/Assets/data/movie.json"
   )
-source_group("data" FILES 
+source_group("data" FILES
       "src/Assets/data/config.json"
       "src/Assets/data/genre.json"
       "src/Assets/data/genres.json"
@@ -253,7 +260,7 @@ set_property(SOURCE ${SOURCE_data} PROPERTY VS_DEPLOYMENT_CONTENT 1)
 set(SOURCE_fonts
       "src/Assets/fonts/FontAwesome.otf"
   )
-source_group("fonts" FILES 
+source_group("fonts" FILES
       "src/Assets/fonts/FontAwesome.otf"
   )
 set_property(SOURCE ${SOURCE_fonts} PROPERTY VS_DEPLOYMENT_LOCATION "fonts")
@@ -264,7 +271,7 @@ set(SOURCE_tests
       "src/Assets/tests/tests_runner.js"
       "src/Assets/tests/ti-mocha.js"
   )
-source_group("tests" FILES 
+source_group("tests" FILES
       "src/Assets/tests/should.js"
       "src/Assets/tests/tests_runner.js"
       "src/Assets/tests/ti-mocha.js"
@@ -275,7 +282,7 @@ set_property(SOURCE ${SOURCE_tests} PROPERTY VS_DEPLOYMENT_CONTENT 1)
 set(SOURCE_tests_specs
       "src/Assets/tests/specs/app_tests.js"
   )
-source_group("tests/specs" FILES 
+source_group("tests/specs" FILES
       "src/Assets/tests/specs/app_tests.js"
   )
 set_property(SOURCE ${SOURCE_tests_specs} PROPERTY VS_DEPLOYMENT_LOCATION "tests\\specs")

--- a/Examples/Movies/src/Package.win10.appxmanifest.in
+++ b/Examples/Movies/src/Package.win10.appxmanifest.in
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  IgnorableNamespaces="uap mp">
+
+  <Identity
+    Name="@PACKAGE_GUID@"
+    Publisher="@PUBLISHER_ID@"
+    Version="@VERSION@" />
+
+  <mp:PhoneIdentity PhoneProductId="@PHONE_PRODUCT_ID@" PhonePublisherId="@PHONE_PUBLISHER_ID@"/>
+
+  <Properties>
+    <DisplayName>@SHORT_NAME@</DisplayName>
+    <PublisherDisplayName>@PUBLISHER_DISPLAY_NAME@</PublisherDisplayName>
+    <Logo>StoreLogo.png</Logo>
+  </Properties>
+
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.0.0" MaxVersionTested="10.0.0.0" />
+  </Dependencies>
+
+  <Resources>
+    <Resource Language="x-generate" />
+  </Resources>
+
+  <Applications>
+    <Application Id="App"
+      Executable="$targetnametoken$.exe"
+      EntryPoint="@SHORT_NAME@.App">
+      <uap:VisualElements
+        DisplayName="@SHORT_NAME@"
+        Square150x150Logo="Square150x150Logo.png"
+        Square44x44Logo="Square44x44Logo.png"
+        Description="@SHORT_NAME@"
+        BackgroundColor="transparent">
+        <uap:DefaultTile Square71x71Logo="Square71x71Logo.png"/>
+        <uap:SplashScreen Image="SplashScreen.png" />
+      </uap:VisualElements>
+
+    </Application>
+  </Applications>
+
+  <Capabilities>
+	<Capability Name="internetClient" />
+  </Capabilities>
+</Package>

--- a/Examples/NG/CMakeLists.txt
+++ b/Examples/NG/CMakeLists.txt
@@ -5,7 +5,9 @@
 # Please see the LICENSE included with this distribution for details.
 cmake_minimum_required(VERSION 3.0.0)
 
-if(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsPhone")
+if (${CMAKE_SYSTEM_VERSION} STREQUAL "10.0")
+  set(PLATFORM win10)
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsPhone")
   set(PLATFORM wp)
   add_definitions("-DPHONE")
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsStore")
@@ -99,19 +101,17 @@ set(EXE_NAME ${PROJECT_NAME})
 set(APP_MANIFEST_NAME Package.appxmanifest)
 set(SHORT_NAME ${EXE_NAME})
 set(PACKAGE_GUID "f0473be1-c557-4f98-a103-4ba9f453b5b0")
+set(PUBLISHER_ID "CN=appcelerator")
+set(PUBLISHER_DISPLAY_NAME "Appcelerator")
+set(PHONE_PRODUCT_ID "f0473be1-c557-4f98-a103-4ba9f453b5b0")
+set(PHONE_PUBLISHER_ID "00000000-0000-0000-0000-000000000000")
+set(VERSION "1.1.0.0")
 
 # Generate the app manifest.
-if(${CMAKE_SYSTEM_VERSION} STREQUAL "10.0")
-configure_file(
-  src/Package.win10.appxmanifest.in
-  ${CMAKE_CURRENT_BINARY_DIR}/${APP_MANIFEST_NAME}
-  @ONLY)
-else()
 configure_file(
   src/Package.${PLATFORM}.appxmanifest.in
   ${CMAKE_CURRENT_BINARY_DIR}/${APP_MANIFEST_NAME}
   @ONLY)
-endif()
 
 set(SOURCE_Assets
   ${CMAKE_CURRENT_BINARY_DIR}/${APP_MANIFEST_NAME}
@@ -134,7 +134,7 @@ set(SOURCE_fonts
       "src/Assets/fonts/icomoon.ttf"
       "src/Assets/fonts/icomoon.woff"
   )
-source_group("fonts" FILES 
+source_group("fonts" FILES
       "src/Assets/fonts/icomoon.ttf"
       "src/Assets/fonts/icomoon.woff"
   )

--- a/Examples/NMocha/CMakeLists.txt
+++ b/Examples/NMocha/CMakeLists.txt
@@ -3,7 +3,9 @@
 # Please see the LICENSE included with this distribution for details.
 cmake_minimum_required(VERSION 3.0.0)
 
-if(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsPhone")
+if (${CMAKE_SYSTEM_VERSION} STREQUAL "10.0")
+  set(PLATFORM win10)
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsPhone")
   set(PLATFORM wp)
   add_definitions("-DPHONE")
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsStore")
@@ -92,6 +94,11 @@ set(EXE_NAME ${PROJECT_NAME})
 set(APP_MANIFEST_NAME Package.appxmanifest)
 set(SHORT_NAME ${EXE_NAME})
 set(PACKAGE_GUID "f0473be1-c557-4f98-a103-4ba9f453b5b0")
+set(PUBLISHER_ID "CN=appcelerator")
+set(PUBLISHER_DISPLAY_NAME "Appcelerator")
+set(PHONE_PRODUCT_ID "f0473be1-c557-4f98-a103-4ba9f453b5b0")
+set(PHONE_PUBLISHER_ID "00000000-0000-0000-0000-000000000000")
+set(VERSION "1.1.0.0")
 
 # Generate the app manifest.
 configure_file(

--- a/Examples/NMocha/src/Package.win10.appxmanifest.in
+++ b/Examples/NMocha/src/Package.win10.appxmanifest.in
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  IgnorableNamespaces="uap mp">
+
+  <Identity
+    Name="@PACKAGE_GUID@"
+    Publisher="@PUBLISHER_ID@"
+    Version="@VERSION@" />
+
+  <mp:PhoneIdentity PhoneProductId="@PHONE_PRODUCT_ID@" PhonePublisherId="@PHONE_PUBLISHER_ID@"/>
+
+  <Properties>
+    <DisplayName>@SHORT_NAME@</DisplayName>
+    <PublisherDisplayName>@PUBLISHER_DISPLAY_NAME@</PublisherDisplayName>
+    <Logo>StoreLogo.png</Logo>
+  </Properties>
+
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.0.0" MaxVersionTested="10.0.0.0" />
+  </Dependencies>
+
+  <Resources>
+    <Resource Language="x-generate" />
+  </Resources>
+
+  <Applications>
+    <Application Id="App"
+      Executable="$targetnametoken$.exe"
+      EntryPoint="@SHORT_NAME@.App">
+      <uap:VisualElements
+        DisplayName="@SHORT_NAME@"
+        Square150x150Logo="Square150x150Logo.png"
+        Square44x44Logo="Square44x44Logo.png"
+        Description="@SHORT_NAME@"
+        BackgroundColor="transparent">
+        <uap:DefaultTile Square71x71Logo="Square71x71Logo.png"/>
+        <uap:SplashScreen Image="SplashScreen.png" />
+      </uap:VisualElements>
+
+    </Application>
+  </Applications>
+
+  <Capabilities>
+	<Capability Name="internetClient" />
+  </Capabilities>
+</Package>

--- a/Examples/RSSReader/CMakeLists.txt
+++ b/Examples/RSSReader/CMakeLists.txt
@@ -5,7 +5,9 @@
 # Please see the LICENSE included with this distribution for details.
 cmake_minimum_required(VERSION 3.0.0)
 
-if(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsPhone")
+if (${CMAKE_SYSTEM_VERSION} STREQUAL "10.0")
+  set(PLATFORM win10)
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsPhone")
   set(PLATFORM wp)
   add_definitions("-DPHONE")
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsStore")
@@ -94,6 +96,11 @@ set(EXE_NAME ${PROJECT_NAME})
 set(APP_MANIFEST_NAME Package.appxmanifest)
 set(SHORT_NAME ${EXE_NAME})
 set(PACKAGE_GUID "f0473be1-c557-4f98-a103-4ba9f453b5b0")
+set(PUBLISHER_ID "CN=appcelerator")
+set(PUBLISHER_DISPLAY_NAME "Appcelerator")
+set(PHONE_PRODUCT_ID "f0473be1-c557-4f98-a103-4ba9f453b5b0")
+set(PHONE_PUBLISHER_ID "00000000-0000-0000-0000-000000000000")
+set(VERSION "1.1.0.0")
 
 # Generate the app manifest.
 configure_file(
@@ -126,7 +133,7 @@ set(SOURCE_alloy
       "src/Assets/alloy/underscore.js"
       "src/Assets/alloy/widget.js"
   )
-source_group("alloy" FILES 
+source_group("alloy" FILES
       "src/Assets/alloy/backbone.js"
       "src/Assets/alloy/CFG.js"
       "src/Assets/alloy/constants.js"
@@ -143,7 +150,7 @@ set(SOURCE_alloy_controllers
       "src/Assets/alloy/controllers/index.js"
       "src/Assets/alloy/controllers/master.js"
   )
-source_group("alloy/controllers" FILES 
+source_group("alloy/controllers" FILES
       "src/Assets/alloy/controllers/BaseController.js"
       "src/Assets/alloy/controllers/detail.js"
       "src/Assets/alloy/controllers/index.js"
@@ -155,7 +162,7 @@ set_property(SOURCE ${SOURCE_alloy_controllers} PROPERTY VS_DEPLOYMENT_CONTENT 1
 set(SOURCE_alloy_models
       "src/Assets/alloy/models/Feed.js"
   )
-source_group("alloy/models" FILES 
+source_group("alloy/models" FILES
       "src/Assets/alloy/models/Feed.js"
   )
 set_property(SOURCE ${SOURCE_alloy_models} PROPERTY VS_DEPLOYMENT_LOCATION "alloy\\models")
@@ -166,7 +173,7 @@ set(SOURCE_alloy_styles
       "src/Assets/alloy/styles/index.js"
       "src/Assets/alloy/styles/master.js"
   )
-source_group("alloy/styles" FILES 
+source_group("alloy/styles" FILES
       "src/Assets/alloy/styles/detail.js"
       "src/Assets/alloy/styles/index.js"
       "src/Assets/alloy/styles/master.js"
@@ -180,7 +187,7 @@ set(SOURCE_alloy_sync
       "src/Assets/alloy/sync/rss.js"
       "src/Assets/alloy/sync/sql.js"
   )
-source_group("alloy/sync" FILES 
+source_group("alloy/sync" FILES
       "src/Assets/alloy/sync/localStorage.js"
       "src/Assets/alloy/sync/properties.js"
       "src/Assets/alloy/sync/rss.js"

--- a/Examples/RSSReader/src/Package.win10.appxmanifest.in
+++ b/Examples/RSSReader/src/Package.win10.appxmanifest.in
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  IgnorableNamespaces="uap mp">
+
+  <Identity
+    Name="@PACKAGE_GUID@"
+    Publisher="@PUBLISHER_ID@"
+    Version="@VERSION@" />
+
+  <mp:PhoneIdentity PhoneProductId="@PHONE_PRODUCT_ID@" PhonePublisherId="@PHONE_PUBLISHER_ID@"/>
+
+  <Properties>
+    <DisplayName>@SHORT_NAME@</DisplayName>
+    <PublisherDisplayName>@PUBLISHER_DISPLAY_NAME@</PublisherDisplayName>
+    <Logo>StoreLogo.png</Logo>
+  </Properties>
+
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.0.0" MaxVersionTested="10.0.0.0" />
+  </Dependencies>
+
+  <Resources>
+    <Resource Language="x-generate" />
+  </Resources>
+
+  <Applications>
+    <Application Id="App"
+      Executable="$targetnametoken$.exe"
+      EntryPoint="@SHORT_NAME@.App">
+      <uap:VisualElements
+        DisplayName="@SHORT_NAME@"
+        Square150x150Logo="Square150x150Logo.png"
+        Square44x44Logo="Square44x44Logo.png"
+        Description="@SHORT_NAME@"
+        BackgroundColor="transparent">
+        <uap:DefaultTile Square71x71Logo="Square71x71Logo.png"/>
+        <uap:SplashScreen Image="SplashScreen.png" />
+      </uap:VisualElements>
+
+    </Application>
+  </Applications>
+
+  <Capabilities>
+	<Capability Name="internetClient" />
+  </Capabilities>
+</Package>

--- a/Examples/ToDoList/CMakeLists.txt
+++ b/Examples/ToDoList/CMakeLists.txt
@@ -5,7 +5,9 @@
 # Please see the LICENSE included with this distribution for details.
 cmake_minimum_required(VERSION 3.0.0)
 
-if(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsPhone")
+if (${CMAKE_SYSTEM_VERSION} STREQUAL "10.0")
+  set(PLATFORM win10)
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsPhone")
   set(PLATFORM wp)
   add_definitions("-DPHONE")
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsStore")
@@ -94,6 +96,11 @@ set(EXE_NAME ${PROJECT_NAME})
 set(APP_MANIFEST_NAME Package.appxmanifest)
 set(SHORT_NAME ${EXE_NAME})
 set(PACKAGE_GUID "f0473be1-c557-4f98-a103-4ba9f453b5b0")
+set(PUBLISHER_ID "CN=appcelerator")
+set(PUBLISHER_DISPLAY_NAME "Appcelerator")
+set(PHONE_PRODUCT_ID "f0473be1-c557-4f98-a103-4ba9f453b5b0")
+set(PHONE_PUBLISHER_ID "00000000-0000-0000-0000-000000000000")
+set(VERSION "1.1.0.0")
 
 # Generate the app manifest.
 configure_file(
@@ -124,7 +131,7 @@ set(SOURCE_ui
   "src/Assets/ui/AppTabGroup.js"
   "src/Assets/ui/ListWindow.js"
   )
-source_group("ui" FILES 
+source_group("ui" FILES
   "src/Assets/ui/AddWindow.js"
   "src/Assets/ui/AppTabGroup.js"
   "src/Assets/ui/ListWindow.js"
@@ -137,7 +144,7 @@ set(SOURCE_images
   "src/Assets/images/KS_nav_ui.png"
   "src/Assets/images/KS_nav_views.png"
   )
-source_group("images" FILES 
+source_group("images" FILES
   "src/Assets/images/ic_menu_add.png"
   "src/Assets/images/KS_nav_ui.png"
   "src/Assets/images/KS_nav_views.png"

--- a/Examples/ToDoList/src/Package.win10.appxmanifest.in
+++ b/Examples/ToDoList/src/Package.win10.appxmanifest.in
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  IgnorableNamespaces="uap mp">
+
+  <Identity
+    Name="@PACKAGE_GUID@"
+    Publisher="@PUBLISHER_ID@"
+    Version="@VERSION@" />
+
+  <mp:PhoneIdentity PhoneProductId="@PHONE_PRODUCT_ID@" PhonePublisherId="@PHONE_PUBLISHER_ID@"/>
+
+  <Properties>
+    <DisplayName>@SHORT_NAME@</DisplayName>
+    <PublisherDisplayName>@PUBLISHER_DISPLAY_NAME@</PublisherDisplayName>
+    <Logo>StoreLogo.png</Logo>
+  </Properties>
+
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.0.0" MaxVersionTested="10.0.0.0" />
+  </Dependencies>
+
+  <Resources>
+    <Resource Language="x-generate" />
+  </Resources>
+
+  <Applications>
+    <Application Id="App"
+      Executable="$targetnametoken$.exe"
+      EntryPoint="@SHORT_NAME@.App">
+      <uap:VisualElements
+        DisplayName="@SHORT_NAME@"
+        Square150x150Logo="Square150x150Logo.png"
+        Square44x44Logo="Square44x44Logo.png"
+        Description="@SHORT_NAME@"
+        BackgroundColor="transparent">
+        <uap:DefaultTile Square71x71Logo="Square71x71Logo.png"/>
+        <uap:SplashScreen Image="SplashScreen.png" />
+      </uap:VisualElements>
+
+    </Application>
+  </Applications>
+
+  <Capabilities>
+	<Capability Name="internetClient" />
+  </Capabilities>
+</Package>

--- a/Tools/Scripts/generate_project.js
+++ b/Tools/Scripts/generate_project.js
@@ -15,7 +15,16 @@ var fs = require('fs'),
 	  ok: '✓',
 	  err: '✖',
 	  dot: '․'
-	};
+	},
+	// Constants
+	WIN_8_1 = '8.1',
+	WIN_10 = '10.0',
+	MSBUILD_12 = '12.0',
+	MSBUILD_14 = '14.0',
+	VS_2013_GENERATOR = 'Visual Studio 12 2013',
+	VS_2015_GENERATOR = 'Visual Studio 14 2015',
+	WINDOWS_STORE = 'WindowsStore',
+	WINDOWS_PHONE = 'WindowsPhone';
 
 // With node.js on Windows: use symbols available in terminal default fonts
 if ('win32' == os.platform()) {
@@ -24,98 +33,124 @@ if ('win32' == os.platform()) {
 	symbols.dot = '.';
 }
 
+/**
+ * Generates a VS solution and project to run/debug our Example apps manually.
+ *
+ * @param example_name {String} Name of the example app to generate from (See Examples folder)
+ * @param dest {String} output location/folder
+ * @param platform {String} 'WindowsStore'|'WindowsPhone'
+ * @param sdkVersion {String} '8.1'|'10.0'
+ * @param msdev {String} '12.0'|'14.0' MSBuild version to use
+ * @param arch {String} 'ARM'|'Win32'
+ * @param next {Function} callback function
+ **/
+function generateProject(example_name, dest, platform, sdkVersion, msdev, arch, next) {
+	var example_folder = path.join(__dirname, '..', '..', 'Examples', example_name),
+		generator,
+		prc,
+		out = '';
+
+	// cmake generator name
+	generator = (msdev == MSBUILD_14) ? VS_2015_GENERATOR : VS_2013_GENERATOR;
+	if (arch == 'ARM') {
+		generator += ' ARM';
+	}
+
+	// Make sure our intended output dir exists!
+	if (!fs.existsSync(dest)) {
+		// Make the directory structure!
+		wrench.mkdirSyncRecursive(dest);
+	}
+	// Now let's generate the solution
+	prc = spawn('cmake', ['-G', generator,
+		'-DCMAKE_SYSTEM_NAME=' + platform,
+		'-DCMAKE_SYSTEM_VERSION=' + sdkVersion,
+		'-DTitaniumWindows_DISABLE_TESTS=ON',
+		'-DTitaniumWindows_Global_DISABLE_TESTS=ON',
+		'-DTitaniumWindows_Ti_DISABLE_TESTS=ON',
+		'-DTitaniumWindows_UI_DISABLE_TESTS=ON',
+		'-DTitaniumKit_DISABLE_TESTS=ON',
+		'-DHAL_DISABLE_TESTS=ON',
+		example_folder
+		], {
+			cwd: dest
+		});
+	prc.stdout.on('data', function (data) {
+		console.log(data.toString());
+	});
+	prc.stderr.on('data', function (data) {
+		console.log(data.toString());
+	});
+	prc.on('close', function (code) {
+		var setProcess;
+		if (code != 0) {
+			next("Failed to generate project!");
+		} else {
+			next();
+		}
+	});
+}
+
+// API
+exports.generateProject = generateProject;
+
+
 ////////////////////////////////////
 ////////// MAIN EXECUTION //////////
 ////////////////////////////////////
+if (module.id === ".") {
+	(function () {
+		// Process command line input
+		program
+			.description('Titanium Windows VS Solution Generator')
+			.usage('COMMAND [ARGS] [OPTIONS]')
+			.option('-a, --arch <arch>', '"ARM" (device) or "Win32" (emulator)', /^(ARM|Win32)$/, 'Win32')
+			.option('-o, --outputPath <outputPath>', 'Output path for generated code')
+			.option('-p, --platform <platform>', '"WindowsPhone" or "WindowsStore"', /^Windows(Phone|Store)$/, 'WindowsPhone')
+			.option('-s, --sdk-version <version>', 'Target a specific Windows SDK version [version]', /^(8\.1|10\.0)$/, WIN_8_1)
+			.option('-m, --msbuild <msbuild>', '"12.0" (VS 2013) or "14.0" (VS 2015)', /^(12\.0|14\.0)$/, MSBUILD_12);
 
-// Process command line input
-program
-	.description('Titanium Windows VS Solution Generator')
-	.usage('COMMAND [ARGS] [OPTIONS]')
-	.option('-a, --arch <arch>', '"ARM" (device) or "Win32" (emulator)')
-	.option('-o, --outputPath <outputPath>', 'Output path for generated code')
-	.option('-p, --platform <platform>', '"WindowsPhone" or "WindowsStore"')
-	.option('-t, --target <platform target>', '"8.1" or "10.0"')
-	.option('-m, --msdev <msbuild version>', '"12" (VS 2013) or "14" (VS 2015)');
+		program.command('new'.blue+' <example_name>'.white)
+				.description('	create a new project from the packaged examples'.grey);
 
-program.command('new'.blue+' <example_name>'.white)
-		.description('    create a new project from the packaged examples'.grey);
+		program.parse(process.argv);
 
-program.parse(process.argv);
+		Error.stackTraceLimit = Infinity;
 
-Error.stackTraceLimit = Infinity;
+		if (program.args.length === 0)
+		{
+			var help = program.helpInformation();
+			help = help.replace('Usage: generate_project COMMAND [ARGS] [OPTIONS]','Usage: '+'generate_project'.blue+' COMMAND'.white+' [ARGS] [OPTIONS]'.grey);
+			console.log(help);
+			process.exit(1);
+		}
 
-if (program.args.length === 0)
-{
-	var help = program.helpInformation();
-	help = help.replace('Usage: generate_project COMMAND [ARGS] [OPTIONS]','Usage: '+'generate_project'.blue+' COMMAND'.white+' [ARGS] [OPTIONS]'.grey);
-	//help = logger.stripColors ? colors.stripColors(help) : help;
-	console.log(help);
-	process.exit(0);
+		// TODO USe command built-in API for new command!
+		// Validate the given command, only can be 'new' right now
+		var command = program.args[0];
+		if (command != 'new') {
+			console.log('Unknown command: ' + command.red);
+			process.exit(1);
+		}
+		var example_name = program.args[1] || 'NG'; // The example from Examples dir to turn into a project
+		var abbrev = program.platform; // part of folder name for generated project
+
+		// Win 10 must be 'WindowsStore', VS 2015 and MSBuild 14.0
+		if (program.sdkVersion == WIN_10) {
+			program.msdev = MSBUILD_14;
+			program.platform = WINDOWS_STORE;
+			abbrev = 'Windows10';
+		}
+
+		// output location
+		var dest = program.outputPath || path.join('.', example_name + '.' + abbrev + '.' + program.arch);
+
+		generateProject(example_name, dest, program.platform, program.sdkVersion, program.msdev, program.arch, function (err) {
+			if (err) {
+				console.error(err.toString().red);
+				process.exit(1);
+			}
+			console.log((symbols.ok + ' Generated VS solution. Open ' + dest + '\\' + example_name + '.sln to begin development.').green);
+		});
+	})();
 }
-
-// Validate the platform
-if (program.platform && program.platform != 'WindowsPhone' && program.platform != 'WindowsStore') {
-	console.log('Invalid platform "' + program.platform + '" specified, must be one of ["WindowsPhone", "WindowsStore"]');
-	process.exit(1);
-}
-
-// validate the arch
-if (program.arch && program.arch != 'Win32' && program.arch != 'ARM') {
-	console.log('Invalid arch "' + program.arch + '" specified, must be one of ["Win32", "ARM"]');
-	process.exit(1);
-}
-
-// Validate the given command, only can be 'new' right now
-var command = program.args[0];
-if (command != 'new') {
-	console.log('Unknown command: ' + command.red);
-	process.exit(1);
-}
-var example_name = program.args[1] || 'NG';
-var platform = program.platform || 'WindowsPhone';
-var arch = program.arch || 'Win32';
-var dest = program.outputPath || path.join('.', example_name + '.' + platform + '.' + arch);
-// Make sure our intended output dir exists!
-if (!fs.existsSync(dest)) {
-	// Make the directory structure!
-	wrench.mkdirSyncRecursive(dest);
-}
-var generator = program.msdev == '14' ? 'Visual Studio 14 2015' : 'Visual Studio 12 2013';
-var generator_target = program.target || '8.1';
-
-if (arch == 'ARM') {
-	generator += ' ARM';
-}
-
-var example_folder = path.join(__dirname, '..', '..', 'Examples', example_name);
-// Now let's generate the solution
-var prc = spawn('cmake', ['-G', generator,
-	'-DCMAKE_SYSTEM_NAME=' + platform, 
-	'-DCMAKE_SYSTEM_VERSION=' + generator_target,
-    '-DTitaniumWindows_DISABLE_TESTS=ON',
-    '-DTitaniumWindows_Global_DISABLE_TESTS=ON',
-    '-DTitaniumWindows_Ti_DISABLE_TESTS=ON',
-    '-DTitaniumWindows_UI_DISABLE_TESTS=ON',
-    '-DTitaniumKit_DISABLE_TESTS=ON',
-    '-DHAL_DISABLE_TESTS=ON',
-    example_folder
-	], {
-		cwd: dest
-	});
-prc.stdout.on('data', function (data) {
-   console.log(data.toString());
-});
-prc.stderr.on('data', function (data) {
-   console.log(data.toString());
-});
-prc.on('close', function (code) {
-	var setProcess;
-	if (code != 0) {
-		console.log("Failed to generate project!");
-		process.exit(1);
-	} else {
-		console.log((symbols.ok + ' Generated VS solution. Open ' + dest + '\\' + example_name + '.sln to begin development.').green);
-		process.exit(0);
-	}
-});


### PR DESCRIPTION
The node script didn't need updating for Windows 10, but I did want to clean it up a bit. It now uses the right settings by default if you pass along the -s 10.0 option to target Windows 10 (you don't necessarily have to also set the msbuild version, platform, etc).

The examples needed their CMakeLists.txt update to handle Windows 10, and a Win 10 appxmanifest template needed to be added to each.

https://jira.appcelerator.org/browse/TIMOB-20158