### PR TITLE
Fix: File.write can't handle UTF-8 string

### DIFF
--- a/Source/Titanium/include/TitaniumWindows/File.hpp
+++ b/Source/Titanium/include/TitaniumWindows/File.hpp
@@ -151,7 +151,7 @@ namespace TitaniumWindows
 				if (append) {
 					writeContentFromFile(writer, appendingFile);
 				}
-				writer->WriteString(TitaniumWindows::Utility::ConvertString(string));
+				writer->WriteString(TitaniumWindows::Utility::ConvertUTF8String(string));
 				return writer->DetachBuffer();
 			}
 


### PR DESCRIPTION
Fix for [TIMOB-20288](https://jira.appcelerator.org/browse/TIMOB-20288).

```javascript
var filePath = Ti.Filesystem.applicationDataDirectory + "test.txt";
var file = Ti.Filesystem.getFile(filePath);
file.write("日本語 : Japanese");
alert(file.read().text);
```
