### PR TITLE
Fix for trying to access mapservicetoken value when not present in ti.app.properties

### DIFF
--- a/Source/Map/src/View.cpp
+++ b/Source/Map/src/View.cpp
@@ -57,11 +57,14 @@ namespace TitaniumWindows
 			auto properties_ptr = properties_obj.GetPrivate<TitaniumWindows::App::Properties>();
 			TITANIUM_ASSERT(properties_ptr);
 
-			std::string mapservicetoken = properties_ptr->getString("mapservicetoken").get();
-			TITANIUM_ASSERT_AND_THROW(!mapservicetoken.empty(), "Windows mapservicetoken must be defined in tiapp.xml");
-
-			// set mapservicetoken
-			mapview__->MapServiceToken = TitaniumWindows::Utility::ConvertString(mapservicetoken);
+			auto mapservicetoken = properties_ptr->getString("mapservicetoken");
+			if (mapservicetoken) {
+				// set mapservicetoken
+				mapview__->MapServiceToken = TitaniumWindows::Utility::ConvertString(*mapservicetoken);
+			}
+			else {
+				js_context.JSEvaluateScript("Ti.API.error('Windows mapservicetoken must be defined in tiapp.xml');");
+			}
 
 			Titanium::Map::View::setLayoutDelegate<TitaniumWindows::UI::WindowsViewLayoutDelegate>();
 


### PR DESCRIPTION
The values from Ti.App.Properties are boost::optionals. That means they may contain a value or may not. In this case we always treated them like they had a value, which is bad because if there's no value and you call .get() or * on it, it'll barf/crash. So we check if there's a value and if so, set the MapServiceToken. If not we log an error message and move on.