### PR TITLE
[TIMOB-19956] Fix Ti.UI.ListView footerView, footerTitle and headerTitle

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/ListView.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/ListView.hpp
@@ -104,7 +104,8 @@ namespace TitaniumWindows
 
 			std::vector<Windows::UI::Xaml::UIElement^> unfiltered_headers__;
 			std::vector<std::vector<Titanium::UI::ListDataItem>> unfiltered_sectionItems__;
-			std::vector<std::shared_ptr<Titanium::UI::View>> headers_as_view__;
+			std::vector<std::shared_ptr<Titanium::UI::View>> headerViews__;
+			std::vector<std::shared_ptr<Titanium::UI::View>> footerViews__;
 #pragma warning(pop)
 
 			Windows::Foundation::EventRegistrationToken itemclick_event__;


### PR DESCRIPTION
- Only show a header or footer if either ```headerView``` ```headerTitle``` ```footerView``` ```footerTitle``` are set
- Implemented ```footerView``` and ```footerTitle``` functionality
- Added validation to ```headerView``` and ```footerView```

###### TEST CASE
```Javascript
var win = Ti.UI.createWindow({backgroundColor: 'white'}),
    listView = Ti.UI.createListView(),
    ukHeaderView = Ti.UI.createView({backgroundColor: 'black', height: 42}),
    ukFooterView = Ti.UI.createView({backgroundColor: 'black', height: 42}),
    ukSection = Ti.UI.createListSection({headerView: ukHeaderView, footerView: ukFooterView}),
    usSection = Ti.UI.createListSection({headerTitle: 'English US Header', footerTitle: 'English US Footer'});

ukHeaderView.add(Ti.UI.createLabel({text: 'English UK Header', color: 'white'}));
ukFooterView.add(Ti.UI.createLabel({text: 'English UK Footer', color: 'white'}));
ukSection.setItems([
    {properties: {title: 'Lift', color: 'black'}},
    {properties: {title: 'Lorry', color: 'black'}},
    {properties: {title: 'Motorway', color: 'black'}}
]);
listView.appendSection(ukSection);

usSection.setItems([
    {properties: {title: 'Elevator', color: 'black'}},
    {properties: {title: 'Truck', color: 'black'}},
    {properties: {title: 'Freeway', color: 'black'}}
]);
listView.appendSection(usSection);

win.add(listView);
win.open();
```

[TIMOB-19956](https://jira.appcelerator.org/browse/TIMOB-19956)