### PR TITLE
Implement Background Service

### DIFF
--- a/Examples/NMocha/src/Assets/app.js
+++ b/Examples/NMocha/src/Assets/app.js
@@ -19,6 +19,7 @@ var $results = [],
 require('./ti.accelerometer.test');
 require('./ti.app.test');
 require('./ti.app.properties.test');
+require('./ti.app.windows.backgroundservice.test');
 require('./ti.blob.test');
 require('./ti.builtin.test');
 require('./ti.buffer.test');

--- a/Examples/NMocha/src/Assets/ti.app.windows.backgroundservice.test.js
+++ b/Examples/NMocha/src/Assets/ti.app.windows.backgroundservice.test.js
@@ -1,0 +1,44 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-2016 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+var should = require('./should');
+
+describe('Ti.App.Windows.BackgroundService', function () {
+
+    it('API', function (finish) {
+        should(Ti.App.Windows).be.an.Object;
+        should(Ti.App.Windows.BackgroundService).be.an.Object;
+        should(Ti.App.Windows.BackgroundService.registerTimerTask).be.a.Function;
+        should(Ti.App.Windows.BackgroundService.unregisterAllTasks).be.a.Function;
+        finish();
+    });
+
+    it('locationServiceEnabled', function (finish) {
+        should(Ti.App.Windows.BackgroundService.locationServiceEnabled).be.Boolean;
+        Ti.App.Windows.BackgroundService.locationServiceEnabled = true;
+        should(Ti.App.Windows.BackgroundService.locationServiceEnabled).be.true;
+        Ti.App.Windows.BackgroundService.locationServiceEnabled = false;
+        should(Ti.App.Windows.BackgroundService.locationServiceEnabled).be.false;
+        finish();
+    });
+
+    it('registerTimerTask', function (finish) {
+        var task = Ti.App.Windows.BackgroundService.registerTimerTask(function() {
+            Ti.API.info('registerTimerTask');
+        }, 15, true);
+        task.unregister();
+        finish();
+    });
+
+    it('unregisterAllTasks', function (finish) {
+        var task = Ti.App.Windows.BackgroundService.registerTimerTask(function() {
+            Ti.API.info('unregisterAllTasks');
+        }, 15, true);
+        Ti.App.Windows.BackgroundService.unregisterAllTasks();
+        finish();
+    });
+
+});

--- a/Source/Network/include/TitaniumWindows/Network/HTTPClient.hpp
+++ b/Source/Network/include/TitaniumWindows/Network/HTTPClient.hpp
@@ -56,7 +56,6 @@ namespace TitaniumWindows
 			virtual void setRequestHeader(const std::string& name, const std::string& value) TITANIUM_NOEXCEPT override final;
 			// properties
 			virtual std::string get_allResponseHeaders() const TITANIUM_NOEXCEPT override final;
-			virtual void set_timeout(const std::chrono::milliseconds& timeout) TITANIUM_NOEXCEPT override final;
 			
 		protected:
 #pragma warning(push)
@@ -72,14 +71,10 @@ namespace TitaniumWindows
 			concurrency::cancellation_token_source cancellationTokenSource__;
 			//  timeoutRegistrationToken__ - used to remove the timeout handler
 			Windows::Foundation::EventRegistrationToken timeoutRegistrationToken__;
-			// dispatcherTimer__ - WinRT timer used to cancel a HTTP connection if timeout specified
-			Windows::UI::Xaml::DispatcherTimer^ dispatcherTimer__;
 			// responseStream__ - holds response string, the stream is not exposed
 			Windows::Storage::Streams::IBuffer^ responseStream__;
 			// responseDataLen__ - count of character contained in data vector
 			long responseDataLen__ { 0 };
-			// timeoutSpan__ - the span in milliseconds during which the request is active
-			Windows::Foundation::TimeSpan timeoutSpan__;
 			// responseHeaders__ - the collection of key value pairs returned from the server
 
 			std::map<const std::string, std::string> responseHeaders__;
@@ -92,7 +87,7 @@ namespace TitaniumWindows
 			bool disposed__ { false };
 #pragma warning(pop)
 
-			void startDispatcherTimer();
+			void configureTimeout();
 			task<Windows::Storage::Streams::IBuffer^> HTTPClient::HTTPResultAsync(Windows::Storage::Streams::IInputStream^ stream, concurrency::cancellation_token token);
 			Windows::Storage::Streams::Buffer^ charVecToBuffer(std::vector<std::uint8_t> char_vector);
 

