### PR TITLE
[TIMOB-20201] Enable SAFESEH for Windows Store/Phone x86 build

### DIFF
--- a/Examples/NG/src/OutputDebugStringBuf.hpp
+++ b/Examples/NG/src/OutputDebugStringBuf.hpp
@@ -8,6 +8,8 @@
 #ifndef _TITANIUM_MOBILE_WINDOWS_UTIL_OUTPUTDEBUGSTRINGBUF_HPP_
 #define _TITANIUM_MOBILE_WINDOWS_UTIL_OUTPUTDEBUGSTRINGBUF_HPP_
 
+#if defined(_DEBUG)
+
 #include <ostream>
 #include <sstream>
 #include <vector>
@@ -80,4 +82,5 @@ namespace TitaniumWindows {
 
 }  // namespace TitaniumWindows {
 
+#endif
 #endif  // _TITANIUM_MOBILE_WINDOWS_UTIL_OUTPUTDEBUGSTRINGBUF_HPP_

--- a/Examples/NG/src/main.cpp
+++ b/Examples/NG/src/main.cpp
@@ -5,12 +5,15 @@
  * Licensed under the terms of the Apache Public License.
  * Please see the LICENSE included with this distribution for details.
  */
+#if defined(_DEBUG)
 #include "OutputDebugStringBuf.hpp"
+#endif
+
 #include <iostream>
 
 int main(Platform::Array<Platform::String^>^) {
 
-#if defined(_WIN32)
+#if defined(_DEBUG)
   static TitaniumWindows::OutputDebugStringBuf<char> charDebugOutput;
   std::cerr.rdbuf(&charDebugOutput);
   std::clog.rdbuf(&charDebugOutput);

--- a/Examples/NMocha/src/OutputDebugStringBuf.hpp
+++ b/Examples/NMocha/src/OutputDebugStringBuf.hpp
@@ -7,6 +7,7 @@
  */
 #ifndef _TITANIUM_MOBILE_WINDOWS_UTIL_OUTPUTDEBUGSTRINGBUF_HPP_
 #define _TITANIUM_MOBILE_WINDOWS_UTIL_OUTPUTDEBUGSTRINGBUF_HPP_
+#if defined(_DEBUG)
 
 #include <ostream>
 #include <sstream>
@@ -80,4 +81,5 @@ namespace TitaniumWindows {
 
 }  // namespace TitaniumWindows {
 
+#endif
 #endif  // _TITANIUM_MOBILE_WINDOWS_UTIL_OUTPUTDEBUGSTRINGBUF_HPP_

--- a/Examples/NMocha/src/main.cpp
+++ b/Examples/NMocha/src/main.cpp
@@ -5,12 +5,14 @@
  * Licensed under the terms of the Apache Public License.
  * Please see the LICENSE included with this distribution for details.
  */
+#if defined(_DEBUG)
 #include "OutputDebugStringBuf.hpp"
+#endif
+
 #include <iostream>
 
 int main(Platform::Array<Platform::String^>^) {
-
-#if defined(_WIN32)
+#if defined(_DEBUG)
   static TitaniumWindows::OutputDebugStringBuf<char> charDebugOutput;
   std::cerr.rdbuf(&charDebugOutput);
   std::clog.rdbuf(&charDebugOutput);

--- a/Source/LayoutEngine/CMakeLists.txt
+++ b/Source/LayoutEngine/CMakeLists.txt
@@ -78,10 +78,16 @@ if (WIN32)
   # Therefore we test for the processor architecture we are targeting
   # and if its i386 (i.e. the emulator) then we pass /SAFESEH:NO to
   # the linker.
-  include(${PROJECT_SOURCE_DIR}/cmake/TargetArch.cmake)
-  target_architecture(target_architecture)
-  if (${target_architecture} STREQUAL i386)
-    set_property(TARGET LayoutEngine APPEND_STRING PROPERTY LINK_FLAGS " /SAFESEH:NO")
+  # 
+  # If target platform is Windows Phone/Store,
+  # we should not disable SAFESEH otherwise Windows App Certification will fail.
+  # 
+  if (NOT CMAKE_SYSTEM_NAME MATCHES "^Windows(Phone|Store)$")
+    include(${PROJECT_SOURCE_DIR}/cmake/TargetArch.cmake)
+    target_architecture(target_architecture)
+    if (${target_architecture} STREQUAL i386)
+      set_property(TARGET HAL APPEND_STRING PROPERTY LINK_FLAGS " /SAFESEH:NO")
+    endif()
   endif()
 
   # Silence this warning when lnking the Debug configuration:


### PR DESCRIPTION
Fix for [TIMOB-20201](https://jira.appcelerator.org/browse/TIMOB-20201)

- Enable `SAFESEH`([Safe Exception Handlers](https://msdn.microsoft.com/en-us/library/9a89h429.aspx)) for Windows Store/Phone x86 build
- Remove OutputDebugString from some examples

We have been disabling `SAFESEH` linker option just to suppress compiler warning message for simulator according to [HAL/CMakeLists.txt#L195](https://github.com/appcelerator/HAL/blob/master/CMakeLists.txt#L195) and [LayoutEngine/CMakeLists.txt#L57](https://github.com/appcelerator/titanium_mobile_windows/blob/master/Source/LayoutEngine/CMakeLists.txt#L57).

Since SAFESEH option is only available on x86 build, it has been a no problem before because it only affects on the simulator. But in the Windows 10 world, we could have x86 app for the Store App, and disabling SAFESEH won't pass the Windows App Certification for x86. We should enable it again even on x86 build.
