### PR TITLE
[TIMOB-20481] Support l10n application name

### DIFF
--- a/cli/commands/_build/generate.js
+++ b/cli/commands/_build/generate.js
@@ -65,11 +65,11 @@ function generateI18N(next) {
 		}
 
 		// process default app_name
-		if (!data[locale].strings.app_name) {
+		if (data[locale].strings && !data[locale].strings.app_name) {
 			data[locale].strings.app_name = data.en.app.appname;
 		}
 		// process default app_description
-		if (!data[locale].strings.app_description) {
+		if (data[locale].strings && !data[locale].strings.app_description) {
 			data[locale].strings.app_description = data[locale].strings.app_name;
 		}
 

--- a/cli/commands/_build/generate.js
+++ b/cli/commands/_build/generate.js
@@ -67,10 +67,14 @@ function generateI18N(next) {
 		// process default app_name
 		if (data[locale].strings && !data[locale].strings.app_name) {
 			data[locale].strings.app_name = data.en.app.appname;
+		} else {
+			addString('app_name', data.en.app.appname);
 		}
 		// process default app_description
 		if (data[locale].strings && !data[locale].strings.app_description) {
 			data[locale].strings.app_description = data[locale].strings.app_name;
+		} else {
+			addString('app_description', data.en.app.appname);
 		}
 
 		data[locale].strings && Object.keys(data[locale].strings).forEach(function (name) {

--- a/cli/commands/_build/generate.js
+++ b/cli/commands/_build/generate.js
@@ -64,13 +64,17 @@ function generateI18N(next) {
 			root.appendChild(dataNode);
 		}
 
-		// process app_name first
-		addString('app_name', data[locale].app && data[locale].app.appname || this.tiapp.name);
+		// process default app_name
+		if (!data[locale].strings.app_name) {
+			data[locale].strings.app_name = data.en.app.appname;
+		}
+		// process default app_description
+		if (!data[locale].strings.app_description) {
+			data[locale].strings.app_description = data[locale].strings.app_name;
+		}
 
 		data[locale].strings && Object.keys(data[locale].strings).forEach(function (name) {
-			if (name !== 'appname') {
-				addString(name, data[locale].strings[name]);
-			}
+			addString(name, data[locale].strings[name]);
 		});
 
 		this.logger.debug(__('Writing %s strings => %s', locale.cyan, dest.cyan));

--- a/templates/build/Package.phone.appxmanifest.in.ejs
+++ b/templates/build/Package.phone.appxmanifest.in.ejs
@@ -12,7 +12,7 @@
         PhonePublisherId="@PHONE_PUBLISHER_ID@" />
 
   <Properties>
-    <DisplayName>@SHORT_NAME@</DisplayName>
+    <DisplayName>ms-resource:app_name</DisplayName>
     <PublisherDisplayName>@PUBLISHER_DISPLAY_NAME@</PublisherDisplayName>
     <Logo>StoreLogo.png</Logo>
 <% for(var i = 0; i < manifest.Properties.length; i++) { -%>
@@ -40,14 +40,14 @@
 		 Executable="$targetnametoken$.exe"
 		 EntryPoint="@SHORT_NAME@.App">
       <m3:VisualElements
-          DisplayName="@SHORT_NAME@"
-          Description="@SHORT_NAME@"
+          DisplayName="ms-resource:app_name"
+          Description="ms-resource:app_description"
           BackgroundColor="#171717"
           ForegroundText="light"
           Square150x150Logo="Square150x150Logo.png" 
           Square44x44Logo="Square44x44Logo.png" 
           ToastCapable="true">
-        <m3:DefaultTile ShortName="@SHORT_NAME@" Square71x71Logo="Square71x71Logo.png">
+        <m3:DefaultTile ShortName="ms-resource:app_name" Square71x71Logo="Square71x71Logo.png">
           <m3:ShowNameOnTiles>
             <m3:ShowOn Tile="square150x150Logo" />
           </m3:ShowNameOnTiles>

--- a/templates/build/Package.store.appxmanifest.in.ejs
+++ b/templates/build/Package.store.appxmanifest.in.ejs
@@ -7,7 +7,7 @@
 	    Version="@VERSION@" />
 
   <Properties>
-    <DisplayName>@SHORT_NAME@</DisplayName>
+    <DisplayName>ms-resource:app_name</DisplayName>
     <PublisherDisplayName>@PUBLISHER_DISPLAY_NAME@</PublisherDisplayName>
     <Logo>StoreLogo.png</Logo>
 <% for(var i = 0; i < manifest.Properties.length; i++) { -%>
@@ -35,14 +35,14 @@
 		 Executable="$targetnametoken$.exe"
 		 EntryPoint="@SHORT_NAME@.App">
       <m2:VisualElements
-          DisplayName="@SHORT_NAME@"
-          Description="@SHORT_NAME@"
+          DisplayName="ms-resource:app_name"
+          Description="ms-resource:app_description"
           BackgroundColor="#171717"
           ForegroundText="light"
           Square150x150Logo="Logo.png"
           Square30x30Logo="SmallLogo.png"
           ToastCapable="true">
-        <m2:DefaultTile ShortName="@SHORT_NAME@">
+        <m2:DefaultTile ShortName="ms-resource:app_name">
           <m2:ShowNameOnTiles>
             <m2:ShowOn Tile="square150x150Logo" />
           </m2:ShowNameOnTiles>

--- a/templates/build/Package.win10.appxmanifest.in.ejs
+++ b/templates/build/Package.win10.appxmanifest.in.ejs
@@ -14,7 +14,7 @@
   <mp:PhoneIdentity PhoneProductId="@PHONE_PRODUCT_ID@" PhonePublisherId="@PHONE_PUBLISHER_ID@"/>
 
   <Properties>
-    <DisplayName>@SHORT_NAME@</DisplayName>
+    <DisplayName>ms-resource:app_name</DisplayName>
     <PublisherDisplayName>@PUBLISHER_DISPLAY_NAME@</PublisherDisplayName>
     <Logo>StoreLogo.png</Logo>
 <% for(var i = 0; i < manifest.Properties.length; i++) { -%>
@@ -38,10 +38,10 @@
       Executable="$targetnametoken$.exe"
       EntryPoint="@SHORT_NAME@.App">
       <uap:VisualElements
-        DisplayName="@SHORT_NAME@"
+        DisplayName="ms-resource:app_name"
         Square150x150Logo="Square150x150Logo.png"
         Square44x44Logo="Square44x44Logo.png"
-        Description="@SHORT_NAME@"
+        Description="ms-resource:app_description"
         BackgroundColor="transparent">
         <uap:DefaultTile Square71x71Logo="Square71x71Logo.png"/>
         <uap:SplashScreen Image="SplashScreen.png" />


### PR DESCRIPTION
[TIMOB-20481](https://jira.appcelerator.org/browse/TIMOB-20481)

Add localization support for application name. You can use Titanium's [string localization resources](http://docs.appcelerator.com/platform/latest/#!/api/Titanium.Locale-method-getString) to localize application name. You need to use `app_name` for application name, and `app_description` for application description. These entries are optional. Note that you may need to uninstall existing app in order to see updated application name.

## i18n/en/strings.xml
```xml
<?xml version="1.0" encoding="UTF-8"?>
<resources>
    <string name="app_name">Titanium Test App</string>
    <string name="app_description">This is awesome app</string>
</resources>
```

## i18n/ja/strings.xml
```xml
<?xml version="1.0" encoding="UTF-8"?>
<resources>
    <string name="app_name">Titanium テスト</string>
</resources>
```
