### PR TITLE
Fix: ProgressBar default layout should be SIZE, not FILL

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/ProgressBar.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/ProgressBar.hpp
@@ -53,7 +53,7 @@ namespace TitaniumWindows
 
 			ProgressBar(const JSContext&) TITANIUM_NOEXCEPT;
 
-			virtual ~ProgressBar()                  = default;
+			virtual ~ProgressBar();
 			ProgressBar(const ProgressBar&)            = default;
 			ProgressBar& operator=(const ProgressBar&) = default;
 #ifdef TITANIUM_MOVE_CTOR_AND_ASSIGN_DEFAULT_ENABLE
@@ -74,6 +74,8 @@ namespace TitaniumWindows
 			Windows::UI::Xaml::Controls::StackPanel^ panel__;
 			Windows::UI::Xaml::Controls::ProgressBar^ bar__;
 			Windows::UI::Xaml::Controls::TextBlock^ label__;
+
+			Windows::Foundation::EventRegistrationToken sizechanged_event__;
 
 		};
 	}  // namespace UI

--- a/Source/UI/src/ProgressBar.cpp
+++ b/Source/UI/src/ProgressBar.cpp
@@ -48,6 +48,17 @@ namespace TitaniumWindows
 			bar__ = ref new Windows::UI::Xaml::Controls::ProgressBar();
 			bar__->Background = ref new Windows::UI::Xaml::Media::SolidColorBrush(Windows::UI::Colors::Gray);
 
+			sizechanged_event__ = panel__->SizeChanged += ref new SizeChangedEventHandler([this](Platform::Object^ sender, SizeChangedEventArgs^ e) {
+				const auto fill = Titanium::UI::Constants::to_string(Titanium::UI::LAYOUT::FILL);
+				const auto layout = getViewLayoutDelegate<WindowsViewLayoutDelegate>();
+				if (layout->get_height() != fill) {
+					layout->set_height(std::to_string(e->NewSize.Height));
+				}
+				if (layout->get_width() != fill) {
+					layout->set_width(std::to_string(e->NewSize.Width));
+				}
+			});
+
 			label__ = ref new Windows::UI::Xaml::Controls::TextBlock();
 			label__->Text = "";
 
@@ -62,8 +73,8 @@ namespace TitaniumWindows
 			panel__->Children->Append(bar__);
 
 			Titanium::UI::ProgressBar::setLayoutDelegate<ProgressBarLayoutDelegate>(bar__);
-			layoutDelegate__->set_defaultHeight(Titanium::UI::LAYOUT::FILL);
-			layoutDelegate__->set_defaultWidth(Titanium::UI::LAYOUT::FILL);
+			layoutDelegate__->set_defaultHeight(Titanium::UI::LAYOUT::SIZE);
+			layoutDelegate__->set_defaultWidth(Titanium::UI::LAYOUT::SIZE);
 			getViewLayoutDelegate<ProgressBarLayoutDelegate>()->setComponent(panel__);
 		}
 
@@ -71,6 +82,11 @@ namespace TitaniumWindows
 			: Titanium::UI::ProgressBar(js_context)
 		{
 			TITANIUM_LOG_DEBUG("ProgressBar::ctor Initialize");
+		}
+
+		ProgressBar::~ProgressBar()
+		{
+			panel__->SizeChanged -= sizechanged_event__;
 		}
 
 		void ProgressBar::JSExportInitialize() 


### PR DESCRIPTION
Fix for [TIMOB-20282](https://jira.appcelerator.org/browse/TIMOB-20282)

According to [Transitioning to the New UI Layout System](http://docs.appcelerator.com/platform/latest/#!/guide/Transitioning_to_the_New_UI_Layout_System), the default layout of `ProgressBar` should be `Ti.UI.SIZE`, not `Ti.UI.FILL`. For instance following example should show green background only under the progress bar & text, and it should not fill parent view.

```javascript
var pb = Ti.UI.createProgressBar({
    min: 0,
    max: 10,
    value: 5,
    color: 'blue',
    backgroundColor: 'green',
    backgroundDisabledColor: 'gray',
    message: 'Downloading 0 of 10'
});
var win = Ti.UI.createWindow({backgroundColor:'yellow'});
win.add(pb);
win.open();
pb.show();
```

![windows_8_1](https://cloud.githubusercontent.com/assets/1661068/12744195/340db7d4-c9d6-11e5-8fbd-eb9ef822bfff.png)
