### PR TITLE
Fix: Window width & height for Store App doesn't work

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/Window.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/Window.hpp
@@ -91,6 +91,7 @@ namespace TitaniumWindows
 			virtual void disableEvent(const std::string& event_name) TITANIUM_NOEXCEPT override;
 
 			void updateWindowsCommandBar(const std::shared_ptr<TitaniumWindows::UI::WindowsXaml::CommandBar>& commandbar);
+			void updateWindowSize() TITANIUM_NOEXCEPT;
 
 		private:
 #pragma warning(push)

--- a/Source/UI/src/Window.cpp
+++ b/Source/UI/src/Window.cpp
@@ -178,6 +178,7 @@ namespace TitaniumWindows
 
 		void Window::updateWindowSize() TITANIUM_NOEXCEPT
 		{
+#if defined(IS_WINDOWS_10)
 			const auto currentBounds = Windows::UI::Xaml::Window::Current->Bounds;
 
 			const auto layout    = getViewLayoutDelegate();
@@ -192,7 +193,7 @@ namespace TitaniumWindows
 			if (!Windows::UI::ViewManagement::ApplicationView::GetForCurrentView()->TryResizeView(Size(width, height))) {
 				TITANIUM_LOG_WARN("Titanium::Window: Unable to resize root Window with size ", width, "x", height);
 			}
-
+#endif
 		}
 
 		void Window::open(const std::shared_ptr<Titanium::UI::OpenWindowParams>& params) TITANIUM_NOEXCEPT


### PR DESCRIPTION
Fix for [TIMOB-20187](https://jira.appcelerator.org/browse/TIMOB-20187)

*This works only on Windows 10 Store App*.

```javascript
var win = Ti.UI.createWindow({width:600, height:800, backgroundColor:'green'}),
    lbl = Ti.UI.createLabel({ text: 'Hello, World' });
win.add(lbl);
win.open();
```