### PR TITLE
[TIMOB-20569] Fix: View visible property doesn't seem to work

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
@@ -327,7 +327,6 @@ namespace TitaniumWindows
 
 			  @discussion Determines whether the view is visible
 			*/
-			virtual bool get_visible() const TITANIUM_NOEXCEPT override;
 			virtual void set_visible(const bool& visible) TITANIUM_NOEXCEPT override;
 
 			/*!

--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -205,19 +205,6 @@ namespace TitaniumWindows
 		{
 			Titanium::UI::ViewLayoutDelegate::set_visible(visible);
 			getComponent()->Visibility = (visible ? Visibility::Visible : Visibility::Collapsed);
-
-			// all visible schildren should be affected by parent visibility
-			for (const auto child : children__) {
-				const auto layout    = child->getViewLayoutDelegate<WindowsViewLayoutDelegate>();
-				const auto component = layout->getComponent();
-
-				// don't change visibility of hidden component.
-				// only "visible" children are affected by parent visibility
-				if (layout->get_visible()) {
-					getComponent()->Visibility = (visible ? Visibility::Visible : Visibility::Collapsed);
-				}
-
-			}
 		}
 
 		void WindowsViewLayoutDelegate::animate(const std::shared_ptr<Titanium::UI::Animation>& animation, JSObject& callback, const JSObject& this_object) TITANIUM_NOEXCEPT

--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -201,15 +201,23 @@ namespace TitaniumWindows
 			insertAt(params);
 		}
 
-		bool WindowsViewLayoutDelegate::get_visible() const TITANIUM_NOEXCEPT
-		{
-			return getComponent()->Visibility == Visibility::Visible;
-		}
-
 		void WindowsViewLayoutDelegate::set_visible(const bool& visible) TITANIUM_NOEXCEPT
 		{
 			Titanium::UI::ViewLayoutDelegate::set_visible(visible);
 			getComponent()->Visibility = (visible ? Visibility::Visible : Visibility::Collapsed);
+
+			// all visible schildren should be affected by parent visibility
+			for (const auto child : children__) {
+				const auto layout    = child->getViewLayoutDelegate<WindowsViewLayoutDelegate>();
+				const auto component = layout->getComponent();
+
+				// don't change visibility of hidden component.
+				// only "visible" children are affected by parent visibility
+				if (layout->get_visible()) {
+					getComponent()->Visibility = (visible ? Visibility::Visible : Visibility::Collapsed);
+				}
+
+			}
 		}
 
 		void WindowsViewLayoutDelegate::animate(const std::shared_ptr<Titanium::UI::Animation>& animation, JSObject& callback, const JSObject& this_object) TITANIUM_NOEXCEPT
@@ -1275,10 +1283,6 @@ namespace TitaniumWindows
 			}
 
 			if (is_panel__) {
-				for (auto child : panel->Children) {
-					child->Visibility = Visibility::Collapsed;
-				}
-
 				setWidth = true;
 				setHeight = true;
 			}
@@ -1303,12 +1307,6 @@ namespace TitaniumWindows
 
 			Canvas::SetLeft(component, rect.x);
 			Canvas::SetTop(component, rect.y);
-
-			if (is_panel__) {
-				for (auto child : panel->Children) {
-					child->Visibility = Visibility::Visible;
-				}
-			}
 
 			if (!is_scrollview__ && !std::isnan(component->Width) && !std::isnan(component->Height)) {
 				auto clipRect = ref new Media::RectangleGeometry();


### PR DESCRIPTION
Fix for [TIMOB-20569](https://jira.appcelerator.org/browse/TIMOB-20569)

## Test Code

### View.visible should just work

```javascript
var win = Titanium.UI.createWindow({backgroundColor:'green'});
var view = Titanium.UI.createView({
    backgroundColor: 'red',
    width: 200,
    height: 200
});
var view2 = Titanium.UI.createView({
    borderRadius: 10,
    backgroundColor: 'green',
    width: 150,
    height: 150
});
var label = Ti.UI.createLabel({
    text: 'TEST',
    backgroundColor: 'blue',
    visible: false /* hidden */
});
view2.add(label);

view.add(view2);
view.addEventListener('click', function () {
    label.visible = !label.visible;
})
win.add(view);
win.open();
```

### Visible child views should be shown/hidden along with parent view

```javascript
var win = Titanium.UI.createWindow({backgroundColor:'green'});
var view = Titanium.UI.createView({
    backgroundColor: 'red',
    width: 200,
    height: 200
});
var view2 = Titanium.UI.createView({
    borderRadius: 10,
    backgroundColor: 'green',
    width: 150,
    height: 150
});
var label = Ti.UI.createLabel({
    text: 'TEST',
    backgroundColor: 'blue',
    visible: true
});
view2.add(label);

view.add(view2);
view.addEventListener('click', function () {
    // label should be hidden/visible along with view2
    view2.visible = !view2.visible;
})
win.add(view);
win.open();
```
### Hidden child views should not be shown along with parent view

```javascript
var win = Titanium.UI.createWindow({backgroundColor:'green'});
var view = Titanium.UI.createView({
    backgroundColor: 'red',
    width: 200,
    height: 200
});
var view2 = Titanium.UI.createView({
    borderRadius: 10,
    backgroundColor: 'green',
    width: 150,
    height: 150
});
var label = Ti.UI.createLabel({
    text: 'TEST',
    backgroundColor: 'blue',
    visible: false /* hidden */
});
view2.add(label);

view.add(view2);
view.addEventListener('click', function () {
    // label should not be shown along with view2
    view2.visible = !view2.visible;
})
win.add(view);
win.open();
```

### Hidden View should hide its child view

```javascript
var win = Titanium.UI.createWindow({backgroundColor:'green'});
var view = Titanium.UI.createView({
    backgroundColor: 'red',
    width: 200,
    height: 200
});
var view2 = Titanium.UI.createView({
    borderRadius: 10,
    backgroundColor: 'green',
    width: 150,
    height: 150,
    visible: false /* hidden */
});
var label = Ti.UI.createLabel({
    text: 'TEST',
    backgroundColor: 'blue',
    visible: true /* label should not be visible when view2.visible=false */
});
view2.add(label);

view.add(view2);
view.addEventListener('click', function () {
    // label should be hidden/visible along with view2
    view2.visible = !view2.visible;
})
win.add(view);
win.open();
```