### PR TITLE
[TIMOB-20566] Pass wp-sdk to windowslib during connect()

### DIFF
--- a/cli/commands/_build/config/deviceID.js
+++ b/cli/commands/_build/config/deviceID.js
@@ -46,6 +46,7 @@ module.exports = function configOptionDeviceID(order) {
 		// check the device
 		if (cli.argv.target === 'wp-device') {
 			// try connecting to the device to detect no device or more than 1 device
+			this.windowslibOptions['wpsdk'] = cli.argv['wp-sdk'];
 			windowslib.device.connect(dev.udid, this.windowslibOptions)
 				.on('connected', function () {
 					callback(null, value);


### PR DESCRIPTION
- Pass ```wp-sdk``` to windowslib so it can determine the correct tool to use [wptool.js#L397](https://github.com/appcelerator/windowslib/blob/master/lib/wptool.js#L397)

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-20566)