### PR TITLE
Lazy load Ti.UI.Windows

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/WindowsModule.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/WindowsModule.hpp
@@ -38,19 +38,16 @@ namespace TitaniumWindows
 
 			static void JSExportInitialize();
 
-			virtual void postInitialize(JSObject& js_object) override;
+			TITANIUM_PROPERTY_READONLY_DEF(CommandBar);
+			TITANIUM_PROPERTY_READONLY_DEF(AppBarButton);
+			TITANIUM_PROPERTY_READONLY_DEF(AppBarToggleButton);
+			TITANIUM_PROPERTY_READONLY_DEF(AppBarSeparator);
+			TITANIUM_PROPERTY_READONLY_DEF(SystemIcon);
 
 			TITANIUM_FUNCTION_DEF(createCommandBar);
 			TITANIUM_FUNCTION_DEF(createAppBarButton);
 			TITANIUM_FUNCTION_DEF(createAppBarToggleButton);
 			TITANIUM_FUNCTION_DEF(createAppBarSeparator);
-
-		private:
-			JSObject commandBar__;
-			JSObject appBarButton__;
-			JSObject appBarToggleButton__;
-			JSObject appBarSeparator__;
-			JSObject systemIcon__;
 		};
 	}  // namespace UI
 }  // namespace TitaniumWindows

--- a/Source/UI/include/TitaniumWindows/UIModule.hpp
+++ b/Source/UI/include/TitaniumWindows/UIModule.hpp
@@ -35,11 +35,11 @@ namespace TitaniumWindows
 	class TITANIUMWINDOWS_UI_EXPORT UIModule final : public Titanium::UIModule, public JSExport<UIModule>
 	{
 	public:
+		TITANIUM_PROPERTY_READONLY_DEF(Windows);
+
 		virtual void set_backgroundColor(const std::string& color) TITANIUM_NOEXCEPT final override;
 
 		UIModule(const JSContext&) TITANIUM_NOEXCEPT;
-
-		virtual void postInitialize(JSObject& js_object) override;
 
 		virtual ~UIModule() TITANIUM_NOEXCEPT;
 		UIModule(const UIModule&) = default;
@@ -50,8 +50,6 @@ namespace TitaniumWindows
 #endif
 
 		static void JSExportInitialize();
-	private:
-		JSObject windows__;
 	};
 }  // namespace TitaniumWindows
 

--- a/Source/UI/src/UIModule.cpp
+++ b/Source/UI/src/UIModule.cpp
@@ -17,7 +17,6 @@ namespace TitaniumWindows
 
 	UIModule::UIModule(const JSContext& js_context) TITANIUM_NOEXCEPT
 		: Titanium::UIModule(js_context)
-		, windows__(js_context.CreateObject(JSExport<TitaniumWindows::WindowsModule>::Class()))
 	{
 	}
 
@@ -25,16 +24,16 @@ namespace TitaniumWindows
 	{
 	}
 
-	// Initialize Windows-specific UI types
-	void UIModule::postInitialize(JSObject& js_object) 
+	void UIModule::JSExportInitialize() 
 	{
-		Titanium::UIModule::postInitialize(js_object);
-		js_object.SetProperty("Windows", windows__);
-	}
-
-	void UIModule::JSExportInitialize() {
 		JSExport<UIModule>::SetClassVersion(1);
 		JSExport<UIModule>::SetParent(JSExport<Titanium::UIModule>::Class());
+		TITANIUM_ADD_CONSTANT_PROPERTY(UIModule, Windows);
+	}
+
+	TITANIUM_PROPERTY_GETTER(UIModule, Windows)
+	{
+		return get_context().CreateObject(JSExport<TitaniumWindows::WindowsModule>::Class());
 	}
 
 	void UIModule::set_backgroundColor(const std::string& color) TITANIUM_NOEXCEPT

--- a/Source/UI/src/WindowsModule.cpp
+++ b/Source/UI/src/WindowsModule.cpp
@@ -38,32 +38,48 @@ namespace TitaniumWindows
 
 		WindowsModule::WindowsModule(const JSContext& js_context) TITANIUM_NOEXCEPT
 			: Titanium::Module(js_context)
