### PR TITLE
[TIMOB-20385] Fix: ScrollView does not respect `top` property on views

### DIFF
--- a/Examples/NMocha/src/Assets/ti.ui.layout.test.js
+++ b/Examples/NMocha/src/Assets/ti.ui.layout.test.js
@@ -996,6 +996,44 @@ describe("Titanium.UI.Layout", function () {
         win.open();
     });
 
+    //TIMOB-20385
+    it("scrollViewWithTop", function (finish) {
+        var win = createWindow({
+            backgroundColor: "#7B6700",
+            layout: "vertical"
+        }, finish);
+        var NavBarView = Ti.UI.createView({
+            height: "25",
+            top: 0,
+            backgroundColor: "green",
+            width: "100%"
+        });
+        var scrollView = Ti.UI.createScrollView({
+            height: 300,
+            width: Ti.UI.FILL,
+            scrollType: "vertical",
+            layout: "vertical",
+            backgroundColor: "red"
+        });
+        var button = Ti.UI.createButton({
+            title: "Click",
+            width: "100",
+            height: "50",
+            top: 20, left: 40
+        });
+        scrollView.add(button);
+        win.add(NavBarView);
+        win.add(scrollView);
+        scrollView.addEventListener("postlayout", function (e) {
+            if (didPostlayout) return;
+            didPostlayout = true;
+            should(scrollView.size.height).eql(300);
+            should(button.top).eql(20);
+            should(button.left).eql(40);
+        });
+        win.open();
+    });
+
     //TIMOB-8891
     ((Ti.Platform.version.indexOf('6.3.9600') == 0 && Ti.Platform.osname === 'windowsstore') ? it.skip : it)("scrollViewWithLargeVerticalLayoutChild", function (finish) {
         var win = createWindow({}, finish);

--- a/Source/UI/include/TitaniumWindows/UI/ScrollView.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/ScrollView.hpp
@@ -29,6 +29,8 @@ namespace TitaniumWindows
 
 			virtual void add(const std::shared_ptr<Titanium::UI::View>& view) TITANIUM_NOEXCEPT override;
 			virtual void set_layout(const std::string& layout) TITANIUM_NOEXCEPT override;
+			virtual void set_width(const std::string&) TITANIUM_NOEXCEPT override;
+			virtual void set_height(const std::string&) TITANIUM_NOEXCEPT override;
 
 			virtual void requestLayout(const bool& fire_event = false) override;
 

--- a/Source/UI/src/ScrollView.cpp
+++ b/Source/UI/src/ScrollView.cpp
@@ -41,6 +41,22 @@ namespace TitaniumWindows
 			contentView__->set_layout(layout);
 		}
 
+		void ScrollViewLayoutDelegate::set_width(const std::string& width) TITANIUM_NOEXCEPT
+		{
+			WindowsViewLayoutDelegate::set_width(width);
+			if (width != Titanium::UI::Constants::to_string(Titanium::UI::LAYOUT::SIZE)) {
+				contentView__->set_width(Titanium::UI::Constants::to_string(Titanium::UI::LAYOUT::FILL));
+			}
+		}
+
+		void ScrollViewLayoutDelegate::set_height(const std::string& height) TITANIUM_NOEXCEPT
+		{
+			WindowsViewLayoutDelegate::set_height(height);
+			if (height != Titanium::UI::Constants::to_string(Titanium::UI::LAYOUT::SIZE)) {
+				contentView__->set_height(Titanium::UI::Constants::to_string(Titanium::UI::LAYOUT::FILL));
+			}
+		}
+
 		void ScrollView::postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments)
 		{
 			using namespace Windows::UI::Xaml::Controls;
@@ -64,10 +80,10 @@ namespace TitaniumWindows
 
 			Titanium::UI::ScrollView::setLayoutDelegate<ScrollViewLayoutDelegate>(this, content->getViewLayoutDelegate<WindowsViewLayoutDelegate>());
 
-			layoutDelegate__->set_defaultHeight(Titanium::UI::LAYOUT::FILL);
-			layoutDelegate__->set_defaultWidth(Titanium::UI::LAYOUT::FILL);
-			layoutDelegate__->set_autoLayoutForHeight(Titanium::UI::LAYOUT::FILL);
-			layoutDelegate__->set_autoLayoutForWidth(Titanium::UI::LAYOUT::FILL);
+			layoutDelegate__->set_defaultHeight(Titanium::UI::LAYOUT::SIZE);
+			layoutDelegate__->set_defaultWidth(Titanium::UI::LAYOUT::SIZE);
+			layoutDelegate__->set_autoLayoutForHeight(Titanium::UI::LAYOUT::SIZE);
+			layoutDelegate__->set_autoLayoutForWidth(Titanium::UI::LAYOUT::SIZE);
 
 			getViewLayoutDelegate<ScrollViewLayoutDelegate>()->setComponent(scroll_viewer__);
 


### PR DESCRIPTION
Fix for [TIMOB-20385](https://jira.appcelerator.org/browse/TIMOB-20385)

ScrollView does not respect `top` property on child views.

```javascript
var win = Ti.UI.createWindow({
    backgroundColor: "#7B6700",
    layout: "vertical"
});
var NavBarView = Ti.UI.createView({
    height: "25",
    top: 0,
    backgroundColor: "green",
    width: "100%"
});
var scrollView = Ti.UI.createScrollView({
    height: '50%',
    width: Ti.UI.FILL,
    scrollType: "vertical",
    layout: "vertical",
    backgroundColor: "gray"
});
var button = Ti.UI.createButton({
    title: "Click",
    width: "100",
    height: "50",
    backgroundColor: 'blue',
    top: 20, left: 20
});
scrollView.add(button);
win.add(NavBarView);
win.add(scrollView);
scrollView.addEventListener("postlayout", function (e) {
    Ti.API.info(JSON.stringify(button.rect));
});
win.open();
```

![sc](https://cloud.githubusercontent.com/assets/1661068/13316064/8472d0e2-dbf1-11e5-80f7-258302bef85f.png)
