### PR TITLE
Make sure .winmd has at least one public entry point

### DIFF
--- a/Source/Filesystem/CMakeLists.txt
+++ b/Source/Filesystem/CMakeLists.txt
@@ -48,6 +48,7 @@ endif()
 set(SOURCE_Filesystem
   include/TitaniumWindows/Filesystem.hpp
   src/Filesystem.cpp
+  src/TitaniumEntryPoint.cpp
   )
 
 source_group(Titanium\\Filesystem FILES ${SOURCE_Filesystem})

--- a/Source/Filesystem/src/TitaniumEntryPoint.cpp
+++ b/Source/Filesystem/src/TitaniumEntryPoint.cpp
@@ -1,0 +1,11 @@
+/*
+ * Just to make sure .winmd file has at least one public entry point (TIMOB-20192)
+ */
+namespace TitaniumWindows_Filesystem
+{
+	public ref class TitaniumEntryPoint sealed
+	{
+	public:
+		TitaniumEntryPoint() { };
+	};
+}

--- a/Source/Global/CMakeLists.txt
+++ b/Source/Global/CMakeLists.txt
@@ -52,6 +52,7 @@ set(SOURCE_Global
   src/GlobalObject.cpp
   include/TitaniumWindows/GlobalString.hpp
   src/GlobalString.cpp
+  src/TitaniumEntryPoint.cpp
   )
 
 source_group(Titanium\\Global FILES ${SOURCE_Global})

--- a/Source/Global/src/TitaniumEntryPoint.cpp
+++ b/Source/Global/src/TitaniumEntryPoint.cpp
@@ -1,0 +1,11 @@
+/*
+ * Just to make sure .winmd file has at least one public entry point (TIMOB-20192)
+ */
+namespace TitaniumWindows_Global
+{
+	public ref class TitaniumEntryPoint sealed
+	{
+	public:
+		TitaniumEntryPoint() { };
+	};
+}

--- a/Source/Map/CMakeLists.txt
+++ b/Source/Map/CMakeLists.txt
@@ -58,6 +58,7 @@ set(SOURCE_Map
   include/TitaniumWindows/Map.hpp
   include/TitaniumWindows/Map/Annotation.hpp
   src/Annotation.cpp
+  src/TitaniumEntryPoint.cpp
   )
 
 source_group(Titanium\\Map FILES ${SOURCE_Map})

--- a/Source/Map/src/TitaniumEntryPoint.cpp
+++ b/Source/Map/src/TitaniumEntryPoint.cpp
@@ -1,0 +1,11 @@
+/*
+ * Just to make sure .winmd file has at least one public entry point (TIMOB-20192)
+ */
+namespace TitaniumWindows_Map
+{
+	public ref class TitaniumEntryPoint sealed
+	{
+	public:
+		TitaniumEntryPoint() { };
+	};
+}

--- a/Source/Media/CMakeLists.txt
+++ b/Source/Media/CMakeLists.txt
@@ -67,6 +67,7 @@ set(SOURCE_Media
   src/Media/Sound.cpp
   src/Media/MusicPlayer.cpp
   src/Media/VideoPlayer.cpp
+  src/TitaniumEntryPoint.cpp
   )
 
 source_group(Titanium\\Media FILES ${SOURCE_Media})

--- a/Source/Media/src/TitaniumEntryPoint.cpp
+++ b/Source/Media/src/TitaniumEntryPoint.cpp
@@ -1,0 +1,11 @@
+/*
+ * Just to make sure .winmd file has at least one public entry point (TIMOB-20192)
+ */
+namespace TitaniumWindows_Media
+{
+	public ref class TitaniumEntryPoint sealed
+	{
+	public:
+		TitaniumEntryPoint() { };
+	};
+}

--- a/Source/Network/CMakeLists.txt
+++ b/Source/Network/CMakeLists.txt
@@ -51,6 +51,7 @@ set(SOURCE_Network
   include/TitaniumWindows/detail/NetworkBase.hpp
   src/Network.cpp
   src/HTTPClient.cpp
+  src/TitaniumEntryPoint.cpp
   )
 
 source_group(Titanium\\Network FILES ${SOURCE_Network})

--- a/Source/Network/src/TitaniumEntryPoint.cpp
+++ b/Source/Network/src/TitaniumEntryPoint.cpp
@@ -1,0 +1,11 @@
+/*
+ * Just to make sure .winmd file has at least one public entry point (TIMOB-20192)
+ */
+namespace TitaniumWindows_Network
+{
+	public ref class TitaniumEntryPoint sealed
+	{
+	public:
+		TitaniumEntryPoint() { };
+	};
+}

