### PR TITLE
Use Pivot for UI.TabGroup on Windows 10

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/Tab.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/Tab.hpp
@@ -64,7 +64,7 @@ namespace TitaniumWindows
 			virtual void focus() override;
 
 		private:
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			Windows::UI::Xaml::Controls::PivotItem^ pivotItem__;
 #else
 			Windows::UI::Xaml::Controls::Grid^  grid__;

--- a/Source/UI/include/TitaniumWindows/UI/TabGroup.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/TabGroup.hpp
@@ -82,7 +82,7 @@ namespace TitaniumWindows
 			std::shared_ptr<TitaniumWindows::UI::Window> window__;
 			Windows::UI::Xaml::Controls::Grid^  grid__;
 
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			Windows::UI::Xaml::Controls::Pivot^ pivot__;
 #else
 			//

--- a/Source/UI/src/Tab.cpp
+++ b/Source/UI/src/Tab.cpp
@@ -29,7 +29,7 @@ namespace TitaniumWindows
 		{
 			Titanium::UI::Tab::postCallAsConstructor(js_context, arguments);	
 
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			pivotItem__ = ref new PivotItem();
 
 			Titanium::UI::Tab::setLayoutDelegate<WindowsViewLayoutDelegate>();
@@ -44,7 +44,7 @@ namespace TitaniumWindows
 		void Tab::set_title(const std::string& title) TITANIUM_NOEXCEPT
 		{
 			Titanium::UI::Tab::set_title(title);
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			pivotItem__->Header = TitaniumWindows::Utility::ConvertUTF8String(title);
 #else
 
@@ -56,7 +56,7 @@ namespace TitaniumWindows
 			if (window != window__) {
 				const auto windows_window = dynamic_cast<TitaniumWindows::UI::Window*>(window.get());
 				const auto view = windows_window->getComponent();
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 				pivotItem__->Content = view;
 #else
 				if (grid__->Children->Size > 0) {

--- a/Source/UI/src/TabGroup.cpp
+++ b/Source/UI/src/TabGroup.cpp
@@ -37,7 +37,7 @@ namespace TitaniumWindows
 
 			grid__  = ref new Grid();
 
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			pivot__ = ref new Pivot();
 
 			pivot__->SelectionChanged += ref new SelectionChangedEventHandler([this](Platform::Object^ sender, SelectionChangedEventArgs^ e) {
@@ -111,7 +111,7 @@ namespace TitaniumWindows
 		{
 			Titanium::UI::TabGroup::set_barColor(value);
 			const auto brush = ref new Media::SolidColorBrush(WindowsViewLayoutDelegate::ColorForName(value));
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			pivot__->Background = brush;
 #else
 			sectionView__->Background = brush;
@@ -127,7 +127,7 @@ namespace TitaniumWindows
 		{
 			if (updateUI && activeTab != activeTab__) {
 				const auto tabview = activeTab->getViewLayoutDelegate<WindowsViewLayoutDelegate>()->getComponent();
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 				pivot__->SelectedItem = tabview;
 #else
 				if (grid__->Children->Size > 1) {
@@ -157,7 +157,7 @@ namespace TitaniumWindows
 		void TabGroup::set_tabs(const std::vector<std::shared_ptr<Titanium::UI::Tab>>& tabs) TITANIUM_NOEXCEPT
 		{
 			Titanium::UI::TabGroup::set_tabs(tabs);
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			pivot__->Items->Clear();
 #else
 			sectionViewItems__->Clear();
@@ -178,7 +178,7 @@ namespace TitaniumWindows
 			const auto windows_tab = dynamic_cast<TitaniumWindows::UI::Tab*>(tab.get());
 			const auto tabview = windows_tab->getViewLayoutDelegate<WindowsViewLayoutDelegate>()->getComponent();
 			if (windows_tab) {
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 				pivot__->Items->Append(tabview);
 #else
 				sectionViewItems__->Append(Utility::ConvertUTF8String(windows_tab->get_title()));


### PR DESCRIPTION
[TIMOB-20164](https://jira.appcelerator.org/browse/TIMOB-20164)

*Note: This needs #522 to be merged otherwise you'll see crash.*

Use `Windows::UI::Xaml::Controls::Pivot` for `Ti.UI.Tab/TabGroup` on Windows 10.

Note that the default color scheme is different between Windows 10 and Windows 10 Mobile.

![wm](https://cloud.githubusercontent.com/assets/1661068/12111755/2718da2e-b3db-11e5-81cb-d92d38942ce1.png)

![w](https://cloud.githubusercontent.com/assets/1661068/12111782/509b166e-b3db-11e5-8a0c-130e5247eeb2.png)

```javascript
// create tab group
var tabGroup = Titanium.UI.createTabGroup();


//
// create base UI tab and root window
//
var win1 = Titanium.UI.createWindow({
    title: 'Tab 1',
    backgroundColor: '#fff'
});
var tab1 = Titanium.UI.createTab({
    icon: 'KS_nav_views.png',
    title: 'Tab 1',
    window: win1
});

var label1 = Titanium.UI.createLabel({
    color: '#999',
    text: 'I am Window 1',
    font: { fontSize: 20, fontFamily: 'Helvetica Neue' },
    textAlign: 'center',
    width: 'auto'
});

win1.add(label1);

//
// create controls tab and root window
//
var win2 = Titanium.UI.createWindow({
    title: 'Tab 2',
    backgroundColor: '#fff'
});
var tab2 = Titanium.UI.createTab({
    icon: 'KS_nav_ui.png',
    title: 'Tab 2',
    window: win2
});

var label2 = Titanium.UI.createLabel({
    color: '#999',
    text: 'I am Window 2',
    font: { fontSize: 20, fontFamily: 'Helvetica Neue' },
    textAlign: 'center',
    width: 'auto'
});

win2.add(label2);



//
//  add tabs
//
tabGroup.addTab(tab1);
tabGroup.addTab(tab2);


// open tab group
tabGroup.open();
```