-			, commandBar__(js_context.CreateObject(JSExport<TitaniumWindows::UI::WindowsXaml::CommandBar>::Class()))
-			, appBarButton__(js_context.CreateObject(JSExport<TitaniumWindows::UI::WindowsXaml::AppBarButton>::Class()))
-			, appBarToggleButton__(js_context.CreateObject(JSExport<TitaniumWindows::UI::WindowsXaml::AppBarToggleButton>::Class())) 
-			, appBarSeparator__(js_context.CreateObject(JSExport<TitaniumWindows::UI::WindowsXaml::AppBarSeparator>::Class())) 
-			, systemIcon__(js_context.CreateObject(JSExport<TitaniumWindows::UI::WindowsXaml::SystemIcon>::Class())) 
 		{
 			TITANIUM_LOG_DEBUG("WindowsModule::ctor Initialize");
-		}
-
-		void WindowsModule::postInitialize(JSObject& js_object) 
-		{
-			js_object.SetProperty("CommandBar", commandBar__);
-			js_object.SetProperty("AppBarButton", appBarButton__);
-			js_object.SetProperty("AppBarSeparator", appBarSeparator__);
-			js_object.SetProperty("AppBarToggleButton", appBarToggleButton__);
-			js_object.SetProperty("SystemIcon", systemIcon__);
 		}
 
 		void WindowsModule::JSExportInitialize() 
 		{
 			JSExport<WindowsModule>::SetClassVersion(1);
 			JSExport<WindowsModule>::SetParent(JSExport<Titanium::Module>::Class());
+			TITANIUM_ADD_CONSTANT_PROPERTY(WindowsModule, CommandBar);
+			TITANIUM_ADD_CONSTANT_PROPERTY(WindowsModule, AppBarButton);
+			TITANIUM_ADD_CONSTANT_PROPERTY(WindowsModule, AppBarSeparator);
+			TITANIUM_ADD_CONSTANT_PROPERTY(WindowsModule, AppBarToggleButton);
+			TITANIUM_ADD_CONSTANT_PROPERTY(WindowsModule, SystemIcon);
 			TITANIUM_ADD_FUNCTION(WindowsModule, createCommandBar);
 			TITANIUM_ADD_FUNCTION(WindowsModule, createAppBarButton);
 			TITANIUM_ADD_FUNCTION(WindowsModule, createAppBarToggleButton);
 			TITANIUM_ADD_FUNCTION(WindowsModule, createAppBarSeparator);
+		}
+
+		TITANIUM_PROPERTY_GETTER(WindowsModule, CommandBar)
+		{
+			return get_context().CreateObject(JSExport<TitaniumWindows::UI::WindowsXaml::CommandBar>::Class());
+		}
+
+		TITANIUM_PROPERTY_GETTER(WindowsModule, AppBarButton)
+		{
+			return get_context().CreateObject(JSExport<TitaniumWindows::UI::WindowsXaml::AppBarButton>::Class());
+		}
+
+		TITANIUM_PROPERTY_GETTER(WindowsModule, AppBarSeparator)
+		{
+			return get_context().CreateObject(JSExport<TitaniumWindows::UI::WindowsXaml::AppBarSeparator>::Class());
+		}
+
+		TITANIUM_PROPERTY_GETTER(WindowsModule, AppBarToggleButton)
+		{
+			return get_context().CreateObject(JSExport<TitaniumWindows::UI::WindowsXaml::AppBarToggleButton>::Class());
+		}
+
+		TITANIUM_PROPERTY_GETTER(WindowsModule, SystemIcon) 
+		{
+			return get_context().CreateObject(JSExport<TitaniumWindows::UI::WindowsXaml::SystemIcon>::Class());
 		}
 
 		TITANIUM_FUNCTION(WindowsModule, createCommandBar) 


### PR DESCRIPTION
Implement "lazy loading" for `Ti.UI.Windows` to reduce memory consumption when it's never used.

FYI  `Ti.UI.Windows` navigation sample code:
```javascript
var win = Ti.UI.createWindow({ backgroundColor: 'blue' });

// Windows command bar
var commandBar = Ti.UI.Windows.createCommandBar();

// create buttons for the command bar
var backButton = Ti.UI.Windows.createAppBarButton({ icon: Ti.UI.Windows.SystemIcon.BACK, touchEnabled: false });
var nextButton = Ti.UI.Windows.createAppBarButton({ icon: Ti.UI.Windows.SystemIcon.FORWARD });
var separator = Ti.UI.Windows.createAppBarSeparator();
var acceptButton = Ti.UI.Windows.createAppBarToggleButton({ icon: Ti.UI.Windows.SystemIcon.ACCEPT });

backButton.addEventListener('click', function () {
    win.close();
});

acceptButton.addEventListener('click', function () {
    backButton.touchEnabled = acceptButton.checked;
});

var newwin = Ti.UI.createWindow({
    backgroundColor: 'green'
});
var closeButton = Ti.UI.createButton({
    backgroundColor: 'black',
    title: 'Close this window'
});
closeButton.addEventListener('click', function () {
    newwin.close();
});
newwin.add(closeButton);

nextButton.addEventListener('click', function () {
    // command bar should be closed when newwin is opened, because command bar is not attached to newwin.
    newwin.open();
});

commandBar.items = [backButton, nextButton, separator, acceptButton];

win.add(commandBar);
win.open();
```