### PR TITLE
[TIMOB-20281] Implement Titanium.View.enabled

### DIFF
--- a/Source/TitaniumKit/include/Titanium/UI/View.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/View.hpp
@@ -75,13 +75,6 @@ namespace Titanium
 
 			/*!
 			  @property
-			  @abstract enabled
-			  @discussion Determines if the view is enabled or disabled.
-			*/
-			TITANIUM_PROPERTY_IMPL_DEF(bool, enabled);
-
-			/*!
-			  @property
 			  @abstract focusable
 			  @discussion Whether view should be focusable while navigating with the trackball.
 			*/
@@ -363,7 +356,6 @@ namespace Titanium
 
 			std::uint32_t clipMode__; // iOS specific
 			std::uint32_t softKeyboardOnFocus__; // Android specific
-			bool enabled__ { true };
 			bool focusable__ { true };
 			bool keepScreenOn__ { false };
 #pragma warning(pop)

--- a/Source/TitaniumKit/include/Titanium/UI/ViewLayoutDelegate.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/ViewLayoutDelegate.hpp
@@ -106,6 +106,18 @@ namespace Titanium
 			virtual void set_visible(const bool& visible) TITANIUM_NOEXCEPT;
 
 			/*!
+			  @method
+
+			  @abstract enabled : Boolean
+
+			  @discussion Determines whether the view is enabled.
+
+			  Default: true
+			*/
+			virtual bool get_enabled() const TITANIUM_NOEXCEPT;
+			virtual void set_enabled(const bool& enabled) TITANIUM_NOEXCEPT;
+
+			/*!
 			@method
 
 			@abstract backgroundImage : String
@@ -622,6 +634,7 @@ namespace Titanium
 			std::string tintColor__;
 			bool touchEnabled__;
 			bool visible__;
+			bool enabled__;
 			int32_t zIndex__;
 
 			std::string backgroundDisabledColor__;

--- a/Source/TitaniumKit/src/UI/View.cpp
+++ b/Source/TitaniumKit/src/UI/View.cpp
@@ -45,7 +45,6 @@ namespace Titanium
 		TITANIUM_PROPERTY_READWRITE(View, std::string, accessibilityValue)
 		TITANIUM_PROPERTY_READWRITE(View, std::uint32_t, clipMode)
 		TITANIUM_PROPERTY_READWRITE(View, std::uint32_t, softKeyboardOnFocus)
-		TITANIUM_PROPERTY_READWRITE(View, bool, enabled)
 		TITANIUM_PROPERTY_READWRITE(View, bool, focusable)
 		TITANIUM_PROPERTY_READWRITE(View, bool, keepScreenOn)
 
@@ -801,6 +800,18 @@ namespace Titanium
 			return true;
 		}
 
+		TITANIUM_PROPERTY_GETTER(View, enabled)
+		{
+			return get_context().CreateBoolean(layoutDelegate__->get_enabled());
+		}
+
+		TITANIUM_PROPERTY_SETTER(View, enabled)
+		{
+			TITANIUM_ASSERT(argument.IsBoolean());
+			layoutDelegate__->set_enabled(static_cast<bool>(argument));
+			return true;
+		}
+
 		TITANIUM_PROPERTY_GETTER(View, width)
 		{
 			return get_context().CreateString(layoutDelegate__->get_width());
@@ -864,8 +875,6 @@ namespace Titanium
 		TITANIUM_PROPERTY_SETTER_STRING(View, accessibilityValue)
 		TITANIUM_PROPERTY_GETTER_UINT(View, clipMode)
 		TITANIUM_PROPERTY_SETTER_UINT(View, clipMode)
-		TITANIUM_PROPERTY_GETTER_BOOL(View, enabled)
-		TITANIUM_PROPERTY_SETTER_BOOL(View, enabled)
 		TITANIUM_PROPERTY_GETTER_BOOL(View, focusable)
 		TITANIUM_PROPERTY_SETTER_BOOL(View, focusable)
 		TITANIUM_PROPERTY_GETTER_UINT(View, softKeyboardOnFocus)

--- a/Source/TitaniumKit/src/UI/ViewLayoutDelegate.cpp
+++ b/Source/TitaniumKit/src/UI/ViewLayoutDelegate.cpp
@@ -20,6 +20,7 @@ namespace Titanium
 			borderWidth__(0),
 			touchEnabled__(true),
 			visible__(true),
+			enabled__(true),
 			defaultWidth__(Titanium::UI::LAYOUT::SIZE),
 			defaultHeight__(Titanium::UI::LAYOUT::SIZE),
 			autoLayoutForHeight__(defaultHeight__),
@@ -298,6 +299,16 @@ namespace Titanium
 		void ViewLayoutDelegate::set_visible(const bool& visible) TITANIUM_NOEXCEPT
 		{
 			visible__ = visible;
+		}
+
+		bool ViewLayoutDelegate::get_enabled() const TITANIUM_NOEXCEPT
+		{
+			return enabled__;
+		}
+
+		void ViewLayoutDelegate::set_enabled(const bool& enabled) TITANIUM_NOEXCEPT
+		{
+			enabled__ = enabled;
 		}
 
 		std::string ViewLayoutDelegate::get_tintColor() const TITANIUM_NOEXCEPT

--- a/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
@@ -125,6 +125,17 @@ namespace TitaniumWindows
 			/*!
 			  @method
 
+			  @abstract enabled : Boolean
+
+			  @discussion Determines whether the view is enabled.
+
+			  Default: true
+			*/
+			virtual void set_enabled(const bool& enabled) TITANIUM_NOEXCEPT override;
+
+			/*!
+			  @method
+
 			  @abstract height : Number/String
 
 			  @discussion View height, in platform-specific units.
@@ -405,6 +416,8 @@ namespace TitaniumWindows
 
 			void setDefaultBackground();
 			void updateBackground(Windows::UI::Xaml::Media::Brush^);
+			void updateDisabledBackground();
+			Windows::UI::Xaml::Media::Brush^ getBackground();
 
 			virtual std::shared_ptr<Titanium::UI::View> rescueGetView(const JSObject& view) TITANIUM_NOEXCEPT override;
 			virtual void registerNativeUIWrapHook(const std::function<JSObject(const JSContext&, const JSObject&)>& requireCallback);
@@ -470,6 +483,7 @@ namespace TitaniumWindows
 			Windows::UI::Xaml::Media::SolidColorBrush^ backgroundFocusedColorBrush__{ nullptr };
 			Windows::UI::Xaml::Media::SolidColorBrush^ backgroundSelectedColorBrush__{ nullptr };
 			Windows::UI::Xaml::Media::SolidColorBrush^ borderColorBrush__{ nullptr };
+			Windows::UI::Xaml::Media::Brush^ previousBackgroundBrush__{ nullptr };
 
 			Windows::UI::Xaml::Media::LinearGradientBrush^ backgroundLinearGradientBrush__{ nullptr };
 #pragma warning(pop)


### PR DESCRIPTION
- Implement ```Titanium.View.enabled``` functionality
- ```Windows::UI::Xaml::Controls::Canvas``` cannot be _enabled/disabled_, this had to be done manually
- ```backgroundDisabledColor``` of components has no effect, Windows uses a darker color of the parents ```backgroundColor```

###### TEST CASE
```Javascript
var win = Ti.UI.createWindow(),
    view = Ti.UI.createView({ enabled: false, width: '80%', height: '50%', backgroundColor: 'blue', backgroundDisabledColor: 'red' }),
    btn = Ti.UI.createButton({ title: 'BUTTON', backgroundColor: 'red' });

view.add(btn);
win.add(view);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-20281)