### PR TITLE
[TIMOB-20612] postlayout events not firing

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
@@ -458,6 +458,7 @@ namespace TitaniumWindows
 			virtual std::shared_ptr<Titanium::UI::View> rescueGetView(const JSObject& view) TITANIUM_NOEXCEPT override;
 			virtual void registerNativeUIWrapHook(const std::function<JSObject(const JSContext&, const JSObject&)>& requireCallback);
 			virtual void fireSimplePositionEvent(const std::string& event_name, Windows::UI::Xaml::FrameworkElement^ sender, Windows::Foundation::Point position);
+			virtual void firePostLayoutEvent();
 
 			static Windows::UI::Xaml::Media::ImageBrush^ CreateImageBrushFromPath(const std::string& path);
 			static Windows::UI::Xaml::Media::ImageBrush^ CreateImageBrushFromBitmapImage(Windows::UI::Xaml::Media::Imaging::BitmapImage^ image);

--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -59,7 +59,7 @@ namespace TitaniumWindows
 			delete layout_node__;
 		}
 
-			std::shared_ptr<Titanium::UI::View> WindowsViewLayoutDelegate::rescueGetView(const JSObject& view) TITANIUM_NOEXCEPT
+		std::shared_ptr<Titanium::UI::View> WindowsViewLayoutDelegate::rescueGetView(const JSObject& view) TITANIUM_NOEXCEPT
 		{
 			// If this is a native wrapper, we need to jump through a lot of hoops to basically unwrap and rewrap as a Ti.UI.View
 			auto context = view.get_context();
@@ -1350,15 +1350,22 @@ namespace TitaniumWindows
 					}
 				}
 
-				if (fire_event && postlayout_listening__) {
-				 	auto event_delegate = event_delegate__.lock();
-				 	if (event_delegate != nullptr) {
-						// Fire postlayout event
-						JSContext js_context = event_delegate->get_context();
-						JSObject  eventArgs = js_context.CreateObject();
-						eventArgs.SetProperty("source", event_delegate->get_object());
-						event_delegate->fireEvent("postlayout", eventArgs);
-					}
+				if (fire_event) {
+					firePostLayoutEvent();
+				}
+			}
+		}
+
+		void WindowsViewLayoutDelegate::firePostLayoutEvent()
+		{
+			if (postlayout_listening__) {
+				auto event_delegate = event_delegate__.lock();
+				if (event_delegate != nullptr) {
+					// Fire postlayout event
+					JSContext js_context = event_delegate->get_context();
+					JSObject  eventArgs = js_context.CreateObject();
+					eventArgs.SetProperty("source", event_delegate->get_object());
+					event_delegate->fireEvent("postlayout", eventArgs);
 				}
 			}
 		}
@@ -1408,7 +1415,10 @@ namespace TitaniumWindows
 
 			if (needsLayout) {
 				requestLayout(true);
+			} else if (isLoaded()) {
+				firePostLayoutEvent();
 			}
+
 		}
 
 


### PR DESCRIPTION
Fix for [TIMOB-20612](https://jira.appcelerator.org/browse/TIMOB-20612)

```javascript
var win = Titanium.UI.createWindow({backgroundColor:'green'});
var view = Titanium.UI.createView({
    backgroundColor: 'red',
    width: 200,
    height: 200
});
var view2 = Titanium.UI.createView({
    backgroundColor: 'green',
    width: '80%',
    height: '80%',
});
var view3 = Ti.UI.createView({
    backgroundColor: 'gray',
    width: '80%',
    height: '80%'
});

view2.add(view3);
view.add(view2);

view.addEventListener('postlayout', function () {
    Ti.API.info('view postlayout');
});
view.addEventListener('click', function () {
    view.width  = view.width  * 0.9;
    view.height = view.height * 0.9;
});
view2.addEventListener('postlayout', function () {
    Ti.API.info('view2 postlayout');
});
view3.addEventListener('postlayout', function () {
    Ti.API.info('view3 postlayout');
});

win.add(view);
win.open();
```