### PR TITLE
[TIMOB-20236] Fix GetUriFromPath to handle local paths

### DIFF
--- a/Source/UI/src/ImageView.cpp
+++ b/Source/UI/src/ImageView.cpp
@@ -12,6 +12,7 @@
 #include "TitaniumWindows/UI/View.hpp"
 #include "Titanium/Blob.hpp"
 #include <ppltasks.h>
+#include <boost/algorithm/string.hpp>
 
 namespace TitaniumWindows
 {
@@ -210,7 +211,7 @@ namespace TitaniumWindows
 
 			const auto uri = TitaniumWindows::Utility::GetUriFromPath(path);
 			// check if we're loading from local file
-			if (uri->SchemeName == "ms-appx") {
+			if (boost::starts_with(TitaniumWindows::Utility::ConvertString(uri->SchemeName), "ms-")) {
 				concurrency::create_task(StorageFile::GetFileFromApplicationUriAsync(uri)).then([this](concurrency::task<StorageFile^> task){
 					try {
 						auto file = task.get();

--- a/Source/Utility/src/Utility.cpp
+++ b/Source/Utility/src/Utility.cpp
@@ -9,7 +9,7 @@
 
 #include "TitaniumWindows/Utility.hpp"
 #include "HAL/HAL.hpp"
-#include <boost/algorithm/string/predicate.hpp>
+#include <boost/algorithm/string.hpp>
 #include "Titanium/detail/TiImpl.hpp"
 #include "TitaniumWindows/WindowsMacros.hpp"
 #include <ctime>
@@ -160,14 +160,33 @@ namespace TitaniumWindows
 		Windows::Foundation::Uri^ GetUriFromPath(const std::string& path) 
 		{
 			std::string modified = path;
+
+			// fix backslash
+			boost::replace_all<std::string>(modified, "\\", "/");
+
 			// if the path isn't an http/s URI already, fix URI to point to local files in app
 			if (!boost::starts_with(modified, "http://") && !boost::starts_with(modified, "https://")) {
-				// URIs must be absolute
-				if (!boost::starts_with(modified, "/")) {
-					modified = "/" + modified;
+
+				// fix root folder path
+				auto rootFolder = TitaniumWindows::Utility::ConvertString(Windows::ApplicationModel::Package::Current->InstalledLocation->Path);
+				boost::replace_all<std::string>(rootFolder, "\\", "/");
+				boost::replace_all<std::string>(modified, rootFolder, "ms-appx:///");
+				
+				// fix local folder path
+				auto localFolder = TitaniumWindows::Utility::ConvertString(Windows::Storage::ApplicationData::Current->LocalFolder->Path);
+				boost::replace_all<std::string>(localFolder, "\\", "/");
+				boost::replace_all<std::string>(modified, localFolder, "ms-appdata:///local");
+
+				// fix relative path with application directory
+				if (!boost::starts_with(modified, "ms-appx:") && !boost::starts_with(modified, "ms-appdata:")) {
+
+					// always absolute path
+					if (!boost::starts_with(modified, "/")) {
+						modified = "/" + modified;
+					}
+
+					modified = "ms-appx://" + modified;
 				}
-				// use MS's in-app URL scheme
-				modified = "ms-appx://" + modified;
 			}
 			return ref new Windows::Foundation::Uri(TitaniumWindows::Utility::ConvertUTF8String(modified));
 		}
@@ -175,6 +194,10 @@ namespace TitaniumWindows
 		Windows::Foundation::Uri^ GetWebUriFromPath(const std::string& path)
 		{
 			std::string modified = path;
+
+			// fix backslash
+			boost::replace_all<std::string>(modified, "\\", "/");
+
 			// if the path isn't an http/s URI already, fix URI to point to local files in app
 			if (!boost::starts_with(modified, "http://") && !boost::starts_with(modified, "https://")) {
 				// URIs must be absolute


### PR DESCRIPTION
- Fixed ```GetUriFromPath``` to handle local file paths

###### TEST CASE
```Javascript
var win = Ti.UI.createWindow({backgroundColor:'black'}),
    img = Ti.UI.createImageView({height:'50%'}),
    http = Titanium.Network.createHTTPClient({
        onload: function () {
            var f = Ti.Filesystem.getFile(Ti.Filesystem.applicationDataDirectory, 'win.png');
            f.write(this.responseData);
            Ti.App.fireEvent('downloaded', { path: f.nativePath });
        },
        timeout: 3000
    });

http.open('GET', 'http://tinyurl.com/TIMOB-20236');
http.send();
Ti.App.addEventListener('downloaded', function (e) {
    img.image = e.path;
});
img.addEventListener('click', function () {
    img.image = 'Logo.png';
});
win.add(img);
win.open();
```

[TIMOB-20236](https://jira.appcelerator.org/browse/TIMOB-20236)