### PR TITLE
[TIMOB-20080] Implement Ti.Media.AudioPlayer.allowBackground for Windows 10

### DIFF
--- a/Source/Media/src/Media/AudioPlayer.cpp
+++ b/Source/Media/src/Media/AudioPlayer.cpp
@@ -115,7 +115,9 @@ namespace TitaniumWindows
 							state__ = Titanium::Media::AudioState::Stopped;
 							break;
 					}
-					stateChanged();
+					TitaniumWindows::Utility::RunOnUIThread([=]{
+						stateChanged();
+					});
 				}
 			);
 #endif


### PR DESCRIPTION
- State changes need to happen on the main thread
- Although the ```Executable``` should only be defined for ```Control Channel``` or ```Push notification```, ```Audio``` does not work without it
- Updated [wiki](https://wiki.appcelerator.org/display/guides2/tiapp.xml+and+timodule.xml+Reference#tiapp.xmlandtimodule.xmlReference-BackgroundAudioCapability)

###### tiapp.xml Background Audio Extension for _NG.exe_
```XML
<windows>
  <manifest>
    <Extensions>
      <Extension Category="windows.backgroundTasks" Executable="$targetnametoken$.exe" EntryPoint="TitaniumWindows_Media.AudioBackground">
        <BackgroundTasks>
          <Task Type="audio" />
        </BackgroundTasks>
      </Extension>
    </Extensions>
  </manifest>
</windows>
```

###### TEST CASE
```Javascript
var audioPlayer = Ti.Media.createAudioPlayer({url: 'http://media-the.musicradio.com:80/SmoothExtraMP3'}),
    win = Titanium.UI.createWindow({backgroundColor: 'red'}),
    play_btn = Titanium.UI.createButton({title: 'play/pause', top: '33%'}),
    background_btn = Titanium.UI.createButton({title: 'allowBackground: false', top: '66%'});

play_btn.addEventListener('click', function() {
    audioPlayer.isPlaying() ? audioPlayer.stop() : audioPlayer.start();
});
background_btn.addEventListener('click', function() {
    audioPlayer.setAllowBackground(!audioPlayer.allowBackground);
    background_btn.setTitle('allowBackground: ' + audioPlayer.allowBackground);
});

win.add(play_btn);
win.add(background_btn);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-20080)