### PR TITLE
Use SplitView for TabGroup on Windows 10

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/TabGroup.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/TabGroup.hpp
@@ -84,11 +84,13 @@ namespace TitaniumWindows
 
 #if defined(IS_WINDOWS_PHONE)
 			Windows::UI::Xaml::Controls::Pivot^ pivot__;
+#elif defined(IS_WINDOWS_10)
+			Windows::UI::Xaml::Controls::SplitView^ splitView__;
+			Windows::UI::Xaml::Controls::StackPanel^ splitPane__;
+
 #else
 			//
 			// We're going to use ListView for tab navigation because there's no Pivot for Windows Store app.
-			// On Windows 10 we might want to use SplitView instead.
-			// http://igrali.com/2015/04/12/getting-started-with-splitview-control-in-universal-apps/
 			//
 			Windows::UI::Xaml::Controls::ListView^ sectionView__;
 			Windows::UI::Xaml::Data::CollectionViewSource^ sectionViewSource__;

--- a/Source/UI/src/TabGroup.cpp
+++ b/Source/UI/src/TabGroup.cpp
@@ -46,6 +46,14 @@ namespace TitaniumWindows
 			});
 
 			grid__->Children->Append(pivot__);
+#elif defined(IS_WINDOWS_10)
+			splitView__ = ref new SplitView();
+			splitView__->DisplayMode = SplitViewDisplayMode::CompactInline;
+			grid__->Children->Append(splitView__);
+
+			splitPane__ = ref new StackPanel();
+			splitView__->Pane = splitPane__;
+			splitView__->IsPaneOpen = true;
 #else
 			sectionView__ = ref new ListView();
 			sectionView__->IsItemClickEnabled = true;
@@ -113,6 +121,8 @@ namespace TitaniumWindows
 			const auto brush = ref new Media::SolidColorBrush(WindowsViewLayoutDelegate::ColorForName(value));
 #if defined(IS_WINDOWS_PHONE)
 			pivot__->Background = brush;
+#elif defined(IS_WINDOWS_10)
+			splitPane__->Background = brush;
 #else
 			sectionView__->Background = brush;
 #endif
@@ -129,6 +139,9 @@ namespace TitaniumWindows
 				const auto tabview = activeTab->getViewLayoutDelegate<WindowsViewLayoutDelegate>()->getComponent();
 #if defined(IS_WINDOWS_PHONE)
 				pivot__->SelectedItem = tabview;
+#elif defined(IS_WINDOWS_10)
+				splitView__->Content = tabview;
+
 #else
 				if (grid__->Children->Size > 1) {
 					grid__->Children->RemoveAt(1);
@@ -159,6 +172,8 @@ namespace TitaniumWindows
 			Titanium::UI::TabGroup::set_tabs(tabs);
 #if defined(IS_WINDOWS_PHONE)
 			pivot__->Items->Clear();
+#elif defined(IS_WINDOWS_10)
+			splitPane__->Children->Clear();
 #else
 			sectionViewItems__->Clear();
 #endif
@@ -180,6 +195,16 @@ namespace TitaniumWindows
 			if (windows_tab) {
 #if defined(IS_WINDOWS_PHONE)
 				pivot__->Items->Append(tabview);
+#elif defined(IS_WINDOWS_10)
+				auto tabItem = ref new Windows::UI::Xaml::Controls::Button();
+				tabItem->Content = Utility::ConvertUTF8String(windows_tab->get_title());
+
+				tabItem->Click += ref new RoutedEventHandler([this, tabview](Platform::Object^ sender, RoutedEventArgs^ e) {
+					splitView__->Content = tabview;
+				});
+
+				splitPane__->Children->Append(tabItem);
+				splitView__->OpenPaneLength = tabItem->Width;
 #else
 				sectionViewItems__->Append(Utility::ConvertUTF8String(windows_tab->get_title()));
 #endif


### PR DESCRIPTION
Initial cut for [TIMOB-20164](https://jira.appcelerator.org/browse/TIMOB-20164)

This PR makes `Ti.UI.TabGroup` to use `Xaml::Controls::SplitView` instead of `Xaml::Controls::ListView` on Windows 10.

So, following image shows how it looks like on Windows 10 Mobile. I would say it's pretty much similar to how it works when you use Xaml `ListView`. The only difference is I use Xaml `Button` to realize Tab item (where "Tab 1" and "Tab 2" is placed) and this may not give "natural" look & feel compared to Xaml `ListView`.

![surface_pro_3](https://cloud.githubusercontent.com/assets/1661068/12031094/66b2165e-ae4b-11e5-9867-2ad6eb4c130f.png)
And here's how our current "`ListView` version" looks like...I would say it's more natural look & feel.

![surface_pro_3 2](https://cloud.githubusercontent.com/assets/1661068/12031142/ec561954-ae4b-11e5-92a6-2c9eb2f5de34.png)

I used combination of `Button` & `SplitView` in this PR but in fact I could even use `ListView` for the left pane of `SplitView,` and then it will give exactly same look & feel than before. But is that worth it? It gives no functional difference. The good thing when you use `SplitView` might be that it may give more option to implement, which is specific to Windows 10 such as `CompactPaneLength`, `OpenPaneLength` and `IsOpenPane` property.
