### PR TITLE
Fix: Window.fullscreen doesn't work on Windows 10

### DIFF
--- a/Source/UI/src/Window.cpp
+++ b/Source/UI/src/Window.cpp
@@ -254,7 +254,8 @@ namespace TitaniumWindows
 			auto statusBar = Windows::UI::ViewManagement::StatusBar::GetForCurrentView();
 			fullscreen ? statusBar->HideAsync() : statusBar->ShowAsync();
 #elif defined(IS_WINDOWS_10)
-			TITANIUM_LOG_WARN("set_fullscreen is not implemented on Windows 10");
+			auto view = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
+			fullscreen ? view->TryEnterFullScreenMode() : view->ExitFullScreenMode();
 #endif
 		}
 


### PR DESCRIPTION
Fix for [TIMOB-20166](https://jira.appcelerator.org/browse/TIMOB-20166)

```javascript
var win = Ti.UI.createWindow({
    fullscreen: true,
    backgroundColor: 'green'
});

var label = Ti.UI.createLabel({text:'Click here to exit fullscreen'});

// exit fullscreen when label is clicked
label.addEventListener('click', function () {
    win.fullscreen = false;
});
win.add(label);

win.open();
```