### PR TITLE
[TIMOB-18531] Verify --win-publisher-id requirement for production builds

### DIFF
--- a/cli/commands/_build/config/winPublisherId.js
+++ b/cli/commands/_build/config/winPublisherId.js
@@ -30,6 +30,10 @@ module.exports = function configOptionWindowsPublisherID(order) {
 				validate: validate
 			}));
 		}.bind(this),
-		validate: validate
+		validate: validate,
+		required: true,
+		verifyIfRequired: function (callback) {
+			callback(this.cli.argv['deploy-type'] === 'production');
+		}.bind(this)
 	};
 };


### PR DESCRIPTION
- Added ```verifyIfRequired``` to ```winPublisherId.js``` config

###### TEST CASE
```
appc run -p windows -T wp-device --deploy-type production --build-only
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-18531)

