### PR TITLE
[TIMOB-20386] Fix: View based click event is not responsive

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
@@ -450,6 +450,7 @@ namespace TitaniumWindows
 			static Windows::UI::Color ColorForHexCode(const std::string& hexCode);
 
 			virtual void setDefaultBackground();
+			virtual void updateSelectedBackground();
 			virtual void updateBackground(Windows::UI::Xaml::Media::Brush^);
 			virtual void updateDisabledBackground();
 			Windows::UI::Xaml::Media::Brush^ getBackground();
@@ -507,6 +508,7 @@ namespace TitaniumWindows
 			bool is_grid__{false};
 			bool is_control__{false};
 			bool is_scrollview__ { false };
+			bool is_button__{ false };
 			bool is_loaded__{false};
 
 			Titanium::LayoutEngine::Rect oldRect__;

--- a/Source/UI/src/Button.cpp
+++ b/Source/UI/src/Button.cpp
@@ -48,7 +48,7 @@ namespace TitaniumWindows
 			parent->SetColumn(border, 0);
 			parent->SetRow(border, 0);
 
-			getViewLayoutDelegate<WindowsButtonLayoutDelegate>()->setComponent(parent, nullptr, border);
+			getViewLayoutDelegate<WindowsButtonLayoutDelegate>()->setComponent(parent, button__, border);
 		}
 
 		void Button::JSExportInitialize()


### PR DESCRIPTION
Fix for [TIMOB-20386](https://jira.appcelerator.org/browse/TIMOB-20386).

This PR improves response rate of`Ti.UI.Button` `click` event significantly. It looks like the issue is because Xaml `Tapped` event is not so responsive, and on the Button we have `Click` event which works much better.

Sample code: Try clicking the button fast, for instance 3 clicks at one second.

```javascript
var win = Ti.UI.createWindow();
var view = Ti.UI.createView({
    width: Ti.UI.FILL, height: Ti.UI.FILL,
    layout: 'vertical'
});

var count = 0;
var label = Ti.UI.createLabel({
    width: Ti.UI.FILL, height: '10%',
    text: '0',
    textAlign: Ti.UI.TEXT_ALIGNMENT_CENTER,
    font: { fontSize: 48 }
});

var button = Ti.UI.createButton({
    backgroundColor: 'green',
    width: Ti.UI.FILL, height: '10%',
    title: 'PUSH'
});
button.addEventListener('click', function (e) {
    count++;
    label.text = count;
});

view.add(label);
view.add(button);
win.add(view);
win.open();
```

For other components, unfortunately, from what I observed I noticed that Xaml controls's `Tapped` event is not so responsive even on pure native app. So I don't have anything to do with it.

