### PR TITLE
[TIMOB-20605] Fix: view.center not working

### DIFF
--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -830,6 +830,8 @@ namespace TitaniumWindows
 		void WindowsViewLayoutDelegate::set_center(const Titanium::UI::Point& center) TITANIUM_NOEXCEPT
 		{
 			Titanium::UI::ViewLayoutDelegate::set_center(center);
+			setLayoutProperty(Titanium::LayoutEngine::ValueName::CenterX, std::to_string(center.x));
+			setLayoutProperty(Titanium::LayoutEngine::ValueName::CenterY, std::to_string(center.y));
 		}
 
 		void WindowsViewLayoutDelegate::set_enabled(const bool& enabled) TITANIUM_NOEXCEPT


### PR DESCRIPTION
Fix for [TIMOB-20605](https://jira.appcelerator.org/browse/TIMOB-20605)

```javascript
var win = Titanium.UI.createWindow({ backgroundColor: 'green' });
var view = Titanium.UI.createView({
    backgroundColor: 'red',
    width: 200,
    height: 200
});
var view2 = Titanium.UI.createView({
    backgroundColor: 'green',
    width: '80%',
    height: '80%',
});
var view3 = Ti.UI.createView({
    backgroundColor: 'gray',
    width: '80%',
    height: '80%'
});

view2.add(view3);
view.add(view2);

win.addEventListener('click', function (e) {
    view.center = { x: e.x, y: e.y };
})

win.add(view);
win.open();
```