### PR TITLE
 [TIMOB-20236] Fix GetUriFromPath to handle local paths 

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/ImageView.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/ImageView.hpp
@@ -80,11 +80,9 @@ namespace TitaniumWindows
 			void loadContentFromData(std::vector<std::uint8_t>& data);
 
 			Windows::Foundation::EventRegistrationToken layout_event__;
-			Windows::Foundation::EventRegistrationToken loaded_event__;
 			Windows::UI::Xaml::Controls::Image^ image__;
 			Windows::UI::Xaml::Media::Animation::Storyboard^ storyboard__;
 			bool loaded__;
-			bool loaded_event_set__;
 		};
 	} // namespace UI
 } // namespace TitaniumWindow

--- a/Source/UI/src/ImageView.cpp
+++ b/Source/UI/src/ImageView.cpp
@@ -72,7 +72,7 @@ namespace TitaniumWindows
 
 			image__ = ref new Windows::UI::Xaml::Controls::Image();
 
-			layout_event__ = image__->ImageOpened += ref new RoutedEventHandler([this](::Platform::Object^ sender, RoutedEventArgs^ e) {
+			layout_event__ = image__->ImageOpened += ref new RoutedEventHandler([this](Platform::Object^ sender, RoutedEventArgs^ e) {
 				const auto layout = getViewLayoutDelegate<WindowsImageViewLayoutDelegate>();
 				auto rect = layout->computeRelativeSize(
 					Canvas::GetLeft(this->image__),
@@ -85,10 +85,10 @@ namespace TitaniumWindows
 
 			Titanium::UI::ImageView::setLayoutDelegate<WindowsImageViewLayoutDelegate>();
 
-			layoutDelegate__->set_defaultHeight(Titanium::UI::LAYOUT::FILL);
-			layoutDelegate__->set_defaultWidth(Titanium::UI::LAYOUT::FILL);
-			layoutDelegate__->set_autoLayoutForHeight(Titanium::UI::LAYOUT::FILL);
-			layoutDelegate__->set_autoLayoutForWidth(Titanium::UI::LAYOUT::FILL);
+			layoutDelegate__->set_defaultHeight(Titanium::UI::LAYOUT::SIZE);
+			layoutDelegate__->set_defaultWidth(Titanium::UI::LAYOUT::SIZE);
+			layoutDelegate__->set_autoLayoutForHeight(Titanium::UI::LAYOUT::SIZE);
+			layoutDelegate__->set_autoLayoutForWidth(Titanium::UI::LAYOUT::SIZE);
 
 			getViewLayoutDelegate<WindowsImageViewLayoutDelegate>()->setComponent(image__);
 		}
@@ -191,8 +191,17 @@ namespace TitaniumWindows
 				auto bitmap = ref new BitmapImage();
 				writer->DetachStream();
 				stream->Seek(0);
-				bitmap->SetSourceAsync(stream);
-				this->image__->Source = bitmap;
+				concurrency::create_task(bitmap->SetSourceAsync(stream)).then([this, bitmap]() {
+					this->image__->Source = bitmap;
+					const auto layout = getViewLayoutDelegate<WindowsImageViewLayoutDelegate>();
+					auto rect = layout->computeRelativeSize(
+						Canvas::GetLeft(this->image__),
+						Canvas::GetTop(this->image__),
+						bitmap->PixelWidth,
+						bitmap->PixelHeight
+						);
+					layout->onComponentSizeChange(rect);
+				});
 			});
 		}
 

--- a/Source/UI/src/ImageView.cpp
+++ b/Source/UI/src/ImageView.cpp
@@ -12,6 +12,7 @@
 #include "TitaniumWindows/UI/View.hpp"
 #include "Titanium/Blob.hpp"
 #include <ppltasks.h>
+#include <boost/algorithm/string.hpp>
 
 namespace TitaniumWindows
 {
@@ -210,7 +211,7 @@ namespace TitaniumWindows
 
 			const auto uri = TitaniumWindows::Utility::GetUriFromPath(path);
 			// check if we're loading from local file
-			if (uri->SchemeName == "ms-appx") {
+			if (boost::starts_with(TitaniumWindows::Utility::ConvertString(uri->SchemeName), "ms-")) {
 				concurrency::create_task(StorageFile::GetFileFromApplicationUriAsync(uri)).then([this](concurrency::task<StorageFile^> task){
 					try {
 						auto file = task.get();

--- a/Source/UI/src/ImageView.cpp
+++ b/Source/UI/src/ImageView.cpp
@@ -62,7 +62,6 @@ namespace TitaniumWindows
 		ImageView::ImageView(const JSContext& js_context) TITANIUM_NOEXCEPT
 			  : Titanium::UI::ImageView(js_context)
 			  , loaded__(false)
-			  , loaded_event_set__(false)
 		{
 		}
 
@@ -201,6 +200,11 @@ namespace TitaniumWindows
 						bitmap->PixelHeight
 						);
 					layout->onComponentSizeChange(rect);
+
+					if (!loaded__) {
+						loaded__ = true;
+						this->fireEvent("load", this->get_context().CreateObject());
+					}
 				});
 			});
 		}
@@ -209,14 +213,7 @@ namespace TitaniumWindows
 		{
 			Titanium::UI::ImageView::set_image(path);
 
-			// lazy load image event so it doesn't fire load event for defaultImage
-			if (!loaded_event_set__) {
-				loaded_event__ = image__->ImageOpened += ref new RoutedEventHandler([this](::Platform::Object^ sender, RoutedEventArgs^ e) {
-					loaded__ = true;
-					this->fireEvent("load", this->get_context().CreateObject());
-				});
-				loaded_event_set__ = true;
-			}
+			loaded__ = false;
 
 			const auto uri = TitaniumWindows::Utility::GetUriFromPath(path);
 			// check if we're loading from local file

--- a/Source/Utility/src/Utility.cpp
+++ b/Source/Utility/src/Utility.cpp
@@ -170,7 +170,9 @@ namespace TitaniumWindows
 				// fix root folder path
 				auto rootFolder = TitaniumWindows::Utility::ConvertString(Windows::ApplicationModel::Package::Current->InstalledLocation->Path);
 				boost::replace_all<std::string>(rootFolder, "\\", "/");
-				boost::replace_all<std::string>(modified, rootFolder, "ms-appx:///");
+
+				// Note that rootFolder does not end with "/", so we don't need to use ":///" here
+				boost::replace_all<std::string>(modified, rootFolder, "ms-appx://");
 				
 				// fix local folder path
 				auto localFolder = TitaniumWindows::Utility::ConvertString(Windows::Storage::ApplicationData::Current->LocalFolder->Path);

--- a/Source/Utility/src/Utility.cpp
+++ b/Source/Utility/src/Utility.cpp
@@ -9,7 +9,7 @@
 
 #include "TitaniumWindows/Utility.hpp"
 #include "HAL/HAL.hpp"
-#include <boost/algorithm/string/predicate.hpp>
+#include <boost/algorithm/string.hpp>
 #include "Titanium/detail/TiImpl.hpp"
 #include "TitaniumWindows/WindowsMacros.hpp"
 #include <ctime>
@@ -160,14 +160,33 @@ namespace TitaniumWindows
 		Windows::Foundation::Uri^ GetUriFromPath(const std::string& path) 
 		{
 			std::string modified = path;
+
+			// fix backslash
+			boost::replace_all<std::string>(modified, "\\", "/");
+
 			// if the path isn't an http/s URI already, fix URI to point to local files in app
 			if (!boost::starts_with(modified, "http://") && !boost::starts_with(modified, "https://")) {
-				// URIs must be absolute
-				if (!boost::starts_with(modified, "/")) {
-					modified = "/" + modified;
+
+				// fix root folder path
+				auto rootFolder = TitaniumWindows::Utility::ConvertString(Windows::ApplicationModel::Package::Current->InstalledLocation->Path);
+				boost::replace_all<std::string>(rootFolder, "\\", "/");
+				boost::replace_all<std::string>(modified, rootFolder, "ms-appx:///");
+				
+				// fix local folder path
+				auto localFolder = TitaniumWindows::Utility::ConvertString(Windows::Storage::ApplicationData::Current->LocalFolder->Path);
+				boost::replace_all<std::string>(localFolder, "\\", "/");
+				boost::replace_all<std::string>(modified, localFolder, "ms-appdata:///local");
+
+				// fix relative path with application directory
+				if (!boost::starts_with(modified, "ms-appx:") && !boost::starts_with(modified, "ms-appdata:")) {
+
+					// always absolute path
+					if (!boost::starts_with(modified, "/")) {
+						modified = "/" + modified;
+					}
+
+					modified = "ms-appx://" + modified;
 				}
-				// use MS's in-app URL scheme
-				modified = "ms-appx://" + modified;
 			}
 			return ref new Windows::Foundation::Uri(TitaniumWindows::Utility::ConvertUTF8String(modified));
 		}
@@ -175,6 +194,10 @@ namespace TitaniumWindows
 		Windows::Foundation::Uri^ GetWebUriFromPath(const std::string& path)
 		{
 			std::string modified = path;
+
+			// fix backslash
+			boost::replace_all<std::string>(modified, "\\", "/");
+
 			// if the path isn't an http/s URI already, fix URI to point to local files in app
 			if (!boost::starts_with(modified, "http://") && !boost::starts_with(modified, "https://")) {
 				// URIs must be absolute


### PR DESCRIPTION
[TIMOB-20236](https://jira.appcelerator.org/browse/TIMOB-20236) 

Taking over #540 

- Fixed ```GetUriFromPath``` to handle local file paths
- Fix: ImageView default layout should be SIZE, not FILL
- Fix: GetUriFromPath with native path

###### TEST CASE
```Javascript
var win = Ti.UI.createWindow({backgroundColor:'black'}),
    img = Ti.UI.createImageView({height:'50%'}),
    http = Titanium.Network.createHTTPClient({
        onload: function () {
            var f = Ti.Filesystem.getFile(Ti.Filesystem.applicationDataDirectory, 'win.png');
            f.write(this.responseData);
            Ti.App.fireEvent('downloaded', { path: f.nativePath });
        },
        timeout: 3000
    });

http.open('GET', 'http://tinyurl.com/TIMOB-20236');
http.send();
Ti.App.addEventListener('downloaded', function (e) {
    // img.image = e.path;
    img.image = Ti.Filesystem.applicationDataDirectory + 'win.png';
});
img.addEventListener('click', function () {
    img.image = 'Logo.png';
});
win.add(img);
win.open();
```