### PR TITLE
Fix: Disable OutputDebugString on Release build

### DIFF
--- a/templates/build/include/OutputDebugStringBuf.hpp
+++ b/templates/build/include/OutputDebugStringBuf.hpp
@@ -8,6 +8,8 @@
 #ifndef _TITANIUM_MOBILE_WINDOWS_UTIL_OUTPUTDEBUGSTRINGBUF_HPP_
 #define _TITANIUM_MOBILE_WINDOWS_UTIL_OUTPUTDEBUGSTRINGBUF_HPP_
 
+#if defined(_DEBUG)
+
 #include <ostream>
 #include <sstream>
 #include <vector>
@@ -80,4 +82,5 @@ namespace TitaniumWindows {
 
 }  // namespace TitaniumWindows {
 
+#endif  // _DEBUG
 #endif  // _TITANIUM_MOBILE_WINDOWS_UTIL_OUTPUTDEBUGSTRINGBUF_HPP_

--- a/templates/build/src/main.cpp
+++ b/templates/build/src/main.cpp
@@ -5,12 +5,15 @@
  * Licensed under the terms of the Apache Public License.
  * Please see the LICENSE included with this distribution for details.
  */
+#if defined(_DEBUG)
 #include "OutputDebugStringBuf.hpp"
+#endif
+
 #include <iostream>
 
 int main(Platform::Array<Platform::String^>^) {
 
-#if defined(_WIN32)
+#if defined(_DEBUG)
   static TitaniumWindows::OutputDebugStringBuf<char> charDebugOutput;
   std::cerr.rdbuf(&charDebugOutput);
   std::clog.rdbuf(&charDebugOutput);


### PR DESCRIPTION
Disable debug log on Release build which causes certification error described in [TIMOB-20192](https://jira.appcelerator.org/browse/TIMOB-20192).