--- a/Source/Ti/CMakeLists.txt
+++ b/Source/Ti/CMakeLists.txt
@@ -79,6 +79,12 @@ set(SOURCE_App
   include/TitaniumWindows/App.hpp
   include/TitaniumWindows/AppModule.hpp
   src/AppModule.cpp
+  include/TitaniumWindows/App/WindowsModule.hpp
+  src/App/WindowsModule.cpp
+  include/TitaniumWindows/App/BackgroundService.hpp
+  src/App/BackgroundService.cpp
+  include/TitaniumWindows/App/BackgroundServiceTask.hpp
+  src/App/BackgroundServiceTask.cpp
   )
 
 set(SOURCE_Platform

--- a/Source/Ti/include/TitaniumWindows/App/BackgroundService.hpp
+++ b/Source/Ti/include/TitaniumWindows/App/BackgroundService.hpp
@@ -1,0 +1,120 @@
+/**
+* Ti.App.Windows.BackgroundService
+*
+* Copyright (c) 2016 by Appcelerator, Inc. All Rights Reserved.
+* Licensed under the terms of the Apache Public License.
+* Please see the LICENSE included with this distribution for details.
+*/
+#ifndef _TITANIUMWINDOWS_APP_WINDOWS_BACKGROUNDSERVICE_HPP_
+#define _TITANIUMWINDOWS_APP_WINDOWS_BACKGROUNDSERVICE_HPP_
+
+#include "TitaniumWindows_Ti_EXPORT.h"
+#include "Titanium/Module.hpp"
+#include "TitaniumWindows/WindowsMacros.hpp"
+#include <unordered_map>
+#include <atomic>
+
+using namespace HAL;
+
+namespace TitaniumWindows_Ti
+{
+	/*
+	 * @class
+	 * @discussion This is background task for BackgroundService.
+	        Entrypoint: TitaniumWindows_Ti.BackgroundServiceTask
+	 */
+	[Windows::Foundation::Metadata::WebHostHidden]
+	public ref class BackgroundServiceTask sealed : public Windows::ApplicationModel::Background::IBackgroundTask
+	{
+	public:
+		virtual void Run(Windows::ApplicationModel::Background::IBackgroundTaskInstance^ taskInstance);
+	};
+}
+
+namespace Titanium
+{
+	struct LocationCoordinates;
+}
+
+namespace TitaniumWindows
+{
+	namespace App
+	{
+		// Use WindowsXaml namespace instead of "Windows"
+		// because it screws up entire namespace in Xaml...
+		namespace WindowsXaml
+		{
+			class BackgroundServiceTask;
+
+			/*!
+			  @class
+			  @discussion This is the Titanium.App.Windows.BackgroundService implementation
+			*/
+			class TITANIUMWINDOWS_TI_EXPORT BackgroundService final : public Titanium::Module, public JSExport<BackgroundService>
+			{
+
+			public:
+				BackgroundService(const JSContext&) TITANIUM_NOEXCEPT;
+
+				virtual ~BackgroundService();
+				BackgroundService(const BackgroundService&)            = default;
+				BackgroundService& operator=(const BackgroundService&) = default;
+	#ifdef TITANIUM_MOVE_CTOR_AND_ASSIGN_DEFAULT_ENABLE
+				BackgroundService(BackgroundService&&)                 = default;
+				BackgroundService& operator=(BackgroundService&&)      = default;
+	#endif
+
+				/*!
+				  @method
+				  @abstract registerTimerTask
+				  @param callback Sets callback that is invoked on time event. Callback param: { source [object], canceled [bool] }
+				  @param freshnessTime Sets interval of a time event in minutes. Windows requires at least 15 minutes
+				  @param oneShot Sets whether the time event trigger will be used only once or each time the FreshnessTime interval elapses.
+				  @return BackgroundServiceTask object
+				  @discussion Register a time event that triggers a background task to run.
+				*/
+				TITANIUM_FUNCTION_DEF(registerTimerTask);
+
+				/*!
+				  @method
+				  @abstract unregisterAllTasks
+				  @discussion Unregisters all registered background task associated with this application.
+				*/
+				TITANIUM_FUNCTION_DEF(unregisterAllTasks);
+
+				/*!
+				  @property
+				  @abstract locationServiceEnabled
+				  @discussion Indicates to enable or disable location services in background. If it's enabled, task callback will contain location data.
+				*/
+				TITANIUM_PROPERTY_DEF(locationServiceEnabled);
+
+				static void JSExportInitialize();
+				virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;
+
+				std::shared_ptr<BackgroundServiceTask> registerTimerTask(JSObject& callback, const std::uint32_t& freshnessTime, const bool& oneShot, Windows::ApplicationModel::Background::IBackgroundCondition^ condition = nullptr);
+				std::shared_ptr<BackgroundServiceTask> registerTask(JSObject& callback, Windows::ApplicationModel::Background::IBackgroundTrigger^ trigger, Windows::ApplicationModel::Background::IBackgroundCondition^ condition);
+
+				static Windows::ApplicationModel::Background::IBackgroundTaskRegistration^ GetTask(const std::uint32_t& id);
+				static void UnregisterTask(const std::uint32_t& id);
+				static void UnregisterTasks();
+
+				static bool Get_LocationServiceEnabled() TITANIUM_NOEXCEPT;
+				static void Set_LocationServiceEnabled(const bool&) TITANIUM_NOEXCEPT;
+
+				static void ResetLastGeoposition() TITANIUM_NOEXCEPT;
+				static void UpdateLastGeoposition(Windows::Devices::Geolocation::Geoposition^) TITANIUM_NOEXCEPT;
+				static Titanium::LocationCoordinates GetLastGeoposition() TITANIUM_NOEXCEPT;
+			protected:
+#pragma warning(push)
+#pragma warning(disable : 4251)
+				static ::Platform::String^ TASK_ENTRYPOINT_NAME;
+				static std::atomic<std::uint32_t> task_id_generator__;
+				static ::Platform::String^ LAST_GEOLOCATION_KEY;
+				static ::Platform::String^ GEOLOCATION_ENABLED_KEY;
+#pragma warning(pop)
+			};
+		} // namespace WindowsXaml
+	}  // namespace App
+}  // namespace TitaniumWindows
+#endif // _TITANIUMWINDOWS_APP_WINDOWS_BACKGROUNDSERVICE_HPP_

--- a/Source/Ti/include/TitaniumWindows/App/BackgroundServiceTask.hpp
+++ b/Source/Ti/include/TitaniumWindows/App/BackgroundServiceTask.hpp
@@ -1,0 +1,78 @@
+/**
+* Ti.App.Windows.BackgroundServiceTask
+*
+* Copyright (c) 2016 by Appcelerator, Inc. All Rights Reserved.
+* Licensed under the terms of the Apache Public License.
+* Please see the LICENSE included with this distribution for details.
+*/
+#ifndef _TITANIUMWINDOWS_APP_WINDOWS_BACKGROUNDSERVICETASK_HPP_
+#define _TITANIUMWINDOWS_APP_WINDOWS_BACKGROUNDSERVICETASK_HPP_
+
+#include "TitaniumWindows_Ti_EXPORT.h"
+#include "Titanium/Module.hpp"
+#include "Titanium/detail/TiBase.hpp"
+
+using namespace Windows::ApplicationModel::Background;
+using namespace HAL;
+
+namespace TitaniumWindows
+{
+	namespace App
+	{
+		// Use WindowsXaml namespace instead of "Windows"
+		// because it screws up entire namespace in Xaml...
+		namespace WindowsXaml
+		{
+			/*!
+			  @class BackgroundServiceTask
+			  @discussion This is the Titanium.App.Windows.BackgroundServiceTask implementation
+			      This class holds task id which can be used to query BackgroundTaskRegistration.
+			      Note that this class doesn't hold reference to the task (BackgroundTaskRegistration) intentionally
+			      because Windows itself should manage life-cycle of the task and we don't want to keep reference to it.
+			*/
+			class TITANIUMWINDOWS_TI_EXPORT BackgroundServiceTask final : public Titanium::Module, public JSExport<BackgroundServiceTask>
+			{
+
+			public:
+				BackgroundServiceTask(const JSContext&) TITANIUM_NOEXCEPT;
+
+				virtual ~BackgroundServiceTask();
+				BackgroundServiceTask(const BackgroundServiceTask&)            = default;
+				BackgroundServiceTask& operator=(const BackgroundServiceTask&) = default;
+	#ifdef TITANIUM_MOVE_CTOR_AND_ASSIGN_DEFAULT_ENABLE
+				BackgroundServiceTask(BackgroundServiceTask&&)                 = default;
+				BackgroundServiceTask& operator=(BackgroundServiceTask&&)      = default;
+	#endif
+				static void JSExportInitialize();
+				virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;
+
+				void construct(const std::uint32_t& id, BackgroundTaskRegistration^ registration, JSObject& callback);
+				void unregister();
+				void taskCompleted(const bool& canceled = false);
+
+				/*!
+				  @property
+				  @abstract taskId
+				  @discussiona taskId that is associated with this task. Read-Only.
+				*/
+				TITANIUM_PROPERTY_IMPL_READONLY_DEF(std::uint32_t, taskId);
+
+				/*!
+				  method
+				  @abstract unregister
+				  @discussiona Unregisters this background task.
+				*/
+				TITANIUM_FUNCTION_DEF(unregister);
+
+			protected:
+#pragma warning(push)
+#pragma warning(disable : 4251)
+				JSObject callback__;
+				std::uint32_t taskId__{ 0 };
+				Windows::Foundation::EventRegistrationToken completed_event__;
+#pragma warning(pop)
+			};
+		} // namespace WindowsXaml
+	}  // namespace App
+}  // namespace TitaniumWindows
+#endif // _TITANIUMWINDOWS_APP_WINDOWS_BACKGROUNDSERVICETASK_HPP_

--- a/Source/Ti/include/TitaniumWindows/App/WindowsModule.hpp
+++ b/Source/Ti/include/TitaniumWindows/App/WindowsModule.hpp
@@ -1,0 +1,45 @@
+/**
+* Ti.App.Windows module
+*
+* Copyright (c) 2016 by Appcelerator, Inc. All Rights Reserved.
+* Licensed under the terms of the Apache Public License.
+* Please see the LICENSE included with this distribution for details.
+*/
+#ifndef _TITANIUMWINDOWS_APP_WINDOWSMODULE_HPP_
+#define _TITANIUMWINDOWS_APP_WINDOWSMODULE_HPP_
+
+#include "Titanium/Module.hpp"
+#include "TitaniumWindows_Ti_EXPORT.h"
+
+namespace TitaniumWindows
+{
+	namespace App
+	{
+		using namespace HAL;
+
+		/*!
+		  @class
+
+		  @discussion This is the Titanium.App.Windows implementation
+		*/
+		class TITANIUMWINDOWS_TI_EXPORT WindowsModule final : public Titanium::Module, public JSExport<WindowsModule>
+		{
+
+		public:
+			WindowsModule(const JSContext&) TITANIUM_NOEXCEPT;
+
+			virtual ~WindowsModule()                = default;
+			WindowsModule(const WindowsModule&)            = default;
+			WindowsModule& operator=(const WindowsModule&) = default;
+#ifdef TITANIUM_MOVE_CTOR_AND_ASSIGN_DEFAULT_ENABLE
+			WindowsModule(WindowsModule&&)                 = default;
+			WindowsModule& operator=(WindowsModule&&)      = default;
+#endif
+
+			static void JSExportInitialize();
+
+			TITANIUM_PROPERTY_READONLY_DEF(BackgroundService);
+		};
+	}  // namespace App
+}  // namespace TitaniumWindows
+#endif // _TITANIUMWINDOWS_APP)WINDOWSMODULE_HPP_

--- a/Source/Ti/include/TitaniumWindows/AppModule.hpp
+++ b/Source/Ti/include/TitaniumWindows/AppModule.hpp
@@ -44,6 +44,8 @@ namespace TitaniumWindows
 		AppModule& operator=(AppModule&&) = default;
 #endif
 
+		TITANIUM_PROPERTY_READONLY_DEF(Windows);
+
 		virtual bool keyboardVisible() const TITANIUM_NOEXCEPT override;
 
 		static void JSExportInitialize();

--- a/Source/Ti/src/App/BackgroundService.cpp
+++ b/Source/Ti/src/App/BackgroundService.cpp
@@ -1,0 +1,290 @@
+/**
+* Ti.App.Windows.BackgroundService
+*
+* Copyright (c) 2016 by Appcelerator, Inc. All Rights Reserved.
+* Licensed under the terms of the Apache Public License.
+* Please see the LICENSE included with this distribution for details.
+*/
+#include "TitaniumWindows/App/BackgroundService.hpp"
+#include "TitaniumWindows/App/BackgroundServiceTask.hpp"
+#include "Titanium/GeolocationModule.hpp"
+#include "Titanium/detail/TiImpl.hpp"
+#include "TitaniumWindows/Utility.hpp"
+#include <boost/algorithm/string/predicate.hpp>
+
+using namespace Windows::Foundation;
+using namespace Windows::Devices::Geolocation;
+using namespace Windows::ApplicationModel::Background;
+using namespace Windows::Storage;
+
+namespace TitaniumWindows_Ti
+{
+	void BackgroundServiceTask::Run(IBackgroundTaskInstance^ taskInstance)
+	{
+		const auto deferral = Platform::Agile<BackgroundTaskDeferral>(taskInstance->GetDeferral());
+		const auto location_enabled = TitaniumWindows::App::WindowsXaml::BackgroundService::Get_LocationServiceEnabled();
+		if (location_enabled) {
+
+			const auto geolocator_ = ref new Geolocator();
+			geolocator_->MovementThreshold = 1;
+			geolocator_->ReportInterval = 0;
+			geolocator_->DesiredAccuracy = PositionAccuracy::High;
+
+			TitaniumWindows::App::WindowsXaml::BackgroundService::ResetLastGeoposition();
+
+			concurrency::create_task(geolocator_->GetGeopositionAsync()).then([deferral](concurrency::task<Geoposition^> task){
+				try {
+					TitaniumWindows::App::WindowsXaml::BackgroundService::UpdateLastGeoposition(task.get());
+				} catch (Platform::COMException^ e) {
+					TitaniumWindows::App::WindowsXaml::BackgroundService::ResetLastGeoposition();
+					TITANIUM_LOG_WARN(TitaniumWindows::Utility::ConvertString(e->Message));
+				}
+				deferral->Complete();
+			});
+		} else {
+			// Complete the task immediately just to tell subscriber "Complete" event
+			deferral->Complete();
+		}
+	}
+}
+
+namespace TitaniumWindows
+{
+	namespace App
+	{
+		namespace WindowsXaml 
+		{
+			Platform::String^ BackgroundService::TASK_ENTRYPOINT_NAME { "TitaniumWindows_Ti.BackgroundServiceTask" };
+			Platform::String^ BackgroundService::LAST_GEOLOCATION_KEY { "TitaniumWindows_Ti.BackgroundServiceTask.LastGeolocation" };
+			Platform::String^ BackgroundService::GEOLOCATION_ENABLED_KEY{ "TitaniumWindows_Ti.BackgroundServiceTask.GeolocationEnabled" };
+			std::atomic<std::uint32_t> BackgroundService::task_id_generator__;
+
+			BackgroundService::BackgroundService(const JSContext& js_context) TITANIUM_NOEXCEPT
+				: Titanium::Module(js_context, "Titanium.App.Windows.BackgroundService")
+			{
+				TITANIUM_LOG_DEBUG("BackgroundService::ctor Initialize");
+			}
+
+			BackgroundService::~BackgroundService() 
+			{
+				TITANIUM_LOG_DEBUG("BackgroundService::dtor");
+				UnregisterTasks();
+			}
+
+			void BackgroundService::postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) 
+			{
+				Titanium::Module::postCallAsConstructor(js_context, arguments);
+				TITANIUM_LOG_DEBUG("BackgroundService::postCallAsConstructor");
+			}
+
+			void BackgroundService::JSExportInitialize() 
+			{
+				JSExport<BackgroundService>::SetClassVersion(1);
+				JSExport<BackgroundService>::SetParent(JSExport<Titanium::Module>::Class());
+
+				TITANIUM_ADD_FUNCTION(BackgroundService, registerTimerTask);
+				TITANIUM_ADD_FUNCTION(BackgroundService, unregisterAllTasks);
+				TITANIUM_ADD_PROPERTY(BackgroundService, locationServiceEnabled);
+			}
+
+			std::shared_ptr<BackgroundServiceTask> BackgroundService::registerTimerTask(JSObject& callback, const std::uint32_t& freshnessTime, const bool& oneShot, IBackgroundCondition^ condition)
+			{
+				return registerTask(callback, ref new TimeTrigger(freshnessTime, oneShot), condition);
+			}
+
+			std::shared_ptr<BackgroundServiceTask> BackgroundService::registerTask(JSObject& callback, IBackgroundTrigger^ trigger, IBackgroundCondition^ condition)
+			{
+#if defined(IS_WINDOWS_PHONE)
+				BackgroundExecutionManager::RequestAccessAsync();
+#endif
+				const auto taskId   = task_id_generator__++;
+				const auto taskName = Windows::ApplicationModel::Package::Current->Id->Name + "." + taskId;
+
+				// Make sure to unregister all task which has same name
+				// This could happen when last process doesn't unregister tasks properly.
+				UnregisterTask(taskId);
+
+				const auto builder = ref new BackgroundTaskBuilder();
+				builder->Name = taskName;
+				builder->TaskEntryPoint = TASK_ENTRYPOINT_NAME;
+				builder->SetTrigger(trigger);
+
+				if (condition != nullptr)
+				{
+					builder->AddCondition(condition);
+					builder->CancelOnConditionLoss = true;
+				}
+
+				auto task = get_context().CreateObject(JSExport<BackgroundServiceTask>::Class()).CallAsConstructor().GetPrivate<BackgroundServiceTask>();
+				task->construct(taskId, builder->Register(), callback);
+
+				return task;
+			}
+
+			IBackgroundTaskRegistration^ BackgroundService::GetTask(const std::uint32_t& id) 
+			{
+				const auto taskName = Windows::ApplicationModel::Package::Current->Id->Name + "." + id;
+				const auto iter = BackgroundTaskRegistration::AllTasks->First();
+				auto hasCurrent = iter->HasCurrent;
+				while (hasCurrent)
+				{
+					const auto cur = iter->Current->Value;
+					if (cur->Name == taskName)
+					{
+						return cur;
+					}
+					hasCurrent = iter->MoveNext();
+				}
+
+				return nullptr;
+			}
+
+			void BackgroundService::UnregisterTask(const std::uint32_t& id)
+			{
+				const auto taskName = Windows::ApplicationModel::Package::Current->Id->Name + "." + id;
+				const auto iter = BackgroundTaskRegistration::AllTasks->First();
+				auto hasCurrent = iter->HasCurrent;
+				while (hasCurrent)
+				{
+					const auto cur = iter->Current->Value;
+					if (cur->Name == taskName)
+					{
+						cur->Unregister(true);
+					}
+					hasCurrent = iter->MoveNext();
+				}
+			}
+
+			void BackgroundService::UnregisterTasks() 
+			{
+				const auto taskName = TitaniumWindows::Utility::ConvertString(Windows::ApplicationModel::Package::Current->Id->Name);
+				const auto iter = BackgroundTaskRegistration::AllTasks->First();
+				auto hasCurrent = iter->HasCurrent;
+				while (hasCurrent)
+				{
+					const auto cur = iter->Current->Value;
+					if (boost::starts_with(TitaniumWindows::Utility::ConvertString(cur->Name), taskName))
+					{
+						cur->Unregister(true);
+					}
+					hasCurrent = iter->MoveNext();
+				}
+			}
+
+			bool BackgroundService::Get_LocationServiceEnabled() TITANIUM_NOEXCEPT
+			{
+				//
+				// We need to share configuration with BackgroundTask using LocalSettings
+				//
+				return ApplicationData::Current->LocalSettings->Values->HasKey(GEOLOCATION_ENABLED_KEY);
+			}
+
+			void BackgroundService::Set_LocationServiceEnabled(const bool& enabled) TITANIUM_NOEXCEPT
+			{
+				ResetLastGeoposition();
+
+				if (enabled) {
+					ApplicationData::Current->LocalSettings->Values->Insert(GEOLOCATION_ENABLED_KEY, dynamic_cast<PropertyValue^>(PropertyValue::CreateBoolean(true)));
+				} else {
+					ApplicationData::Current->LocalSettings->Values->Remove(GEOLOCATION_ENABLED_KEY);
+				}
+			}
+
+			void BackgroundService::UpdateLastGeoposition(Geoposition^ pos) TITANIUM_NOEXCEPT
+			{
+				ResetLastGeoposition();
+
+				const auto accuracy  = pos->Coordinate->Accuracy;
+				const auto latitude  = pos->Coordinate->Point->Position.Latitude;
+				const auto longitude = pos->Coordinate->Point->Position.Longitude;
+				const auto altitude  = pos->Coordinate->Point->Position.Altitude;
+				const auto altitudeAccuracy = pos->Coordinate->AltitudeAccuracy;
+				const auto heading = pos->Coordinate->Heading;
+				const auto speed = pos->Coordinate->Speed;
+
+				/*
+				* accuracy, altitude, altitudeAccuracy, heading, longitude, latitude, speed, floor, timestamp
+				*/
+				auto values = ref new Platform::Array<double>(9);
+				values->Data[0] = accuracy;
+				values->Data[1] = altitude;
+				values->Data[2] = altitudeAccuracy ? altitudeAccuracy->Value : 0;
+				values->Data[3] = heading ? heading->Value : 0;
+				values->Data[4] = longitude;
+				values->Data[5] = latitude;
+				values->Data[6] = speed ? speed->Value : 0;
+				values->Data[7] = 0; /* floor: unused */
+				auto now = ref new Windows::Globalization::Calendar();
+				now->SetToNow();
+				values->Data[8] = static_cast<double>(TitaniumWindows::Utility::GetMSecSinceEpoch(now->GetDateTime()).count());
+
+				ApplicationData::Current->LocalSettings->Values->Insert(LAST_GEOLOCATION_KEY, dynamic_cast<PropertyValue^>(PropertyValue::CreateDoubleArray(values)));
+			}
+
+			void BackgroundService::ResetLastGeoposition() TITANIUM_NOEXCEPT
+			{
+				ApplicationData::Current->LocalSettings->Values->Remove(LAST_GEOLOCATION_KEY);
+			}
+
+			Titanium::LocationCoordinates BackgroundService::GetLastGeoposition() TITANIUM_NOEXCEPT
+			{
+				Titanium::LocationCoordinates pos;
+				if (!Get_LocationServiceEnabled() || !ApplicationData::Current->LocalSettings->Values->HasKey(LAST_GEOLOCATION_KEY)) {
+					pos.available = false;
+					return pos;
+				}
+
+				auto values = ref new Platform::Array<double>(9);
+				safe_cast<IPropertyValue^>(ApplicationData::Current->LocalSettings->Values->Lookup(LAST_GEOLOCATION_KEY))->GetDoubleArray(&values);
+
+				/*
+				 * accuracy, altitude, altitudeAccuracy, heading, longitude, latitude, speed, floor, timestamp
+				 */
+				pos.accuracy  = values->Data[0];
+				pos.altitude  = values->Data[1];
+				pos.altitudeAccuracy = values->Data[2];
+				pos.heading   = values->Data[3];
+				pos.longitude = values->Data[4];
+				pos.latitude  = values->Data[5];
+				pos.speed = values->Data[6];
+
+				Titanium::LocationCoordinatesFloor floor;
+				floor.level = static_cast<std::int32_t>(values->Data[7]);
+				pos.floor = floor;
+
+				pos.timestamp = std::chrono::milliseconds(static_cast<std::chrono::milliseconds::rep>(values->Data[8]));
+
+				return pos;
+			}
+
+			TITANIUM_FUNCTION(BackgroundService, registerTimerTask)
+			{
+				ENSURE_OBJECT_AT_INDEX(callback, 0);
+				ENSURE_OPTIONAL_UINT_AT_INDEX(freshnessTime, 1, 15);
+				ENSURE_OPTIONAL_BOOL_AT_INDEX(oneShot, 2, false);
+				const auto task = registerTimerTask(callback, freshnessTime, oneShot);
+				if (task) {
+					return task->get_object();
+				}
+				return get_context().CreateNull();
+			}
+
+			TITANIUM_FUNCTION(BackgroundService, unregisterAllTasks) 
+			{
+				UnregisterTasks();
+				return get_context().CreateUndefined();
+			}
+
+			TITANIUM_PROPERTY_GETTER(BackgroundService, locationServiceEnabled)
+			{
+				return get_context().CreateBoolean(Get_LocationServiceEnabled());
+			}
+
+			TITANIUM_PROPERTY_SETTER(BackgroundService, locationServiceEnabled)
+			{
+				Set_LocationServiceEnabled(static_cast<bool>(argument));
+				return true;
+			}
+		} // namespace WindowsXaml
+	}  // namespace App
+}  // namespace TitaniumWindows

