### PR TITLE
[TIMOB-20300] Disable reuse of MSBuild in build.js

### DIFF
--- a/Tools/Scripts/build/build.js
+++ b/Tools/Scripts/build/build.js
@@ -158,6 +158,7 @@ function runMSBuild(msBuildVersion, slnFile, buildType, arch, parallel, quiet, c
 	}
 	args.unshift(slnFile);
 	parallel && args.push('/m');
+	args.push('/nr:false');
 	spawnWithArgs('MSBuild', 'C:/Program Files (x86)/MSBuild/' + msBuildVersion + '/Bin/MSBuild.exe', args, {}, quiet, callback);
 }
 


### PR DESCRIPTION
- Disable the reuse of MSBuild nodes; preventing the locking of resources

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-20300)