### PR TITLE
Windows 10 Jenkins: Use 10.010586 emulator to resolve failing builds

### DIFF
--- a/Tools/Scripts/win10.bat
+++ b/Tools/Scripts/win10.bat
@@ -15,9 +15,8 @@ IF %BUILDLEVEL% NEQ 0 (
 	rmdir node_modules /Q /S
 	exit /B %BUILDLEVEL%
 )
-call node test.js -s 10.0
+call node test.js -s 10.0.10586
 SET TESTLEVEL=%ERRORLEVEL%
-taskkill /F /IM xde.exe /T
 rmdir node_modules /Q /S
 cd ..\\..\\..
 


### PR DESCRIPTION
- Allow ```test.js``` ```-s``` to support a suffix that can be used to select a specific emulator version
- Set ```win10.bat``` to use ```10.0.10586```
- Fixed deployment issues with Windows 10 Jenkins server

###### EXAMPLE
```
node test.js -s 10.0.10586
```