--- a/Source/Ti/src/App/BackgroundService.cpp
+++ b/Source/Ti/src/App/BackgroundService.cpp
@@ -94,7 +94,7 @@ namespace TitaniumWindows
 
 			std::shared_ptr<BackgroundServiceTask> BackgroundService::registerTask(JSObject& callback, IBackgroundTrigger^ trigger, IBackgroundCondition^ condition)
 			{
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 				BackgroundExecutionManager::RequestAccessAsync();
 #endif
 				const auto taskId   = task_id_generator__++;

--- a/Source/Ti/src/App/BackgroundServiceTask.cpp
+++ b/Source/Ti/src/App/BackgroundServiceTask.cpp
@@ -1,0 +1,97 @@
+/**
+* Ti.App.Windows.BackgroundServiceTask
+*
+* Copyright (c) 2016 by Appcelerator, Inc. All Rights Reserved.
+* Licensed under the terms of the Apache Public License.
+* Please see the LICENSE included with this distribution for details.
+*/
+#include "TitaniumWindows/App/BackgroundServiceTask.hpp"
+#include "TitaniumWindows/App/BackgroundService.hpp"
+#include "Titanium/GeolocationModule.hpp"
+#include "Titanium/detail/TiImpl.hpp"
+#include <ppltasks.h>
+
+namespace TitaniumWindows
+{
+	namespace App
+	{
+		namespace WindowsXaml 
+		{
+			BackgroundServiceTask::BackgroundServiceTask(const JSContext& js_context) TITANIUM_NOEXCEPT
+				: Titanium::Module(js_context, "Titanium.App.Windows.BackgroundServiceTask")
+				, callback__(js_context.CreateObject())
+			{
+				TITANIUM_LOG_DEBUG("BackgroundServiceTask::ctor Initialize");
+			}
+
+			BackgroundServiceTask::~BackgroundServiceTask() 
+			{
+				TITANIUM_LOG_DEBUG("BackgroundServiceTask::dtor");
+
+				// Make sure we remove all listeners
+				const auto task = BackgroundService::GetTask(taskId__);
+				if (task) {
+					task->Completed -= completed_event__;
+				}
+			}
+
+			void BackgroundServiceTask::postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) 
+			{
+				Titanium::Module::postCallAsConstructor(js_context, arguments);
+				TITANIUM_LOG_DEBUG("BackgroundServiceTask::postCallAsConstructor");
+			}
+
+			void BackgroundServiceTask::JSExportInitialize() 
+			{
+				JSExport<BackgroundServiceTask>::SetClassVersion(1);
+				JSExport<BackgroundServiceTask>::SetParent(JSExport<Titanium::Module>::Class());
+				TITANIUM_ADD_FUNCTION(BackgroundServiceTask, unregister);
+			}
+
+			TITANIUM_PROPERTY_READ(BackgroundServiceTask, std::uint32_t, taskId);
+
+			void BackgroundServiceTask::taskCompleted(const bool& canceled) 
+			{
+				TITANIUM_ASSERT(callback__.IsFunction());
+
+				const auto ctx = get_context();
+
+				auto e = ctx.CreateObject();
+				e.SetProperty("source", get_object());
+				e.SetProperty("canceled", ctx.CreateBoolean(canceled));
+
+				auto pos = TitaniumWindows::App::WindowsXaml::BackgroundService::GetLastGeoposition();
+				if (pos.available) {
+					e.SetProperty("location", LocationCoordinates_to_js(ctx, pos));
+				}
+
+				const std::vector<JSValue> callback_args{ e };
+				callback__(callback_args, get_object());
+			}
+
+			void BackgroundServiceTask::construct(const std::uint32_t& id, BackgroundTaskRegistration^ registration, JSObject& callback)
+			{
+				taskId__   = id;
+				callback__ = callback;
+				completed_event__ = registration->Completed += ref new BackgroundTaskCompletedEventHandler([this](BackgroundTaskRegistration^ task, BackgroundTaskCompletedEventArgs^ args) {
+					taskCompleted();
+				});
+			}
+
+			void BackgroundServiceTask::unregister()
+			{
+				const auto task = BackgroundService::GetTask(taskId__);
+				if (task) {
+					task->Unregister(true);
+					taskCompleted(true);
+				}
+			}
+
+			TITANIUM_FUNCTION(BackgroundServiceTask, unregister)
+			{
+				unregister();
+				return get_context().CreateUndefined();
+			}
+		} // namespace WindowsXaml
+	}  // namespace App
+}  // namespace TitaniumWindows

