### PR TITLE
[5_2_X] Cherry-Pick #550 Revert JavaScriptCore RAM size config

### DIFF
--- a/Tools/Scripts/setup.js
+++ b/Tools/Scripts/setup.js
@@ -31,10 +31,10 @@ var async = require('async'),
 	// Constants
 	WIN_8_1 = '8.1',
 	WIN_10 = '10.0',
-	// Default JSC URL to build for Win 8.1. See https://jira.appcelerator.org/browse/TIMOB-20101
-	JSC_81_URL = "http://timobile.appcelerator.com.s3.amazonaws.com/jscore/JavaScriptCore-Windows-1449751225.zip",
+	// Default JSC URL to build for Win 8.1.
+	JSC_81_URL = "http://timobile.appcelerator.com.s3.amazonaws.com/jscore/JavaScriptCore-Windows-1453983009.zip",
 	// Default JSC URL for building against Win 10
-	JSC_10_URL = "http://timobile.appcelerator.com.s3.amazonaws.com/jscore/JavaScriptCore-Windows-1449385087-win10.zip",
+	JSC_10_URL = "http://timobile.appcelerator.com.s3.amazonaws.com/jscore/JavaScriptCore-Windows-1453983009-win10.zip",
 	GTEST_URL = (os.platform() === 'win32') ? "http://timobile.appcelerator.com.s3.amazonaws.com/gtest-1.7.0-windows.zip" : "http://timobile.appcelerator.com.s3.amazonaws.com/gtest-1.7.0-osx.zip",
 	BOOST_URL = "http://timobile.appcelerator.com.s3.amazonaws.com/boost_1_57_0.zip";
 


### PR DESCRIPTION
Cherry-Pick #550

Part of [TIMOB-20197](https://jira.appcelerator.org/browse/TIMOB-20197)

For me combination of fixing JavaScriptCore RAM size and [reducing memory consumption ion TitaniumKit](https://jira.appcelerator.org/browse/TIMOB-20256) fixes the crash at startup.
