### PR TITLE
[TIMOB-18531] Use default publisher-guid when none is given on build

### DIFF
--- a/cli/commands/_build/config.js
+++ b/cli/commands/_build/config.js
@@ -62,6 +62,10 @@ function config(logger, config, cli) {
 		}
 	}
 
+	function shouldForceProduction(argv) {
+		return (argv['target'] === 'dist-phonestore' || argv['target'] === 'dist-winstore');
+	}
+
 	// we hook into the pre-validate event so that we can stop the build before
 	// prompting if we know the build is going to fail.
 	//
@@ -79,6 +83,11 @@ function config(logger, config, cli) {
 		assertIssue(this.windowsInfo.issues, 'WINDOWS_MSBUILD_ERROR');
 		assertIssue(this.windowsInfo.issues, 'WINDOWS_MSBUILD_TOO_OLD');
 
+		// force production build when you package the app
+		if (shouldForceProduction(cli.argv)) {
+			cli.argv['deploy-type'] = 'production';
+		}
+	
 		callback();
 	}.bind(this));
 

--- a/cli/commands/_build/config/winPublisherId.js
+++ b/cli/commands/_build/config/winPublisherId.js
@@ -18,9 +18,16 @@ module.exports = function configOptionWindowsPublisherID(order) {
 		callback(null, value);
 	}
 
+	function shouldPrompt(argv) {
+		// You need to check abbreviated form too here because they are not expanded yet
+		return (argv['T'] === 'dist-phonestore' || argv['target']      === 'dist-phonestore') ||
+		       (argv['T'] === 'dist-winstore'   || argv['target']      === 'dist-winstore') ||
+		       (argv['D'] === 'production'      || argv['deploy-type'] === 'production');
+	}
+
 	return {
 		abbr: 'I',
-		default: this.cli.argv['deploy-type'] !== 'production' ? '00000000-0000-1000-8000-000000000000' : this.config.get('windows.publisherId'),
+		default: !shouldPrompt(this.cli.argv) ? '00000000-0000-1000-8000-000000000000' : this.config.get('windows.publisherId'),
 		desc: __('your Windows publisher ID, obtained from %s', 'https://dev.windows.com/en-us/Account/Management'.cyan),
 		hint: __('id'),
 		order: order,
@@ -33,7 +40,7 @@ module.exports = function configOptionWindowsPublisherID(order) {
 		validate: validate,
 		required: true,
 		verifyIfRequired: function (callback) {
-			callback(this.cli.argv['deploy-type'] === 'production');
+			callback(shouldPrompt(this.cli.argv));
 		}.bind(this)
 	};
 };


### PR DESCRIPTION
Fix for [TIMOB-18531](https://jira.appcelerator.org/browse/TIMOB-18531)

Ti CLI should prompt to enter a guid when building for `dist-phonestore` or `dist-winstore` if `windows.publisherId` is not configured.

```
ti config -r windows.publisherId
appc run -p windows -T dist-phonestore
```

This also forces `production` build on every `dist-*` build even when `deploy-type` is given explicitly.