--- a/Source/Ti/src/App/WindowsModule.cpp
+++ b/Source/Ti/src/App/WindowsModule.cpp
@@ -1,0 +1,54 @@
+/**
+* Ti.App.Windows module
+*
+* Copyright (c) 2016 by Appcelerator, Inc. All Rights Reserved.
+* Licensed under the terms of the Apache Public License.
+* Please see the LICENSE included with this distribution for details.
+*/
+#include "TitaniumWindows/App/WindowsModule.hpp"
+#include "TitaniumWindows/App/BackgroundService.hpp"
+#include "Titanium/detail/TiImpl.hpp"
+
+#define CREATE_TITANIUM_APP_WINDOWS(NAME) \
+  JSValue Titanium_property = this_object.get_context().get_global_object().GetProperty("Titanium"); \
+  TITANIUM_ASSERT(Titanium_property.IsObject()); \
+  JSObject Titanium = static_cast<JSObject>(Titanium_property); \
+  JSValue App_property = Titanium.GetProperty("App"); \
+  TITANIUM_ASSERT(App_property.IsObject()); \
+  JSObject App = static_cast<JSObject>(App_property); \
+  JSValue App_WIN_property = App.GetProperty("Windows"); \
+  TITANIUM_ASSERT(App_WIN_property.IsObject()); \
+  JSObject App_WIN = static_cast<JSObject>(App_WIN_property); \
+  JSValue NAME##_property = App_WIN.GetProperty(#NAME); \
+  TITANIUM_ASSERT(NAME##_property.IsObject()); \
+  JSObject NAME = static_cast<JSObject>(NAME##_property); \
+  auto NAME##_obj = NAME.CallAsConstructor(parameters); \
+  applyProperties(parameters, NAME##_obj); \
+  return NAME##_obj;
+
+namespace TitaniumWindows
+{
+	namespace App
+	{
+		using namespace ::Windows::UI::Xaml;
+
+		WindowsModule::WindowsModule(const JSContext& js_context) TITANIUM_NOEXCEPT
+			: Titanium::Module(js_context)
+		{
+			TITANIUM_LOG_DEBUG("App::WindowsModule::ctor Initialize");
+		}
+
+		void WindowsModule::JSExportInitialize() 
+		{
+			JSExport<WindowsModule>::SetClassVersion(1);
+			JSExport<WindowsModule>::SetParent(JSExport<Titanium::Module>::Class());
+			TITANIUM_ADD_CONSTANT_PROPERTY(WindowsModule, BackgroundService);
+		}
+
+		TITANIUM_PROPERTY_GETTER(WindowsModule, BackgroundService)
+		{
+			return get_context().CreateObject(JSExport<TitaniumWindows::App::WindowsXaml::BackgroundService>::Class());
+		}
+
+	}  // namespace UI
+}  // namespace TitaniumWindows

--- a/Source/Ti/src/AppModule.cpp
+++ b/Source/Ti/src/AppModule.cpp
@@ -7,6 +7,7 @@
 */
 
 #include "TitaniumWindows/AppModule.hpp"
+#include "TitaniumWindows/App/WindowsModule.hpp"
 #include "Titanium/detail/TiLogger.hpp"
 
 using namespace Windows::Foundation;
@@ -20,9 +21,16 @@ namespace TitaniumWindows
 		TITANIUM_LOG_DEBUG("AppModule::ctor Initialize");
 	}
 
-	void AppModule::JSExportInitialize() {
+	void AppModule::JSExportInitialize() 
+	{
 		JSExport<AppModule>::SetClassVersion(1);
 		JSExport<AppModule>::SetParent(JSExport<Titanium::AppModule>::Class());
+		TITANIUM_ADD_CONSTANT_PROPERTY(AppModule, Windows);
+	}
+
+	TITANIUM_PROPERTY_GETTER(AppModule, Windows)
+	{
+		return get_context().CreateObject(JSExport<TitaniumWindows::App::WindowsModule>::Class());
 	}
 
 	JSObject AppModule::RectToJS(const JSContext& js_context, const Windows::Foundation::Rect& rect)

--- a/Source/Titanium/src/TitaniumWindows.cpp
+++ b/Source/Titanium/src/TitaniumWindows.cpp
@@ -324,6 +324,9 @@ namespace TitaniumWindows
 
 	void Application::OnResuming(Object ^sender, Object ^args) 
 	{
+		// shorthand to indicate we're in background
+		js_context__.JSEvaluateScript("Ti.App.Windows.BackgroundService.suspended = false;");
+
 		// Since we only have "resuming" event, we fires both resume and resumed event.
 		GET_TITANIUM_APP(App);
 		App->fireEvent("resume");
@@ -334,6 +337,8 @@ namespace TitaniumWindows
 	{
 		auto deferral = e->SuspendingOperation->GetDeferral();
 
+		// shorthand to indicate we're in background
+		js_context__.JSEvaluateScript("Ti.App.Windows.BackgroundService.suspended = true;");
 		js_context__.JSEvaluateScript("Ti.Analytics._receivedResponse = false");
 
 		// Since we only have "suspending" event, we fires both pause and paused event.

--- a/Source/TitaniumKit/include/Titanium/GeolocationModule.hpp
+++ b/Source/TitaniumKit/include/Titanium/GeolocationModule.hpp
@@ -12,10 +12,49 @@
 #include "Titanium/Module.hpp"
 #include "Titanium/Geolocation/Constants.hpp"
 #include "HAL/HAL.hpp"
+#include <chrono>
 
 namespace Titanium
 {
 	using namespace HAL;
+
+	/*!
+	  @struct
+	  @discussion Simple object holding floor of the building on which the user is located.
+      In places where floor information can be determined.
+	  See http://docs.appcelerator.com/platform/latest/#!/api/LocationCoordinatesFloor
+	*/
+	struct LocationCoordinatesFloor 
+	{
+		std::int32_t level { 0 };
+	};
+
+	TITANIUMKIT_EXPORT LocationCoordinatesFloor js_to_LocationCoordinatesFloor(const JSObject& object);
+	TITANIUMKIT_EXPORT JSObject LocationCoordinatesFloor_to_js(const JSContext& js_context, const LocationCoordinatesFloor& params);
+
+	/*!
+	  @struct
+	  @discussion Simple object holding the data for a location update.
+	  See http://docs.appcelerator.com/platform/latest/#!/api/LocationCoordinates
+	*/
+	struct LocationCoordinates
+	{
+		double accuracy  { 0 };
+		double altitude  { 0 };
+		double altitudeAccuracy  { 0 };
+		double heading   { 0 };
+		double longitude { 0 };
+		double latitude  { 0 };
+		double speed     { 0 };
+		LocationCoordinatesFloor floor;
+		std::chrono::milliseconds timestamp;
+
+		/* for internal use, to indicate this value is valid */
+		bool available { true };
+	};
+
+	TITANIUMKIT_EXPORT LocationCoordinates js_to_LocationCoordinates(const JSObject& object);
+	TITANIUMKIT_EXPORT JSObject LocationCoordinates_to_js(const JSContext& js_context, const LocationCoordinates& params);
 
 	/*!
 	  @class
@@ -185,35 +224,6 @@ namespace Titanium
 		TITANIUM_FUNCTION_DEF(getLastGeolocation);
 
 		protected:
-			JSValue accuracy_best__;
-			JSValue accuracy_best_for_navigation__;
-			JSValue accuracy_hundred_meters__;
-			JSValue accuracy_kilometer__;
-			JSValue accuracy_nearest_ten_meters__;
-			JSValue accuracy_three_kilometers__;
-			JSValue accuracy_high__;
-			JSValue accuracy_low__;
-			JSValue activitytype_automotive_navigation__;
-			JSValue activitytype_fitness__;
-			JSValue activitytype_other__;
-			JSValue activitytype_other_navigation__;
-			JSValue authorization_always__;
-			JSValue authorization_authorized__;
-			JSValue authorization_denied__;
-			JSValue authorization_restricted__;
-			JSValue authorization_unknown__;
-			JSValue authorization_when_in_use__;
-			JSValue error_denied__;
-			JSValue error_heading_failure__;
-			JSValue error_location_unknown__;
-			JSValue error_network__;
-			JSValue error_region_monitoring_delayed__;
-			JSValue error_region_monitoring_denied__;
-			JSValue error_region_monitoring_failure__;
-			JSValue error_timeout__;
-			JSValue provider_gps__;
-			JSValue provider_network__;
-			JSValue provider_passive__;
 			Geolocation::ACCURACY accuracy__;
 			Geolocation::ACTIVITYTYPE activityType__;
 			double distanceFilter__;

--- a/Source/TitaniumKit/src/GeolocationModule.cpp
+++ b/Source/TitaniumKit/src/GeolocationModule.cpp
@@ -11,40 +11,75 @@
 
 namespace Titanium
 {
+	LocationCoordinatesFloor js_to_LocationCoordinatesFloor(const JSObject& object)
+	{
+		LocationCoordinatesFloor params;
+		if (object.HasProperty("level")) {
+			params.level = static_cast<std::int32_t>(object.GetProperty("level"));
+		}
+		return params;
+	};
+
+	JSObject LocationCoordinatesFloor_to_js(const JSContext& js_context, const LocationCoordinatesFloor& params)
+	{
+		auto object = js_context.CreateObject();
+		object.SetProperty("level", js_context.CreateNumber(params.level));
+		return object;
+	}
+
+	LocationCoordinates js_to_LocationCoordinates(const JSObject& object)
+	{
+		LocationCoordinates params;
+		if (object.HasProperty("accuracy")) {
+			params.accuracy = static_cast<double>(object.GetProperty("accuracy"));
+		}
+		if (object.HasProperty("altitude")) {
+			params.altitude = static_cast<double>(object.GetProperty("altitude"));
+		}
+		if (object.HasProperty("altitudeAccuracy")) {
+			params.altitude = static_cast<double>(object.GetProperty("altitudeAccuracy"));
+		}
+		if (object.HasProperty("floor")) {
+			params.floor = js_to_LocationCoordinatesFloor(static_cast<JSObject>(object.GetProperty("altitude")));
+		}
+		if (object.HasProperty("heading")) {
+			params.heading = static_cast<double>(object.GetProperty("heading"));
+		}
+		if (object.HasProperty("latitude")) {
+			params.latitude = static_cast<double>(object.GetProperty("latitude"));
+		}
+		if (object.HasProperty("longitude")) {
+			params.longitude = static_cast<double>(object.GetProperty("longitude"));
+		}
+		if (object.HasProperty("speed")) {
+			params.speed = static_cast<double>(object.GetProperty("speed"));
+		}
+		if (object.HasProperty("timestamp")) {
+			params.timestamp = std::chrono::milliseconds(static_cast<std::chrono::milliseconds::rep>(static_cast<double>(object.GetProperty("timstamp"))));
+		}
+		return params;
+	};
+
+	JSObject LocationCoordinates_to_js(const JSContext& js_context, const LocationCoordinates& params)
+	{
+		auto object = js_context.CreateObject();
+		object.SetProperty("accuracy",  js_context.CreateNumber(params.accuracy));
+		object.SetProperty("altitude",  js_context.CreateNumber(params.altitude));
+		object.SetProperty("altitudeAccuracy", js_context.CreateNumber(params.altitudeAccuracy));
+		object.SetProperty("floor", LocationCoordinatesFloor_to_js(js_context, params.floor));
+		object.SetProperty("heading",   js_context.CreateNumber(params.heading));
+		object.SetProperty("latitude",  js_context.CreateNumber(params.latitude));
+		object.SetProperty("longitude", js_context.CreateNumber(params.longitude));
+		object.SetProperty("speed",     js_context.CreateNumber(params.speed));
+		object.SetProperty("timestamp", js_context.CreateNumber(static_cast<double>(params.timestamp.count())));
+		return object;
+	}
+
 	GeolocationModule::GeolocationModule(const JSContext& js_context) TITANIUM_NOEXCEPT
 		: Module(js_context, "Titanium.Geolocation"),
-		accuracy_best__(js_context.CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::ACCURACY::BEST))),
-		accuracy_best_for_navigation__(js_context.CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::ACCURACY::BEST_FOR_NAVIGATION))),
-		accuracy_high__(js_context.CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::ACCURACY::HIGH))),
-		accuracy_hundred_meters__(js_context.CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::ACCURACY::HUNDRED_METERS))),
-		accuracy_kilometer__(js_context.CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::ACCURACY::KILOMETER))),
-		accuracy_low__(js_context.CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::ACCURACY::LOW))),
-		accuracy_nearest_ten_meters__(js_context.CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::ACCURACY::NEAREST_TEN_METERS))),
-		accuracy_three_kilometers__(js_context.CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::ACCURACY::THREE_KILOMETERS))),
 		accuracy__(Geolocation::ACCURACY::BEST),
-		activitytype_automotive_navigation__(js_context.CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::ACTIVITYTYPE::AUTOMOTIVE_NAVIGATION))),
-		activitytype_fitness__(js_context.CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::ACTIVITYTYPE::FITNESS))),
-		activitytype_other__(js_context.CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::ACTIVITYTYPE::OTHER))),
-		activitytype_other_navigation__(js_context.CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::ACTIVITYTYPE::OTHER_NAVIGATION))),
 		activityType__(Geolocation::ACTIVITYTYPE::OTHER),
-		authorization_always__(js_context.CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::AUTHORIZATION::ALWAYS))),
-		authorization_authorized__(js_context.CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::AUTHORIZATION::AUTHORIZED))),
-		authorization_denied__(js_context.CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::AUTHORIZATION::DENIED))),
-		authorization_restricted__(js_context.CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::AUTHORIZATION::RESTRICTED))),
-		authorization_unknown__(js_context.CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::AUTHORIZATION::UNKNOWN))),
-		authorization_when_in_use__(js_context.CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::AUTHORIZATION::WHEN_IN_USE))),
 		locationServicesAuthorization__(Geolocation::AUTHORIZATION::UNKNOWN),
-		error_denied__(js_context.CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::ERROR::DENIED))),
-		error_heading_failure__(js_context.CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::ERROR::HEADING_FAILIURE))),
-		error_location_unknown__(js_context.CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::ERROR::LOCATION_UNKNOWN))),
-		error_network__(js_context.CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::ERROR::NETWORK))),
-		error_region_monitoring_delayed__(js_context.CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::ERROR::REGION_MONITORING_DELAYED))),
-		error_region_monitoring_denied__(js_context.CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::ERROR::REGION_MONITORING_DENIED))),
-		error_region_monitoring_failure__(js_context.CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::ERROR::REGION_MONITORING_FAILIURE))),
-		error_timeout__(js_context.CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::ERROR::TIMEOUT))),
-		provider_gps__(js_context.CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::PROVIDER::GPS))),
-		provider_network__(js_context.CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::PROVIDER::NETOWORK))),
-		provider_passive__(js_context.CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::PROVIDER::PASSIVE))),
 		distanceFilter__(0),
 		headingFilter__(0),
 		hasCompass__(false),
@@ -56,151 +91,151 @@ namespace Titanium
 
 	TITANIUM_PROPERTY_GETTER(GeolocationModule, ACCURACY_BEST)
 	{
-		return accuracy_best__;
+		return get_context().CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::ACCURACY::BEST));
 	}
 
 	TITANIUM_PROPERTY_GETTER(GeolocationModule, ACCURACY_BEST_FOR_NAVIGATION)
 	{
-		return accuracy_best_for_navigation__;
+		return get_context().CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::ACCURACY::BEST_FOR_NAVIGATION));
 	}
 
 	TITANIUM_PROPERTY_GETTER(GeolocationModule, ACCURACY_HUNDRED_METERS)
 	{
-		return accuracy_hundred_meters__;
+		return get_context().CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::ACCURACY::HUNDRED_METERS));
 	}
 
 	TITANIUM_PROPERTY_GETTER(GeolocationModule, ACCURACY_KILOMETER)
 	{
-		return accuracy_kilometer__;
+		return get_context().CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::ACCURACY::KILOMETER));
 	}
 
 	TITANIUM_PROPERTY_GETTER(GeolocationModule, ACCURACY_NEAREST_TEN_METERS)
 	{
-		return accuracy_nearest_ten_meters__;
+		return get_context().CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::ACCURACY::NEAREST_TEN_METERS));
 	}
 
 	TITANIUM_PROPERTY_GETTER(GeolocationModule, ACCURACY_THREE_KILOMETERS)
 	{
-		return accuracy_three_kilometers__;
+		return get_context().CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::ACCURACY::THREE_KILOMETERS));
 	}
 
 	TITANIUM_PROPERTY_GETTER(GeolocationModule, ACCURACY_HIGH)
 	{
-		return accuracy_high__;
+		return get_context().CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::ACCURACY::HIGH));
 	}
 
 	TITANIUM_PROPERTY_GETTER(GeolocationModule, ACCURACY_LOW)
 	{
-		return accuracy_low__;
+		return get_context().CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::ACCURACY::LOW));
 	}
 
-	TITANIUM_PROPERTY_READWRITE(GeolocationModule, Geolocation::ACCURACY, accuracy)
+	TITANIUM_PROPERTY_READWRITE(GeolocationModule, Geolocation::ACCURACY, accuracy);
 
 	TITANIUM_PROPERTY_GETTER(GeolocationModule, ACTIVITYTYPE_AUTOMOTIVE_NAVIGATION)
 	{
-			return activitytype_automotive_navigation__;
+		return get_context().CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::ACTIVITYTYPE::AUTOMOTIVE_NAVIGATION));
 	}
 
 	TITANIUM_PROPERTY_GETTER(GeolocationModule, ACTIVITYTYPE_FITNESS)
 	{
-			return activitytype_fitness__;
+		return get_context().CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::ACTIVITYTYPE::FITNESS));
 	}
 
 	TITANIUM_PROPERTY_GETTER(GeolocationModule, ACTIVITYTYPE_OTHER)
 	{
-			return activitytype_other__;
+		return get_context().CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::ACTIVITYTYPE::OTHER));
 	}
 
 	TITANIUM_PROPERTY_GETTER(GeolocationModule, ACTIVITYTYPE_OTHER_NAVIGATION)
 	{
-			return activitytype_other_navigation__;
+		return get_context().CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::ACTIVITYTYPE::OTHER_NAVIGATION));
 	}
 
-	TITANIUM_PROPERTY_READWRITE(GeolocationModule, Geolocation::ACTIVITYTYPE, activityType)
+	TITANIUM_PROPERTY_READWRITE(GeolocationModule, Geolocation::ACTIVITYTYPE, activityType);
 
 	TITANIUM_PROPERTY_GETTER(GeolocationModule, AUTHORIZATION_ALWAYS)
 	{
-			return authorization_always__;
+		return get_context().CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::AUTHORIZATION::ALWAYS));
 	}
 
 	TITANIUM_PROPERTY_GETTER(GeolocationModule, AUTHORIZATION_AUTHORIZED)
 	{
-			return authorization_authorized__;
+		return get_context().CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::AUTHORIZATION::AUTHORIZED));
 	}
 
 	TITANIUM_PROPERTY_GETTER(GeolocationModule, AUTHORIZATION_DENIED)
 	{
-			return authorization_denied__;
+		return get_context().CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::AUTHORIZATION::DENIED));
 	}
 
 	TITANIUM_PROPERTY_GETTER(GeolocationModule, AUTHORIZATION_RESTRICTED)
 	{
-			return authorization_restricted__;
+		return get_context().CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::AUTHORIZATION::RESTRICTED));
 	}
 
 	TITANIUM_PROPERTY_GETTER(GeolocationModule, AUTHORIZATION_UNKNOWN)
 	{
-			return authorization_unknown__;
+		return get_context().CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::AUTHORIZATION::UNKNOWN));
 	}
 
 	TITANIUM_PROPERTY_GETTER(GeolocationModule, AUTHORIZATION_WHEN_IN_USE)
 	{
-			return authorization_when_in_use__;
+		return get_context().CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::AUTHORIZATION::WHEN_IN_USE));
 	}
 
 	TITANIUM_PROPERTY_GETTER(GeolocationModule, ERROR_DENIED)
 	{
-			return error_denied__;
+		return get_context().CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::ERROR::DENIED));
 	}
 
 	TITANIUM_PROPERTY_GETTER(GeolocationModule, ERROR_HEADING_FAILURE)
 	{
-			return error_heading_failure__;
+		return get_context().CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::ERROR::HEADING_FAILIURE));
 	}
 
 	TITANIUM_PROPERTY_GETTER(GeolocationModule, ERROR_LOCATION_UNKNOWN)
 	{
-			return error_location_unknown__;
+		return get_context().CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::ERROR::LOCATION_UNKNOWN));
 	}
 
 	TITANIUM_PROPERTY_GETTER(GeolocationModule, ERROR_NETWORK)
 	{
-			return error_network__;
+		return get_context().CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::ERROR::NETWORK));
 	}
 
 	TITANIUM_PROPERTY_GETTER(GeolocationModule, ERROR_REGION_MONITORING_DELAYED)
 	{
-			return error_region_monitoring_delayed__;
+		return get_context().CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::ERROR::REGION_MONITORING_DELAYED));
 	}
 
 	TITANIUM_PROPERTY_GETTER(GeolocationModule, ERROR_REGION_MONITORING_DENIED)
 	{
-			return error_region_monitoring_denied__;
+		return get_context().CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::ERROR::REGION_MONITORING_DENIED));
 	}
 
 	TITANIUM_PROPERTY_GETTER(GeolocationModule, ERROR_REGION_MONITORING_FAILURE)
 	{
-			return error_region_monitoring_failure__;
+		return get_context().CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::ERROR::REGION_MONITORING_FAILIURE));
 	}
 
 	TITANIUM_PROPERTY_GETTER(GeolocationModule, ERROR_TIMEOUT)
 	{
-			return error_timeout__;
+		return get_context().CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::ERROR::TIMEOUT));
 	}
 
 	TITANIUM_PROPERTY_GETTER(GeolocationModule, PROVIDER_GPS)
 	{
-			return provider_gps__;
+		return get_context().CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::PROVIDER::GPS));
 	}
 
 	TITANIUM_PROPERTY_GETTER(GeolocationModule, PROVIDER_NETWORK)
 	{
-			return provider_network__;
+		return get_context().CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::PROVIDER::NETOWORK));
 	}
 
 	TITANIUM_PROPERTY_GETTER(GeolocationModule, PROVIDER_PASSIVE)
 	{
-			return provider_passive__;
+		return get_context().CreateNumber(Titanium::Geolocation::Constants::to_underlying_type(Titanium::Geolocation::PROVIDER::PASSIVE));
 	}
 
 	TITANIUM_PROPERTY_READWRITE(GeolocationModule, double, distanceFilter)
@@ -240,7 +275,8 @@ namespace Titanium
 		TITANIUM_LOG_WARN("GeolocationModule::reverseGeocoder: Unimplemented");
 	}
 
-	void GeolocationModule::JSExportInitialize() {
+	void GeolocationModule::JSExportInitialize() 
+	{
 		JSExport<GeolocationModule>::SetClassVersion(1);
 		JSExport<GeolocationModule>::SetParent(JSExport<Module>::Class());
 

--- a/Tools/Scripts/build/test.js
+++ b/Tools/Scripts/build/test.js
@@ -170,7 +170,9 @@ function addTiAppProperties(sdkVersion, next) {
 			content.push('\t<property name="presetDouble" type="double">1.23456</property>');
 			content.push('\t<windows><manifest><Capabilities><Capability Name=\"internetClient\" />');
 			content.push('\t<Capability Name=\"contacts\" />');
-			content.push('\t</Capabilities></manifest></windows>');
+			content.push('\t</Capabilities>');
+			content.push('\t<Extensions> <Extension Category="windows.backgroundTasks" EntryPoint="TitaniumWindows_Ti.BackgroundServiceTask"> <BackgroundTasks> <Task Type="timer" /> </BackgroundTasks> </Extension> </Extensions>');
+			content.push('\t</manifest></windows>');
 		}
 	});
 	fs.writeFileSync(tiapp_xml, content.join('\n'));


### PR DESCRIPTION
First cut for background service implementation. [TIMOB-18952](https://jira.appcelerator.org/browse/TIMOB-18952)

Initial goal is to enable HTTP access and geolocation in background.
Here's a sample code:

```javascript
var win = Ti.UI.createWindow({
    backgroundColor: 'blue'
});
var view = Ti.UI.createView({ layout: 'vertical' });

//
// Enable location tracking in background
//
Ti.App.Windows.BackgroundService.locationServiceEnabled = true;

//
// Callback for background task
// Note that you can't use setTimeout/setInterval in background, as well as any UI interaction (of course).
// Also, note that Ti.Geolocation events does not work in background. Use locationServiceEnabled instead.
//
var callback = function (e) {
    //
    // e.source ... task object that invokes this event
    // e.cancel ... indicate that this task is canceled
    // e.location ... Current location. Available only when locationServiceEnabled is true.
    // 
    //
    if (e.canceled) {
        Ti.API.info("Task canceled");
    } else {
        Ti.API.info("Do something useful");
        if (e.location) {
            // location contains latitude, longitude etc.
            // See LocationCoodinates for details (http://docs.appcelerator.com/platform/latest/#!/api/LocationCoordinates)
            Ti.API.info('Current geolocation: ' + JSON.stringify(e.location));
        }
        Ti.API.info("Get something via HTTP then");
        var url = "http://www.appcelerator.com";
        var client = Ti.Network.createHTTPClient({
            onload: function (e) {
                Ti.API.info("Received data size: " + this.responseData.size);
            },
            onerror: function (e) {
                Ti.API.info('Error: ' + e.error);
            },
            timeout: 5000
        });
        client.open("GET", url);
        client.send();
    }
};

var task;
var registerBtn = Ti.UI.createButton({
    title: "register timer task"
});
var unregisterBtn = Ti.UI.createButton({
    title: "unregister timer task"
});
var unregisterAllBtn = Ti.UI.createButton({
    title: "unregister ALL tasks"
});

registerBtn.addEventListener('click', function () {
    //
    // BackgroundService.registerTimerTask(callback, interval_minutes, is_one_shot);
    //
    // Create timer task, that repeats at 15-minute intervals.
    // Note that Windows doesn't accept interval less than 15 minutes.
    //
    task = Ti.App.Windows.BackgroundService.registerTimerTask(callback, 15, false);
});

unregisterBtn.addEventListener('click', function () {
    //
    // When you unregister the task, task invokes callback with canceled = true.
    //
    task.unregister();
});

unregisterAllBtn.addEventListener('click', function () {
    //
    // Unregister all tasks that is associated with this application.
    //
    Ti.App.Windows.BackgroundService.unregisterAllTasks();
});

view.add(registerBtn);
view.add(unregisterBtn);
view.add(unregisterAllBtn);

win.add(view);
win.open();
```


##### IMPORTANT NOTE

To enable background service, both Windows Phone and Windows Store apps require an `timer` BackgroundTask extension as well as `internetClient` and `location` capabilities in the `tiapp.xml`. (See [Windows-specific configuration](https://wiki.appcelerator.org/display/guides2/tiapp.xml+and+timodule.xml+Reference#tiapp.xmlandtimodule.xmlReference-Windows-specificapplicationproperties) for details) Also, when you use geolocation, make sure your devices enables GPS.

###### tiapp.xml Background  Task Extension

```xml
<windows>
  <manifest>
    <Extensions>
        <Extension Category="windows.backgroundTasks" EntryPoint="TitaniumWindows_Ti.BackgroundServiceTask">
          <BackgroundTasks>
            <Task Type="timer" />
          </BackgroundTasks>
        </Extension>
    </Extensions>
    <Capabilities>
      <Capability Name="internetClient" />
      <DeviceCapability Name="location" />
    </Capabilities>
  </manifest>
</windows>
```
