### PR TITLE
[TIMOB-20172] Windows 10: Cannot package for the phonestore or winstore

### DIFF
--- a/cli/hooks/package.js
+++ b/cli/hooks/package.js
@@ -22,7 +22,7 @@ exports.init = function (logger, config, cli) {
 	cli.on('build.post.compile', {
 		priority: 10000,
 		post: function (builder, finished) {
-			if (builder.buildOnly || builder.target !== 'dist-winstore') {
+			if (builder.buildOnly || !/^dist-(phone|win)store$/.test(builder.target)) {
 				return finished();
 			}
 

--- a/cli/hooks/package.js
+++ b/cli/hooks/package.js
@@ -18,6 +18,10 @@ const
 
 exports.cliVersion = '>=3.2';
 
+function sanitizeProjectName(str) {
+	return str.replace(/[^a-zA-Z0-9_]/g, '_').replace(/_+/g, '_').split(/[\W_]/).map(function (s) { return appc.string.capitalize(s); }).join('');
+}
+
 exports.init = function (logger, config, cli) {
 	cli.on('build.post.compile', {
 		priority: 10000,
@@ -27,13 +31,15 @@ exports.init = function (logger, config, cli) {
 			}
 
 			var outputDir = builder.outputDir,
-				wpARMDir = builder.cmakeTargetDir,
-				releaseDir = path.join(wpARMDir, 'Release'),
-				bundle = path.join(releaseDir, fs.readdirSync(releaseDir).filter(function (f) {
-					return f.indexOf('_Bundle') >= 0;
-				})[0]),
-				appx = path.join(bundle, fs.readdirSync(bundle).filter(function (f) {
-					return f.indexOf('.appx') >= 0 && f.indexOf('_scale') === -1;
+				tiapp = builder.tiapp,
+				sanitizedName = sanitizeProjectName(tiapp.name),
+				// name of the directory holding appx and dependencies subfolder
+				dirName = sanitizedName + '_' + appc.version.format(tiapp.version, 4, 4, true) + ((builder.buildConfiguration == 'Debug') ? '_Debug_Test' : '_Test');
+				// path to folder holding appx
+				appxDir = path.resolve(builder.cmakeTargetDir, 'AppPackages', sanitizedName, dirName),
+				appxExtensions = ['.appx', '.appxbundle'],
+				appx = path.join(bundle, fs.readdirSync(appxDir).filter(function (f) {
+					return appxExtensions.indexOf(path.extname(f)) !== -1;
 				})[0]),
 				dest = path.join(outputDir, path.basename(appx));
 

--- a/cli/hooks/wp-run.js
+++ b/cli/hooks/wp-run.js
@@ -2,7 +2,7 @@
  * Runs an app on a Windows Phone device or emulator.
  *
  * @copyright
- * Copyright (c) 2014 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2014-2015 by Appcelerator, Inc. All Rights Reserved.
  *
  * @license
  * Licensed under the terms of the Apache Public License
@@ -195,10 +195,11 @@ exports.init = function (logger, config, cli) {
 				}
 
 				var tiapp = builder.tiapp,
+					sanitizedName = sanitizeProjectName(tiapp.name),
 					// name of the directory holding appx and dependencies subfolder
-					dirName = sanitizeProjectName(tiapp.name) + '_' + appc.version.format(tiapp.version, 4, 4, true) + ((builder.buildConfiguration == 'Debug') ? '_Debug_Test' : '_Test');
+					dirName = sanitizedName + '_' + appc.version.format(tiapp.version, 4, 4, true) + ((builder.buildConfiguration == 'Debug') ? '_Debug_Test' : '_Test');
 					// path to folder holding appx
-					appxDir = path.resolve(builder.cmakeTargetDir, 'AppPackages', sanitizeProjectName(tiapp.name), dirName),
+					appxDir = path.resolve(builder.cmakeTargetDir, 'AppPackages', sanitizedName, dirName),
 					// path to folder holding depencies of the app
 					dependenciesDir = path.resolve(appxDir, 'Dependencies', (builder.cmakeArch == 'Win32') ? 'x86' : builder.cmakeArch),
 					// Options for installing app


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-20172

- copy the appx for dist-winstore AND dist-phonestore targets
- use exact same logic for finding the appx/appxbundle in package hook as we do in the windows phone run hook. (before we looked in a specific directory for a .appx, wasn't the same location as the file we used to install/launch on emulator).