### PR TITLE
[TIMOB-20191] e.source of a table click event should return table row

### DIFF
--- a/Source/UI/src/TableView.cpp
+++ b/Source/UI/src/TableView.cpp
@@ -254,6 +254,7 @@ namespace TitaniumWindows
 						const auto row = sections__.at(sectionIndex)->get_rows().at(itemIndex);
 						eventArgs.SetProperty("row", row->get_object());
 						eventArgs.SetProperty("rowData", fromSection ? row->get_object() : data__.at(itemIndex));
+						eventArgs.SetProperty("source", row->get_object());
 					}
 
 					fireEvent("click", eventArgs);


### PR DESCRIPTION
Fix for [TIMOB-20191](https://jira.appcelerator.org/browse/TIMOB-20191)

```javascript
var win = Ti.UI.createWindow();
var tableData = [{ title: 'Apples' }, { title: 'Bananas' }, { title: 'Carrots' }, { title: 'Potatoes' }];
var table = Ti.UI.createTableView({
    data: tableData
});
table.addEventListener('click', function (e) {
    Ti.API.info(e.source != table); // should be true
    Ti.API.info(e.source == e.row); // should be true
    Ti.API.info(e.source.title == e.row.title); // should be true
});
win.add(table);
win.open();
```