--- a/Source/Sensors/CMakeLists.txt
+++ b/Source/Sensors/CMakeLists.txt
@@ -54,6 +54,7 @@ set(SOURCE_Sensors
   src/Gesture.cpp
   src/Geolocation.cpp
   src/ShakeGestureHelper.cpp
+  src/TitaniumEntryPoint.cpp
   )
 
 source_group(Titanium\\Sensors FILES ${SOURCE_Sensors})

--- a/Source/Sensors/src/TitaniumEntryPoint.cpp
+++ b/Source/Sensors/src/TitaniumEntryPoint.cpp
@@ -1,0 +1,11 @@
+/*
+ * Just to make sure .winmd file has at least one public entry point (TIMOB-20192)
+ */
+namespace TitaniumWindows_Sensors
+{
+	public ref class TitaniumEntryPoint sealed
+	{
+	public:
+		TitaniumEntryPoint() { };
+	};
+}

--- a/Source/Ti/CMakeLists.txt
+++ b/Source/Ti/CMakeLists.txt
@@ -55,6 +55,7 @@ generate_cpp_header_file(resource_group_js_hpp ${PROJECT_SOURCE_DIR}/src/Contact
 set(SOURCE_Ti
   include/TitaniumWindows/TiModule.hpp
   src/TiModule.cpp
+  src/TitaniumEntryPoint.cpp
   )
 
 set(SOURCE_Codec

--- a/Source/Ti/src/TitaniumEntryPoint.cpp
+++ b/Source/Ti/src/TitaniumEntryPoint.cpp
@@ -1,0 +1,11 @@
+/*
+ * Just to make sure .winmd file has at least one public entry point (TIMOB-20192)
+ */
+namespace TitaniumWindows_Ti
+{
+	public ref class TitaniumEntryPoint sealed
+	{
+	public:
+		TitaniumEntryPoint() { };
+	};
+}

--- a/Source/UI/CMakeLists.txt
+++ b/Source/UI/CMakeLists.txt
@@ -108,6 +108,7 @@ set(SOURCE_UI
   src/WindowsViewLayoutDelegate.cpp
   include/TitaniumWindows/UI/UIElement.hpp
   src/UIElement.cpp
+  src/TitaniumEntryPoint.cpp
   )
 
 source_group(Titanium\\UI FILES ${SOURCE_UI})

--- a/Source/UI/src/TitaniumEntryPoint.cpp
+++ b/Source/UI/src/TitaniumEntryPoint.cpp
@@ -1,0 +1,11 @@
+/*
+ * Just to make sure .winmd file has at least one public entry point (TIMOB-20192)
+ */
+namespace TitaniumWindows_UI
+{
+	public ref class TitaniumEntryPoint sealed
+	{
+	public:
+		TitaniumEntryPoint() { };
+	};
+}

--- a/Source/Utility/CMakeLists.txt
+++ b/Source/Utility/CMakeLists.txt
@@ -47,6 +47,7 @@ set(SOURCE_Utility
   include/TitaniumWindows/Utility.hpp
   src/Utility.cpp
   include/TitaniumWindows/WindowsMacros.hpp
+  src/TitaniumEntryPoint.cpp
   )
 
 source_group(Titanium\\Utility FILES ${SOURCE_Utility})

--- a/Source/Utility/src/TitaniumEntryPoint.cpp
+++ b/Source/Utility/src/TitaniumEntryPoint.cpp
@@ -1,0 +1,11 @@
+/*
+ * Just to make sure .winmd file has at least one public entry point (TIMOB-20192)
+ */
+namespace TitaniumWindows_Utility
+{
+	public ref class TitaniumEntryPoint sealed
+	{
+	public:
+		TitaniumEntryPoint() { };
+	};
+}


### PR DESCRIPTION
[TIMOB-20192](https://jira.appcelerator.org/browse/TIMOB-20192)

Attempt to fix "submission error 2001" described in https://msdn.microsoft.com/en-us/library/windows/apps/mt445539.aspx.

This PR just tries to make sure each `.winmd` file has at least one entry point (`ref class`). To test this, use [Ildasm.exe](https://msdn.microsoft.com/en-us/library/aa309387%28v=vs.71%29.aspx) to find a entry point in each `winmd` files. The other way to test is that usually `winmd` files are nearly `1KB` when it has no entry but it should be over `3KB` or so when it has an entry. Note that from what I saw only `TitaniumWindows_*.DLL` has its `winmd`, and `HAL`, `LayoutEngine` and `TitaniumKit` doesn't have it. (I expect it's because they do not use any Windows API?)

FYI `Ildasm.exe` is located under `c:\Program Files(x86)\Microsoft SDKs\Windows\v8.1A\bin\NETFX 4.1.5 Tools\` for me on Windows 10.