### PR TITLE
If DB.execute returns an immediate SQLITE_DONE result, return null ra…

### DIFF
--- a/Examples/NMocha/src/Assets/ti.database.test.js
+++ b/Examples/NMocha/src/Assets/ti.database.test.js
@@ -365,4 +365,29 @@ describe('Titanium.Database', function () {
         // Finish the mocha test
         finish();
     });
+
+    // Test behavior expected by alloy code for createCollection. See TIMOB-20222
+    it('execute returns null instead of empty result set', function (finish) {
+        should(Ti.Database.install).not.be.undefined;
+        should(Ti.Database.install).be.a.Function;
+
+        // Call install on a database file that doesn't exist. We should just make a new db with name 'category'
+        var db = Ti.Database.install("made.up.sqlite", "category");
+
+        // Confirm 'db' is an object
+        should(db).be.a.Object;
+
+        var rows = db.execute('pragma table_info("category");');
+
+        should(rows).be.null;
+
+        // Remove the 'category' database file
+        db.remove();
+
+        // Close the database (unnecessary as remove() does this for us)
+        db.close();
+
+        finish();
+    });
+
 });

--- a/Source/Ti/src/Contacts/group.js
+++ b/Source/Ti/src/Contacts/group.js
@@ -9,9 +9,9 @@ function Group(name, identifier, recordId) {
  * Create Database if necessary and set up tables. Opens the Database for operations. Callers must close the database when done!
  **/
 function createDatabase() {
-    var db = Ti.Database.open('appc_contacts');
-    db.execute('CREATE TABLE IF NOT EXISTS people_groups (group_id INTEGER PRIMARY KEY, person_identifier TEXT)');
-    db.execute('CREATE TABLE IF NOT EXISTS groups (name TEXT, identifier TEXT)');
+	var db = Ti.Database.open('appc_contacts');
+	db.execute('CREATE TABLE IF NOT EXISTS people_groups (group_id INTEGER PRIMARY KEY, person_identifier TEXT)');
+	db.execute('CREATE TABLE IF NOT EXISTS groups (name TEXT, identifier TEXT)');
 	return db;
 }
 
@@ -26,7 +26,7 @@ Group.create = function (name) {
 		return new Group(name, identifier, db.lastInsertRowId);
 	}
 	finally {
-	    db && db.close();
+		db && db.close();
 	}
 };
 
@@ -39,7 +39,7 @@ Group.prototype.add = function (person) {
 		db.execute('INSERT INTO people_groups (group_id, person_identifier) VALUES (?, ?)', this.recordId, person.identifier);
 	}
 	finally {
-	    db && db.close();
+		db && db.close();
 	}
 };
 
@@ -52,7 +52,7 @@ Group.prototype.remove = function (person) {
 		db.execute('DELETE FROM people_groups WHERE (group_id IS ? AND person_identifier IS ?)', this.recordId, person.identifier);
 	}
 	finally {
-	    db && db.close();
+		db && db.close();
 	}
 };
 
@@ -67,7 +67,7 @@ Group.prototype.destroy = function () {
 		db.execute('DELETE FROM groups WHERE (rowid IS ?)', this.recordId);
 	}
 	finally {
-	    db && db.close();
+		db && db.close();
 	}
 };
 
@@ -88,18 +88,18 @@ Group.prototype.memberIdentifiers = function () {
 	try {
 		rows = db.execute('SELECT person_identifier FROM people_groups WHERE (group_id IS ?)', this.recordId);
 		try {
-			while (rows.isValidRow()) {
+			while (rows && rows.isValidRow()) {
 				identifiers.push(rows.fieldByName('person_identifier'));
 				rows.next();
 			}
 			return identifiers;
 		}
 		finally {
-		    rows && rows.close();
+			rows && rows.close();
 		}
 	}
 	finally {
-	    db && db.close();
+		db && db.close();
 	}
 };
 
@@ -133,7 +133,7 @@ Group.getAllGroups = function () {
 	try {
 		rows = db.execute('SELECT * FROM groups');
 		try {
-			while (rows.isValidRow()) {
+			while (rows && rows.isValidRow()) {
 				groups.push(new Group(rows.fieldByName('name'), rows.fieldByName('identifier'), rows.fieldByName('rowid')));
 				rows.next();
 			}
@@ -144,7 +144,7 @@ Group.getAllGroups = function () {
 		}
 	}
 	finally {
-	    db && db.close();
+		db && db.close();
 	}
 };
 
@@ -155,17 +155,17 @@ Group.getGroupByIdentifier = function (identifier) {
 	try {
 		rows = db.execute('SELECT * FROM groups WHERE identifier = ?', identifier);
 		try {
-			if (rows.isValidRow()) {
+			if (rows && rows.isValidRow()) {
 				group = new Group(rows.fieldByName('name'), rows.fieldByName('identifier'), rows.fieldByName('rowid'));
 			}
 			return group;
 		}
 		finally {
-		    rows && rows.close();
+			rows && rows.close();
 		}
 	}
 	finally {
-	    db && db.close();
+		db && db.close();
 	}
 };
 

--- a/Source/TitaniumKit/src/Database/DB.cpp
+++ b/Source/TitaniumKit/src/Database/DB.cpp
@@ -168,6 +168,13 @@ namespace Titanium
 			// Execute query statement
 			auto stepResult = sqlite3_step(statement);
 
+			int affectedRows = 0;
+			if (stepResult == SQLITE_DONE) {
+				sqlite3_finalize(statement);
+				affected_rows__ = 1; // FIXME Why do we set the DB's affected rows to 1 while the result set says 0?
+				return get_context().CreateNull();
+			}
+
 			// Now let's wrap the results in our ResultSet proxy
 			// FIXME Pass these values into the constructor, don't expose the fields
 			// How would we pass along the statement pointer?
@@ -176,14 +183,6 @@ namespace Titanium
 			resultSet->setDatabase(this);
 			const auto insert_result = resultSets__.emplace(statement, resultSet);
 			TITANIUM_ASSERT(insert_result.second);
-			int affectedRows = 0;
-			if (stepResult == SQLITE_DONE) {
-				sqlite3_finalize(statement);
-				resultSet->affected_rows__ = affectedRows;
-				affected_rows__ = resultSet->affected_rows__ + 1; // FIXME Why do we set the DB's affected rows to 1 while the result set says 0?
-				resultSet->statement__ = statement;
-				return resultSet_object;
-			}
 
 			while (stepResult != SQLITE_DONE) {
 				if (stepResult == SQLITE_ROW) {


### PR DESCRIPTION
…ther than an empty ResultSet

I'm not sure if this will fix https://jira.appcelerator.org/browse/TIMOB-20222 by itself, but it appears to at least play a role in that bug. Alloy seems to rely on db.execute returning a null value when "pragma table_info("table")" is called for a nonexistent table, which is specifically what Android does if a SELECT or PRAGMA returns a cursor with 0 columns. So in our case, if we get a value of SQL_DONE and no rows, we return a JS null instead of an empty ResultSet. This implementation may not be correct. I might need to instead call sqlite3_column_count(stmt) and if it's 0 then return null?