### PR TITLE
[TIMOB-20496] Badge icon needed with background task for Store

### DIFF
--- a/cli/commands/_build/copy.js
+++ b/cli/commands/_build/copy.js
@@ -264,6 +264,15 @@ function copyResources(next) {
 		var appIconSetDir = path.join(this.buildDir, 'Assets'),
 			missingIcons = [
 
+			// Square24x24Logo
+			{
+				description: 'Square24x24Logo.png - Used for badge',
+				file: path.join(appIconSetDir, 'Square24x24Logo.png'),
+				width: 24,
+				height: 24,
+				required: true
+			},
+
 			// Square44x44Logo
 			{
 				description: 'Square44x44Logo.png - Used for logo',

--- a/templates/build/Package.store.appxmanifest.in.ejs
+++ b/templates/build/Package.store.appxmanifest.in.ejs
@@ -42,6 +42,7 @@
           Square150x150Logo="Logo.png"
           Square30x30Logo="SmallLogo.png"
           ToastCapable="true">
+        <m2:LockScreen Notification="badge" BadgeLogo="Square24x24Logo.png" />
         <m2:DefaultTile ShortName="@SHORT_NAME@">
           <m2:ShowNameOnTiles>
             <m2:ShowOn Tile="square150x150Logo" />

--- a/templates/build/Package.win10.appxmanifest.in.ejs
+++ b/templates/build/Package.win10.appxmanifest.in.ejs
@@ -43,6 +43,7 @@
         Square44x44Logo="Square44x44Logo.png"
         Description="@SHORT_NAME@"
         BackgroundColor="transparent">
+        <uap:LockScreen Notification="badge" BadgeLogo="Square24x24Logo.png" />
         <uap:DefaultTile Square71x71Logo="Square71x71Logo.png"/>
         <uap:SplashScreen Image="SplashScreen.png" />
       </uap:VisualElements>


### PR DESCRIPTION
[TIMOB-20496](https://jira.appcelerator.org/browse/TIMOB-20496)

Enabling background task requires "badge icon" when building for Windows Store. It is required to package the app even when badge is not actually used.

```
> appc ti build -T dist-winstore -p windows
error APPX1675: App manifest declares background task of type timer, control channel, 
push notification, or location without enabling lock screen notifications. 
```

FYI: Enabling background task (tiapp.xml)
```xml
<windows>
  <manifest>
    <Extensions>
        <Extension Category="windows.backgroundTasks" EntryPoint="TitaniumWindows_Ti.BackgroundServiceTask">
          <BackgroundTasks>
            <Task Type="timer" />
          </BackgroundTasks>
        </Extension>
    </Extensions>
  </manifest>
</windows>
```
