### PR TITLE
Implement Blob imageAs* methods

### DIFF
--- a/Examples/NMocha/src/Assets/ti.blob.test.js
+++ b/Examples/NMocha/src/Assets/ti.blob.test.js
@@ -109,34 +109,61 @@ describe("Titanium.Blob", function () {
         should(file.nativePath).be.eql(blob.nativePath);
         finish();
     });
-    it.skip("imageAsCropped", function (finish) {
-        var blob = Ti.Filesystem.getFile('app.js').read();
+    it("imageAsCropped", function (finish) {
+        var blob = Ti.Filesystem.getFile('Logo.png').read();
         should(blob.imageAsCropped).be.a.Function;
+        should(function () {
+            var b = blob.imageAsCropped({ width: 50, height: 60, x: 0, y: 0 });
+            should(b).be.an.Object;
+            should(b.width).be.eql(50);
+            should(b.height).be.eql(60);
+        }).not.throw();
         finish();
     });
-    it.skip("imageAsResized", function (finish) {
-        var blob = Ti.Filesystem.getFile('app.js').read();
+    it("imageAsResized", function (finish) {
+        var blob = Ti.Filesystem.getFile('Logo.png').read();
         should(blob.imageAsResized).be.a.Function;
+        should(function () {
+            var b = blob.imageAsResized(50, 60);
+            should(b).be.an.Object;
+            should(b.width).be.eql(50);
+            should(b.height).be.eql(60);
+        }).not.throw();
         finish();
     });
-    it.skip("imageAsThumbnail", function (finish) {
-        var blob = Ti.Filesystem.getFile('app.js').read();
+    it("imageAsThumbnail", function (finish) {
+        var blob = Ti.Filesystem.getFile('Logo.png').read();
         should(blob.imageAsThumbnail).be.a.Function;
+        should(function () {
+            var b = blob.imageAsThumbnail(50);
+            should(b).be.an.Object;
+            should(b.width).eql(50);
+            should(b.height).eql(50);
+        }).not.throw();
         finish();
     });
-    it.skip("imageWithAlpha", function (finish) {
-        var blob = Ti.Filesystem.getFile('app.js').read();
+    it("imageWithAlpha", function (finish) {
+        var blob = Ti.Filesystem.getFile('Logo.png').read();
         should(blob.imageWithAlpha).be.a.Function;
+        should(function () {
+            blob.imageWithAlpha();
+        }).not.throw();
         finish();
     });
-    it.skip("imageWithRoundedCorner", function (finish) {
-        var blob = Ti.Filesystem.getFile('app.js').read();
+    it("imageWithRoundedCorner", function (finish) {
+        var blob = Ti.Filesystem.getFile('Logo.png').read();
         should(blob.imageWithRoundedCorner).be.a.Function;
+        should(function () {
+            blob.imageWithRoundedCorner(1);
+        }).not.throw();
         finish();
     });
-    it.skip("imageWithTransparentBorder", function (finish) {
-        var blob = Ti.Filesystem.getFile('app.js').read();
+    it("imageWithTransparentBorder", function (finish) {
+        var blob = Ti.Filesystem.getFile('Logo.png').read();
         should(blob.imageWithTransparentBorder).be.a.Function;
+        should(function () {
+            blob.imageWithTransparentBorder(1);
+        }).not.throw();
         finish();
     });
 });

--- a/Source/Titanium/include/TitaniumWindows/Blob.hpp
+++ b/Source/Titanium/include/TitaniumWindows/Blob.hpp
@@ -78,7 +78,7 @@ namespace TitaniumWindows
 		  @param crop options (width, height, x, y)
 		  @discussion Creates a new blob by resizing/scaling/cropping the underlying image to the specified dimensions.
 		*/
-		std::shared_ptr<Titanium::Blob> transformImage(const std::uint32_t& width, const std::uint32_t height, const Titanium::UI::Dimension& crop) TITANIUM_NOEXCEPT;
+		std::shared_ptr<Titanium::Blob> transformImage(const std::uint32_t& scaledWidth, const std::uint32_t scaledHeight, const Titanium::UI::Dimension& crop) TITANIUM_NOEXCEPT;
 
 		Blob(const JSContext&) TITANIUM_NOEXCEPT;
 		virtual ~Blob();

--- a/Source/Titanium/include/TitaniumWindows/Blob.hpp
+++ b/Source/Titanium/include/TitaniumWindows/Blob.hpp
@@ -25,7 +25,60 @@ namespace TitaniumWindows
 	public:
 		::Platform::Guid getImageEncoder();
 
-		void construct(Windows::Storage::StorageFile^ file);
+		virtual void construct(const std::vector<std::uint8_t>& data, const std::string& mimetype) TITANIUM_NOEXCEPT;
+		virtual void construct(Windows::Storage::StorageFile^ file) TITANIUM_NOEXCEPT;
+
+		/*!
+		  @method
+		  @abstract imageAsCropped
+		  @discussion Creates a new blob by cropping the underlying image to the specified dimensions.
+		*/
+		virtual std::shared_ptr<Titanium::Blob> imageAsCropped(const Titanium::UI::Dimension&) TITANIUM_NOEXCEPT override;
+
+		/*!
+		  @method
+		  @abstract imageAsResized
+		  @discussion Creates a new blob by resizing and scaling the underlying image to the specified dimensions.
+		*/
+		virtual std::shared_ptr<Titanium::Blob> imageAsResized(const std::uint32_t&, const std::uint32_t&) TITANIUM_NOEXCEPT override;
+
+		/*!
+		  @method
+		  @abstract imageAsThumbnail
+		  @discussion Returns a thumbnail version of the underlying image, optionally with a border and rounded corners.
+		*/
+		virtual std::shared_ptr<Titanium::Blob> imageAsThumbnail(const std::uint32_t&, const std::uint32_t&, const double&) TITANIUM_NOEXCEPT override;
+
+		/*!
+		  @method
+		  @abstract imageWithAlpha
+		  @discussion Returns a copy of the underlying image with an added alpha channel.
+		*/
+		virtual std::shared_ptr<Titanium::Blob> imageWithAlpha() TITANIUM_NOEXCEPT override;
+
+		/*!
+		  @method
+		  @abstract imageWithRoundedCorner
+		  @discussion Returns a copy of the underlying image with rounded corners added.
+		*/
+		virtual std::shared_ptr<Titanium::Blob> imageWithRoundedCorner(const std::uint32_t&, const std::uint32_t&) TITANIUM_NOEXCEPT override;
+
+		/*!
+		  @method
+		  @abstract imageWithTransparentBorder
+		  @discussion Returns a copy of the underlying image with an added transparent border.
+		*/
+		virtual std::shared_ptr<Titanium::Blob> imageWithTransparentBorder(const std::uint32_t&) TITANIUM_NOEXCEPT override;
+
+		/*!
+		  @method
+		  @abstract transformImage
+		  @param width Width to resize
+		  @param height Height to resize
+		  @param crop options (width, height, x, y)
+		  @discussion Creates a new blob by resizing/scaling/cropping the underlying image to the specified dimensions.
+		*/
+		std::shared_ptr<Titanium::Blob> transformImage(const std::uint32_t& width, const std::uint32_t height, const Titanium::UI::Dimension& crop) TITANIUM_NOEXCEPT;
 
 		Blob(const JSContext&) TITANIUM_NOEXCEPT;
 		virtual ~Blob();

--- a/Source/Titanium/include/TitaniumWindows/Blob.hpp
+++ b/Source/Titanium/include/TitaniumWindows/Blob.hpp
@@ -30,55 +30,13 @@ namespace TitaniumWindows
 
 		/*!
 		  @method
-		  @abstract imageAsCropped
-		  @discussion Creates a new blob by cropping the underlying image to the specified dimensions.
-		*/
-		virtual std::shared_ptr<Titanium::Blob> imageAsCropped(const Titanium::UI::Dimension&) TITANIUM_NOEXCEPT override;
-
-		/*!
-		  @method
-		  @abstract imageAsResized
-		  @discussion Creates a new blob by resizing and scaling the underlying image to the specified dimensions.
-		*/
-		virtual std::shared_ptr<Titanium::Blob> imageAsResized(const std::uint32_t&, const std::uint32_t&) TITANIUM_NOEXCEPT override;
-
-		/*!
-		  @method
-		  @abstract imageAsThumbnail
-		  @discussion Returns a thumbnail version of the underlying image, optionally with a border and rounded corners.
-		*/
-		virtual std::shared_ptr<Titanium::Blob> imageAsThumbnail(const std::uint32_t&, const std::uint32_t&, const double&) TITANIUM_NOEXCEPT override;
-
-		/*!
-		  @method
-		  @abstract imageWithAlpha
-		  @discussion Returns a copy of the underlying image with an added alpha channel.
-		*/
-		virtual std::shared_ptr<Titanium::Blob> imageWithAlpha() TITANIUM_NOEXCEPT override;
-
-		/*!
-		  @method
-		  @abstract imageWithRoundedCorner
-		  @discussion Returns a copy of the underlying image with rounded corners added.
-		*/
-		virtual std::shared_ptr<Titanium::Blob> imageWithRoundedCorner(const std::uint32_t&, const std::uint32_t&) TITANIUM_NOEXCEPT override;
-
-		/*!
-		  @method
-		  @abstract imageWithTransparentBorder
-		  @discussion Returns a copy of the underlying image with an added transparent border.
-		*/
-		virtual std::shared_ptr<Titanium::Blob> imageWithTransparentBorder(const std::uint32_t&) TITANIUM_NOEXCEPT override;
-
-		/*!
-		  @method
 		  @abstract transformImage
 		  @param width Width to resize
 		  @param height Height to resize
 		  @param crop options (width, height, x, y)
 		  @discussion Creates a new blob by resizing/scaling/cropping the underlying image to the specified dimensions.
 		*/
-		std::shared_ptr<Titanium::Blob> transformImage(const std::uint32_t& scaledWidth, const std::uint32_t scaledHeight, const Titanium::UI::Dimension& crop) TITANIUM_NOEXCEPT;
+		virtual std::shared_ptr<Titanium::Blob> transformImage(const std::uint32_t& scaledWidth, const std::uint32_t scaledHeight, const Titanium::UI::Dimension& crop) TITANIUM_NOEXCEPT override;
 
 		Blob(const JSContext&) TITANIUM_NOEXCEPT;
 		virtual ~Blob();

--- a/Source/Titanium/src/Blob.cpp
+++ b/Source/Titanium/src/Blob.cpp
@@ -103,7 +103,7 @@ namespace TitaniumWindows
 		}
 	}
 
-	std::shared_ptr<Titanium::Blob> Blob::transformImage(const std::uint32_t& width, const std::uint32_t height, const Titanium::UI::Dimension& crop) TITANIUM_NOEXCEPT
+	std::shared_ptr<Titanium::Blob> Blob::transformImage(const std::uint32_t& scaledWidth, const std::uint32_t scaledHeight, const Titanium::UI::Dimension& crop) TITANIUM_NOEXCEPT
 	{
 		using namespace Windows::Graphics::Imaging;
 		using namespace Windows::Storage::Streams;
@@ -123,11 +123,11 @@ namespace TitaniumWindows
 			return BitmapDecoder::CreateAsync(instream);
 		}, task_continuation_context::use_arbitrary()).then([outstream](BitmapDecoder^ decoder){
 			return BitmapEncoder::CreateForTranscodingAsync(outstream, decoder);
-		}, task_continuation_context::use_arbitrary()).then([width, height, crop](BitmapEncoder^ encoder){
+		}, task_continuation_context::use_arbitrary()).then([scaledWidth, scaledHeight, crop](BitmapEncoder^ encoder){
 
 			// scaling
-			encoder->BitmapTransform->ScaledWidth  = width;
-			encoder->BitmapTransform->ScaledHeight = height;
+			encoder->BitmapTransform->ScaledWidth  = scaledWidth;
+			encoder->BitmapTransform->ScaledHeight = scaledHeight;
 
 			// cropping
 			BitmapBounds bounds;
@@ -156,8 +156,8 @@ namespace TitaniumWindows
 		auto blob = Blob.CallAsConstructor();
 		auto blob_ptr = blob.GetPrivate<TitaniumWindows::Blob>();
 		blob_ptr->construct(data, mimetype_);
-		blob_ptr->width_  = width;
-		blob_ptr->height_ = height;
+		blob_ptr->width_  = crop.width;
+		blob_ptr->height_ = crop.height;
 
 		return blob.GetPrivate<Titanium::Blob>();
 	}

--- a/Source/Titanium/src/Blob.cpp
+++ b/Source/Titanium/src/Blob.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "TitaniumWindows/Blob.hpp"
+#include "Titanium/UI/Dimension.hpp"
 #include "TitaniumWindows/Utility.hpp"
 #include "TitaniumWindows/GlobalObject.hpp"
 #include <ppltasks.h>
@@ -159,51 +160,7 @@ namespace TitaniumWindows
 		blob_ptr->width_  = crop.width;
 		blob_ptr->height_ = crop.height;
 
-		return blob.GetPrivate<Titanium::Blob>();
+		return blob_ptr;
 	}
 
-	std::shared_ptr<Titanium::Blob> Blob::imageAsCropped(const Titanium::UI::Dimension& options) TITANIUM_NOEXCEPT
-	{
-		return transformImage(width_, height_, options);
-	}
-
-	std::shared_ptr<Titanium::Blob> Blob::imageAsResized(const std::uint32_t& width, const std::uint32_t& height) TITANIUM_NOEXCEPT
-	{
-		Titanium::UI::Dimension crop;
-		crop.width  = width;
-		crop.height = height;
-		crop.x = 0;
-		crop.y = 0;
-
-		return transformImage(width, height, crop);
-	}
-
-	std::shared_ptr<Titanium::Blob> Blob::imageAsThumbnail(const std::uint32_t& size, const std::uint32_t& borderSize, const double& cornerRadius) TITANIUM_NOEXCEPT
-	{
-		Titanium::UI::Dimension crop;
-		crop.width  = size;
-		crop.height = size;
-		crop.x = 0;
-		crop.y = 0;
-
-		return transformImage(size, size, crop);
-	}
-
-	std::shared_ptr<Titanium::Blob> Blob::imageWithAlpha() TITANIUM_NOEXCEPT
-	{
-		TITANIUM_LOG_WARN("Blob::imageWithAlpha: Unimplemented");
-		return nullptr;
-	}
-
-	std::shared_ptr<Titanium::Blob> Blob::imageWithRoundedCorner(const std::uint32_t& cornerSize, const std::uint32_t& borderSize) TITANIUM_NOEXCEPT
-	{
-		TITANIUM_LOG_WARN("Blob::imageWithRoundedCorner: Unimplemented");
-		return nullptr;
-	}
-
-	std::shared_ptr<Titanium::Blob> Blob::imageWithTransparentBorder(const std::uint32_t& size) TITANIUM_NOEXCEPT
-	{
-		TITANIUM_LOG_WARN("Blob::imageWithTransparentBorder: Unimplemented");
-		return nullptr;
-	}
 }  // namespace TitaniumWindows

--- a/Source/TitaniumKit/include/Titanium/Blob.hpp
+++ b/Source/TitaniumKit/include/Titanium/Blob.hpp
@@ -8,6 +8,7 @@
 #define _TITANIUM_BLOB_HPP_
 
 #include "Titanium/Module.hpp"
+#include "Titanium/UI/Dimension.hpp"
 
 namespace Titanium
 {
@@ -93,6 +94,48 @@ namespace Titanium
 		*/
 		virtual void append(const std::shared_ptr<Blob>&) TITANIUM_NOEXCEPT;
 
+		/*!
+		  @method
+		  @abstract imageAsCropped
+		  @discussion Creates a new blob by cropping the underlying image to the specified dimensions.
+		*/
+		virtual std::shared_ptr<Blob> imageAsCropped(const Titanium::UI::Dimension&) TITANIUM_NOEXCEPT;
+
+		/*!
+		  @method
+		  @abstract imageAsResized
+		  @discussion Creates a new blob by resizing and scaling the underlying image to the specified dimensions.
+		*/
+		virtual std::shared_ptr<Blob> imageAsResized(const std::uint32_t&, const std::uint32_t&) TITANIUM_NOEXCEPT;
+
+		/*!
+		  @method
+		  @abstract imageAsThumbnail
+		  @discussion Returns a thumbnail version of the underlying image, optionally with a border and rounded corners.
+		*/
+		virtual std::shared_ptr<Blob> imageAsThumbnail(const std::uint32_t&, const std::uint32_t&, const double&) TITANIUM_NOEXCEPT;
+
+		/*!
+		  @method
+		  @abstract imageWithAlpha
+		  @discussion Returns a copy of the underlying image with an added alpha channel.
+		*/
+		virtual std::shared_ptr<Blob> imageWithAlpha() TITANIUM_NOEXCEPT;
+
+		/*!
+		  @method
+		  @abstract imageWithRoundedCorner
+		  @discussion Returns a copy of the underlying image with rounded corners added.
+		*/
+		virtual std::shared_ptr<Blob> imageWithRoundedCorner(const std::uint32_t&, const std::uint32_t&) TITANIUM_NOEXCEPT;
+
+		/*!
+		  @method
+		  @abstract imageWithTransparentBorder
+		  @discussion Returns a copy of the underlying image with an added transparent border.
+		*/
+		virtual std::shared_ptr<Blob> imageWithTransparentBorder(const std::uint32_t&) TITANIUM_NOEXCEPT;
+
 		virtual void construct(const std::vector<std::uint8_t>& data) TITANIUM_NOEXCEPT;
 		virtual std::vector<std::uint8_t> getData() TITANIUM_NOEXCEPT;
 
@@ -129,6 +172,12 @@ namespace Titanium
 		TITANIUM_FUNCTION_DEF(getText);
 		TITANIUM_FUNCTION_DEF(getWidth);
 		TITANIUM_FUNCTION_DEF(toString);
+		TITANIUM_FUNCTION_DEF(imageAsCropped);
+		TITANIUM_FUNCTION_DEF(imageAsResized);
+		TITANIUM_FUNCTION_DEF(imageAsThumbnail);
+		TITANIUM_FUNCTION_DEF(imageWithAlpha);
+		TITANIUM_FUNCTION_DEF(imageWithRoundedCorner);
+		TITANIUM_FUNCTION_DEF(imageWithTransparentBorder);
 
 	protected:
 #pragma warning(push)

--- a/Source/TitaniumKit/include/Titanium/Blob.hpp
+++ b/Source/TitaniumKit/include/Titanium/Blob.hpp
@@ -8,7 +8,6 @@
 #define _TITANIUM_BLOB_HPP_
 
 #include "Titanium/Module.hpp"
-#include "Titanium/UI/Dimension.hpp"
 
 namespace Titanium
 {
@@ -28,6 +27,11 @@ namespace Titanium
 			FILE = 1,
 			DATA = 2
 		};
+	}
+
+	namespace UI
+	{
+		struct Dimension;
 	}
 
 	/*!
@@ -135,6 +139,16 @@ namespace Titanium
 		  @discussion Returns a copy of the underlying image with an added transparent border.
 		*/
 		virtual std::shared_ptr<Blob> imageWithTransparentBorder(const std::uint32_t&) TITANIUM_NOEXCEPT;
+
+		/*!
+		@method
+		@abstract transformImage
+		@param width Width to resize
+		@param height Height to resize
+		@param crop options (width, height, x, y)
+		@discussion Creates a new blob by resizing/scaling/cropping the underlying image to the specified dimensions.
+		*/
+		virtual std::shared_ptr<Titanium::Blob> transformImage(const std::uint32_t& scaledWidth, const std::uint32_t scaledHeight, const Titanium::UI::Dimension& crop) TITANIUM_NOEXCEPT;
 
 		virtual void construct(const std::vector<std::uint8_t>& data) TITANIUM_NOEXCEPT;
 		virtual std::vector<std::uint8_t> getData() TITANIUM_NOEXCEPT;

--- a/Source/TitaniumKit/include/Titanium/UI/ViewLayoutDelegate.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/ViewLayoutDelegate.hpp
@@ -158,8 +158,8 @@ namespace Titanium
 
 			  Default: 0
 			*/
-			virtual uint32_t get_borderRadius() const TITANIUM_NOEXCEPT;
-			virtual void set_borderRadius(const uint32_t& borderRadius) TITANIUM_NOEXCEPT;
+			virtual double get_borderRadius() const TITANIUM_NOEXCEPT;
+			virtual void set_borderRadius(const double& borderRadius) TITANIUM_NOEXCEPT;
 
 			/*!
 			  @method
@@ -545,7 +545,7 @@ namespace Titanium
 			  @abstract viewShadowRadius
 			  @discussion Determines the blur radius used to create the shadow.
 			*/
-			TITANIUM_PROPERTY_IMPL_DEF(uint32_t, viewShadowRadius);
+			TITANIUM_PROPERTY_IMPL_DEF(double, viewShadowRadius);
 
 			/*!
 			  @property
@@ -606,7 +606,7 @@ namespace Titanium
 			std::string backgroundImage__;
 			std::string backgroundColor__;
 			std::string borderColor__;
-			uint32_t borderRadius__;
+			double borderRadius__;
 			uint32_t borderWidth__;
 			double opacity__;
 			std::string top__;
@@ -638,7 +638,7 @@ namespace Titanium
 			std::string pullBackgroundColor__;
 			std::shared_ptr<TwoDMatrix> transform2D__;
 			std::shared_ptr<ThreeDMatrix> transform3D__;
-			uint32_t viewShadowRadius__;
+			double viewShadowRadius__;
 			std::string viewShadowColor__;
 			Point viewShadowOffset__;
 			bool horizontalWrap__ { true };

--- a/Source/TitaniumKit/src/Blob.cpp
+++ b/Source/TitaniumKit/src/Blob.cpp
@@ -56,7 +56,12 @@ namespace Titanium
 		TITANIUM_ADD_FUNCTION(Blob, getWidth);
 		TITANIUM_ADD_FUNCTION(Blob, append);
 		TITANIUM_ADD_FUNCTION(Blob, toString);
-		// TODO image* methods!
+		TITANIUM_ADD_FUNCTION(Blob, imageAsCropped);
+		TITANIUM_ADD_FUNCTION(Blob, imageAsResized);
+		TITANIUM_ADD_FUNCTION(Blob, imageAsThumbnail);
+		TITANIUM_ADD_FUNCTION(Blob, imageWithAlpha);
+		TITANIUM_ADD_FUNCTION(Blob, imageWithRoundedCorner);
+		TITANIUM_ADD_FUNCTION(Blob, imageWithTransparentBorder);
 	}
 
 	uint32_t Blob::get_length() const TITANIUM_NOEXCEPT
@@ -137,6 +142,42 @@ namespace Titanium
 		mimetype_ = "";
 	}
 
+	std::shared_ptr<Blob> Blob::imageAsCropped(const Titanium::UI::Dimension&) TITANIUM_NOEXCEPT
+	{
+		TITANIUM_LOG_WARN("Blob::imageAsCropped: Unimplemented");
+		return nullptr;
+	}
+
+	std::shared_ptr<Blob> Blob::imageAsResized(const std::uint32_t&, const std::uint32_t&) TITANIUM_NOEXCEPT
+	{
+		TITANIUM_LOG_WARN("Blob::imageAsResized: Unimplemented");
+		return nullptr;
+	}
+
+	std::shared_ptr<Blob> Blob::imageAsThumbnail(const std::uint32_t&, const std::uint32_t&, const double&) TITANIUM_NOEXCEPT
+	{
+		TITANIUM_LOG_WARN("Blob::imageAsThumbnail: Unimplemented");
+		return nullptr;
+	}
+
+	std::shared_ptr<Blob> Blob::imageWithAlpha() TITANIUM_NOEXCEPT
+	{
+		TITANIUM_LOG_WARN("Blob::imageWithAlpha: Unimplemented");
+		return nullptr;
+	}
+
+	std::shared_ptr<Blob> Blob::imageWithRoundedCorner(const std::uint32_t&, const std::uint32_t&) TITANIUM_NOEXCEPT
+	{
+		TITANIUM_LOG_WARN("Blob::imageWithRoundedCorner: Unimplemented");
+		return nullptr;
+	}
+
+	std::shared_ptr<Blob> Blob::imageWithTransparentBorder(const std::uint32_t&) TITANIUM_NOEXCEPT
+	{
+		TITANIUM_LOG_WARN("Blob::imageWithTransparentBorder: Unimplemented");
+		return nullptr;
+	}
+
 	TITANIUM_PROPERTY_GETTER(Blob, length)	
 	{
 		return get_context().CreateNumber(get_length());
@@ -206,6 +247,69 @@ namespace Titanium
 		append(blob_ptr);
 
 		return get_context().CreateUndefined();
+	}
+	
+	TITANIUM_FUNCTION(Blob, imageAsCropped)
+	{
+		ENSURE_OBJECT_AT_INDEX(options, 0);
+		const auto blob = imageAsCropped(Titanium::UI::js_to_Dimension(options));
+		if (blob) {
+			return blob->get_object();	
+		}
+		return get_context().CreateNull();
+	}
+
+	TITANIUM_FUNCTION(Blob, imageAsResized)
+	{
+		ENSURE_UINT_AT_INDEX(width,  0);
+		ENSURE_UINT_AT_INDEX(height, 1);
+		const auto blob = imageAsResized(width, height);
+		if (blob) {
+			return blob->get_object();
+		}
+		return get_context().CreateNull();
+	}
+
+	TITANIUM_FUNCTION(Blob, imageAsThumbnail)
+	{
+		ENSURE_UINT_AT_INDEX(size, 0);
+		ENSURE_OPTIONAL_UINT_AT_INDEX(borderSize, 1, 0);
+		ENSURE_OPTIONAL_DOUBLE_AT_INDEX(cornerRadius, 2, 0);
+		const auto blob = imageAsThumbnail(size, borderSize, cornerRadius);
+		if (blob) {
+			return blob->get_object();
+		}
+		return get_context().CreateNull();
+	}
+
+	TITANIUM_FUNCTION(Blob, imageWithAlpha)
+	{
+		const auto blob = imageWithAlpha();
+		if (blob) {
+			return blob->get_object();
+		}
+		return get_context().CreateNull();
+	}
+
+	TITANIUM_FUNCTION(Blob, imageWithRoundedCorner)
+	{
+		ENSURE_UINT_AT_INDEX(cornerSize, 0);
+		ENSURE_OPTIONAL_UINT_AT_INDEX(borderSize, 1, 0);
+		const auto blob = imageWithRoundedCorner(cornerSize, borderSize);
+		if (blob) {
+			return blob->get_object();
+		}
+		return get_context().CreateNull();
+	}
+
+	TITANIUM_FUNCTION(Blob, imageWithTransparentBorder)
+	{
+		ENSURE_UINT_AT_INDEX(size, 0);
+		const auto blob = imageWithTransparentBorder(size);
+		if (blob) {
+			return blob->get_object();
+		}
+		return get_context().CreateNull();
 	}
 
 	// getter functions

--- a/Source/TitaniumKit/src/Blob.cpp
+++ b/Source/TitaniumKit/src/Blob.cpp
@@ -7,6 +7,7 @@
 #include "Titanium/detail/TiImpl.hpp"
 #include "Titanium/Blob.hpp"
 #include "Titanium/Filesystem/File.hpp"
+#include "Titanium/UI/Dimension.hpp"
 #include <type_traits>
 
 namespace Titanium
@@ -142,22 +143,37 @@ namespace Titanium
 		mimetype_ = "";
 	}
 
-	std::shared_ptr<Blob> Blob::imageAsCropped(const Titanium::UI::Dimension&) TITANIUM_NOEXCEPT
+	std::shared_ptr<Titanium::Blob> Blob::transformImage(const std::uint32_t& scaledWidth, const std::uint32_t scaledHeight, const Titanium::UI::Dimension& crop) TITANIUM_NOEXCEPT
 	{
-		TITANIUM_LOG_WARN("Blob::imageAsCropped: Unimplemented");
+		TITANIUM_LOG_WARN("Blob::transformImage: Unimplemented");
 		return nullptr;
 	}
 
-	std::shared_ptr<Blob> Blob::imageAsResized(const std::uint32_t&, const std::uint32_t&) TITANIUM_NOEXCEPT
+	std::shared_ptr<Titanium::Blob> Blob::imageAsCropped(const Titanium::UI::Dimension& options) TITANIUM_NOEXCEPT
 	{
-		TITANIUM_LOG_WARN("Blob::imageAsResized: Unimplemented");
-		return nullptr;
+		return transformImage(width_, height_, options);
 	}
 
-	std::shared_ptr<Blob> Blob::imageAsThumbnail(const std::uint32_t&, const std::uint32_t&, const double&) TITANIUM_NOEXCEPT
+	std::shared_ptr<Titanium::Blob> Blob::imageAsResized(const std::uint32_t& width, const std::uint32_t& height) TITANIUM_NOEXCEPT
 	{
-		TITANIUM_LOG_WARN("Blob::imageAsThumbnail: Unimplemented");
-		return nullptr;
+		Titanium::UI::Dimension crop;
+		crop.width = width;
+		crop.height = height;
+		crop.x = 0;
+		crop.y = 0;
+
+		return transformImage(width, height, crop);
+	}
+
+	std::shared_ptr<Titanium::Blob> Blob::imageAsThumbnail(const std::uint32_t& size, const std::uint32_t& borderSize, const double& cornerRadius) TITANIUM_NOEXCEPT
+	{
+		Titanium::UI::Dimension crop;
+		crop.width = size;
+		crop.height = size;
+		crop.x = 0;
+		crop.y = 0;
+
+		return transformImage(size, size, crop);
 	}
 
 	std::shared_ptr<Blob> Blob::imageWithAlpha() TITANIUM_NOEXCEPT

--- a/Source/TitaniumKit/src/UI/View.cpp
+++ b/Source/TitaniumKit/src/UI/View.cpp
@@ -449,7 +449,7 @@ namespace Titanium
 		TITANIUM_PROPERTY_SETTER(View, viewShadowRadius)
 		{
 			TITANIUM_ASSERT(argument.IsNumber());
-			layoutDelegate__->set_viewShadowRadius(static_cast<uint32_t>(argument));
+			layoutDelegate__->set_viewShadowRadius(static_cast<double>(argument));
 			return true;
 		}
 
@@ -628,7 +628,7 @@ namespace Titanium
 		TITANIUM_PROPERTY_SETTER(View, borderRadius)
 		{
 			TITANIUM_ASSERT(argument.IsNumber());
-			layoutDelegate__->set_borderRadius(static_cast<uint32_t>(argument));
+			layoutDelegate__->set_borderRadius(static_cast<double>(argument));
 			return true;
 		}
 

--- a/Source/TitaniumKit/src/UI/ViewLayoutDelegate.cpp
+++ b/Source/TitaniumKit/src/UI/ViewLayoutDelegate.cpp
@@ -188,7 +188,7 @@ namespace Titanium
 		  @abstract viewShadowRadius
 		  @discussion Determines the blur radius used to create the shadow.
 		*/
-		TITANIUM_PROPERTY_READWRITE(ViewLayoutDelegate, uint32_t, viewShadowRadius);
+		TITANIUM_PROPERTY_READWRITE(ViewLayoutDelegate, double, viewShadowRadius);
 
 		/*!
 		  @property
@@ -246,12 +246,12 @@ namespace Titanium
 			borderColor__ = borderColor;
 		}
 
-		uint32_t ViewLayoutDelegate::get_borderRadius() const TITANIUM_NOEXCEPT
+		double ViewLayoutDelegate::get_borderRadius() const TITANIUM_NOEXCEPT
 		{
 			return borderRadius__;
 		}
 
-		void ViewLayoutDelegate::set_borderRadius(const uint32_t& borderRadius) TITANIUM_NOEXCEPT
+		void ViewLayoutDelegate::set_borderRadius(const double& borderRadius) TITANIUM_NOEXCEPT
 		{
 			borderRadius__ = borderRadius;
 		}

--- a/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
@@ -90,19 +90,6 @@ namespace TitaniumWindows
 			/*!
 			  @method
 
-			  @abstract borderRadius : Number
-
-			  @discussion Radius for the rounded corners of the view's border.
-
-			  Each corner is rounded using an arc of a circle.
-
-			  Default: 0
-			*/
-			virtual void set_borderRadius(const uint32_t& borderRadius) TITANIUM_NOEXCEPT override;
-
-			/*!
-			  @method
-
 			  @abstract borderWidth : Number
 
 			  @discussion Border width of the view.

--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -694,12 +694,6 @@ namespace TitaniumWindows
 			set_borderWidth(get_borderWidth()); // update brush
 		}
 
-		void WindowsViewLayoutDelegate::set_borderRadius(const uint32_t& borderRadius) TITANIUM_NOEXCEPT
-		{
-			Titanium::UI::ViewLayoutDelegate::set_borderRadius(borderRadius);
-			TITANIUM_LOG_WARN("WindowsViewLayoutDelegate::set_borderRadius is not supported");
-		}
-
 		void WindowsViewLayoutDelegate::set_borderWidth(const uint32_t& borderWidth) TITANIUM_NOEXCEPT
 		{
 			Titanium::UI::ViewLayoutDelegate::set_borderWidth(borderWidth);


### PR DESCRIPTION
First cut for [TIMOB-20257](https://jira.appcelerator.org/browse/TIMOB-20257)

```javascript
var blob = Ti.Filesystem.getFile(Ti.Filesystem.applicationDirectory, 'Square150x150Logo.png').read();
var cropped   = blob.imageAsCropped({width:100, height:100, x:50, y:50});
var resized   = blob.imageAsResized(100, 100);
var thumbnail = blob.imageAsThumbnail(50);
```

`imageAsThumbnail` with `borderSize` and `cornerRaidus` is not implemented.