### PR TITLE
[TIMOB-23115] ImageView.image doesn't handle Ti.File/Blob

### DIFF
--- a/Examples/NMocha/src/Assets/ti.ui.imageview.test.js
+++ b/Examples/NMocha/src/Assets/ti.ui.imageview.test.js
@@ -109,6 +109,108 @@ describe("Titanium.UI.ImageView", function () {
         imageView.image = 'ms-appdata:///local/TIMOB-20609.png';
     });
 
+    (isWindows() ? it : it.skip)("image (File)", function (finish) {
+        var fromFile = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, "Logo.png");
+
+        var imageView = Ti.UI.createImageView();
+        imageView.addEventListener('load', function() {
+            should(imageView.image).be.an.Object;
+            should(imageView.image).eql(fromFile);
+            finish();
+        });
+
+        imageView.image = fromFile;
+    });
+
+    (isWindows() ? it : it.skip)("image (Blob)", function (finish) {
+        var fromFile = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, "Logo.png"),
+            blob = fromFile.read();
+        var imageView = Ti.UI.createImageView();
+        imageView.addEventListener('load', function() {
+            should(imageView.image).be.an.Object;
+            should(imageView.toBlob()).eql(blob);
+            finish();
+        });
+
+        imageView.image = blob;
+    });
+
+    (isWindows() ? it : it.skip)("images", function (finish) {
+        this.timeout(6e4);
+        var win = Ti.UI.createWindow();
+        var imageView = Ti.UI.createImageView({
+            width: Ti.UI.FILL, height: Ti.UI.FILL
+        });
+        imageView.addEventListener('load', function() {
+            should(imageView.animating).be.false;
+            imageView.start();
+            setTimeout(function(){
+                should(imageView.animating).be.true;
+                win.close();
+                finish();
+            }, 3000);
+        });
+        win.addEventListener('open', function() {
+            imageView.images = [
+                'ms-appx:///Logo.png',
+                'ms-appx:///Logo.png',
+                'ms-appx:///Logo.png'
+            ];
+        });
+        win.add(imageView);
+        win.open();
+    });
+
+    (isWindows() ? it : it.skip)("images (File)", function (finish) {
+        this.timeout(6e4);
+        var win = Ti.UI.createWindow();
+        var imageView = Ti.UI.createImageView({
+            width: Ti.UI.FILL, height: Ti.UI.FILL
+        });
+
+        imageView.addEventListener('load', function() {
+            should(imageView.animating).be.false;
+            imageView.start();
+            setTimeout(function(){
+                should(imageView.animating).be.true;
+                win.close();
+                finish();
+            }, 3000);
+        });
+        win.addEventListener('open', function() {
+            var fromFile = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, "Logo.png");
+            imageView.images = [ fromFile, fromFile, fromFile ];
+        });
+
+        win.add(imageView);
+        win.open();
+    });
+
+    (isWindows() ? it : it.skip)("images (Blob)", function (finish) {
+        this.timeout(6e4);
+        var win = Ti.UI.createWindow();
+        var imageView = Ti.UI.createImageView({
+            width: Ti.UI.FILL, height: Ti.UI.FILL
+        });
+
+        imageView.addEventListener('load', function() {
+            should(imageView.animating).be.false;
+            imageView.start();
+            setTimeout(function(){
+                should(imageView.animating).be.true;
+                win.close();
+                finish();
+            }, 3000);
+        });
+        win.addEventListener('open', function() {
+            var fromFile = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, "Logo.png");
+            imageView.images = [ fromFile.read(), fromFile.read(), fromFile.read() ];
+        });
+
+        win.add(imageView);
+        win.open();
+    });
+
     // TIMOB-18684
     it("layoutWithSIZE_and_fixed", function (finish) {
         var win = Ti.UI.createWindow();

--- a/Examples/NMocha/src/Assets/ti.ui.imageview.test.js
+++ b/Examples/NMocha/src/Assets/ti.ui.imageview.test.js
@@ -141,14 +141,14 @@ describe("Titanium.UI.ImageView", function () {
         var imageView = Ti.UI.createImageView({
             width: Ti.UI.FILL, height: Ti.UI.FILL
         });
+        imageView.addEventListener('start', function(){
+            should(imageView.animating).be.true;
+            win.close();
+            finish();
+        });
         imageView.addEventListener('load', function() {
             should(imageView.animating).be.false;
             imageView.start();
-            setTimeout(function(){
-                should(imageView.animating).be.true;
-                win.close();
-                finish();
-            }, 3000);
         });
         win.addEventListener('open', function() {
             imageView.images = [
@@ -167,15 +167,14 @@ describe("Titanium.UI.ImageView", function () {
         var imageView = Ti.UI.createImageView({
             width: Ti.UI.FILL, height: Ti.UI.FILL
         });
-
+        imageView.addEventListener('start', function(){
+            should(imageView.animating).be.true;
+            win.close();
+            finish();
+        });
         imageView.addEventListener('load', function() {
             should(imageView.animating).be.false;
             imageView.start();
-            setTimeout(function(){
-                should(imageView.animating).be.true;
-                win.close();
-                finish();
-            }, 3000);
         });
         win.addEventListener('open', function() {
             var fromFile = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, "Logo.png");
@@ -193,14 +192,14 @@ describe("Titanium.UI.ImageView", function () {
             width: Ti.UI.FILL, height: Ti.UI.FILL
         });
 
+        imageView.addEventListener('start', function(){
+            should(imageView.animating).be.true;
+            win.close();
+            finish();
+        });
         imageView.addEventListener('load', function() {
             should(imageView.animating).be.false;
             imageView.start();
-            setTimeout(function(){
-                should(imageView.animating).be.true;
-                win.close();
-                finish();
-            }, 3000);
         });
         win.addEventListener('open', function() {
             var fromFile = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, "Logo.png");

--- a/Source/TitaniumKit/include/Titanium/UI/ImageView.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/ImageView.hpp
@@ -196,6 +196,8 @@ namespace Titanium
 			  Image to display, defined using a local filesystem path, a File object, a remote URL, or a Blob object containing image data. Blob and File objects are not supported on Mobile Web.
 			*/
 			TITANIUM_PROPERTY_IMPL_DEF(std::string, image);
+			TITANIUM_PROPERTY_IMPL_DEF(std::shared_ptr<Titanium::Blob>, imageAsBlob);
+			TITANIUM_PROPERTY_IMPL_DEF(std::shared_ptr<Titanium::Filesystem::File>, imageAsFile);
 
 			/*!
 			  @method
@@ -205,6 +207,8 @@ namespace Titanium
 			  @discussion Array of images to animate, defined using local filesystem paths, File objects, remote URLs (Android only), or Blob objects containing image data. Blob and File objects are not supported on Mobile Web.
 			*/
 			TITANIUM_PROPERTY_IMPL_DEF(std::vector<std::string>, images);
+			TITANIUM_PROPERTY_IMPL_DEF(std::vector<std::shared_ptr<Titanium::Blob>>, imagesAsBlob);
+			TITANIUM_PROPERTY_IMPL_DEF(std::vector<std::shared_ptr<Titanium::Filesystem::File>>, imagesAsFile);
 
 			/*!
 			  @method
@@ -330,7 +334,11 @@ namespace Titanium
 			bool enableZoomControls__;
 			bool hires__;
 			std::string image__;
+			std::shared_ptr<Titanium::Blob> imageAsBlob__;
+			std::shared_ptr<Titanium::Filesystem::File> imageAsFile__;
 			std::vector<std::string> images__;
+			std::vector<std::shared_ptr<Titanium::Blob>> imagesAsBlob__;
+			std::vector<std::shared_ptr<Titanium::Filesystem::File>> imagesAsFile__;
 			bool preventDefaultImage__;
 			uint32_t repeatCount__;
 			bool reverse__;

--- a/Source/TitaniumKit/src/UI/ImageView.cpp
+++ b/Source/TitaniumKit/src/UI/ImageView.cpp
@@ -53,7 +53,13 @@ namespace Titanium
 
 		std::shared_ptr<Titanium::Blob> ImageView::toBlob(JSValue callback) TITANIUM_NOEXCEPT
 		{
-			return toImage(callback, false);
+			if (imageAsBlob__) {
+				return imageAsBlob__;
+			} else if (imageAsFile__) {
+				return imageAsFile__->read();
+			} else {
+				return toImage(callback, false);
+			}
 		}
 
 		TITANIUM_PROPERTY_READ(ImageView, bool, animating)
@@ -79,7 +85,11 @@ namespace Titanium
 		TITANIUM_PROPERTY_READWRITE(ImageView, bool, enableZoomControls)
 		TITANIUM_PROPERTY_READWRITE(ImageView, bool, hires)
 		TITANIUM_PROPERTY_READWRITE(ImageView, std::string, image)
+		TITANIUM_PROPERTY_READWRITE(ImageView, std::shared_ptr<Titanium::Blob>, imageAsBlob)
+		TITANIUM_PROPERTY_READWRITE(ImageView, std::shared_ptr<Titanium::Filesystem::File>, imageAsFile)
 		TITANIUM_PROPERTY_READWRITE(ImageView, std::vector<std::string>, images)
+		TITANIUM_PROPERTY_READWRITE(ImageView, std::vector<std::shared_ptr<Titanium::Blob>>, imagesAsBlob)
+		TITANIUM_PROPERTY_READWRITE(ImageView, std::vector<std::shared_ptr<Titanium::Filesystem::File>>, imagesAsFile)
 		TITANIUM_PROPERTY_READ(ImageView, bool, paused)
 		TITANIUM_PROPERTY_READWRITE(ImageView, bool, preventDefaultImage)
 		TITANIUM_PROPERTY_READWRITE(ImageView, uint32_t, repeatCount)
@@ -256,22 +266,67 @@ namespace Titanium
 
 		TITANIUM_PROPERTY_GETTER(ImageView, image)
 		{
-			return get_context().CreateString(get_image());
+			const auto image = get_image();
+			if (!image.empty()) {
+				return get_context().CreateString(image);
+			}
+			const auto blob = get_imageAsBlob();
+			if (blob) {
+				return blob->get_object();
+			}
+			const auto file = get_imageAsFile();
+			if (file) {
+				return file->get_object();
+			}
+			return get_context().CreateNull();
 		}
 
 		TITANIUM_PROPERTY_SETTER(ImageView, image)
 		{
-			set_image(static_cast<std::string>(argument));
+			if (argument.IsObject()) {
+				auto obj = static_cast<JSObject>(argument);
+				auto blob = obj.GetPrivate<Titanium::Blob>();
+				if (blob) {
+					set_imageAsBlob(blob);
+					return true;
+				}
+				auto file = obj.GetPrivate<Titanium::Filesystem::File>();
+				if (file) {
+					set_imageAsFile(file);
+					return true;
+				}
+				TITANIUM_LOG_WARN("ImageView.image only accepts String, Blob or File");
+			} else {
+				set_image(static_cast<std::string>(argument));
+			}
 			return true;
 		}
 
 		TITANIUM_PROPERTY_GETTER(ImageView, images)
 		{
+			const auto ctx = get_context();
+			const auto blobs = get_imagesAsBlob();
+			if (blobs.size() > 0) {
+				std::vector<JSValue> images;
+				for (auto blob : blobs) {
+					images.push_back(blob->get_object());
+				}
+				return ctx.CreateArray(images);
+			}
+			const auto files = get_imagesAsFile();
+			if (files.size() > 0) {
+				std::vector<JSValue> images;
+				for (auto file : files) {
+					images.push_back(file->get_object());
+				}
+				return ctx.CreateArray(images);
+			}
+
 			std::vector<JSValue> images;
 			for (auto image : get_images()) {
-				images.push_back(get_context().CreateString(image));
+				images.push_back(ctx.CreateString(image));
 			}
-			return get_context().CreateArray(images);
+			return ctx.CreateArray(images);
 		}
 
 		TITANIUM_PROPERTY_SETTER(ImageView, images)
@@ -281,14 +336,39 @@ namespace Titanium
 			TITANIUM_ASSERT(object.IsArray());
 			
 			std::vector<std::string> images;
+			std::vector<std::shared_ptr<Titanium::Blob>> imagesAsBlob;
+			std::vector<std::shared_ptr<Titanium::Filesystem::File>> imagesAsFile;
 
+			auto useBlob = false;
+			auto useFile = false;
 			const auto item_count = object.GetPropertyNames().GetCount();
 			for (uint32_t i = 0; i < item_count; ++i) {
 				JSValue item = object.GetProperty(i);
-				images.push_back(static_cast<std::string>(item));
+				if (item.IsObject()) {
+					auto itemObj = static_cast<JSObject>(item);
+					auto blob = itemObj.GetPrivate<Titanium::Blob>();
+					auto file = itemObj.GetPrivate<Titanium::Filesystem::File>();
+					if (blob) {
+						useBlob = true;
+						imagesAsBlob.push_back(blob);
+					} else if (file) {
+						useFile = true;
+						imagesAsFile.push_back(file);
+					} else {
+						TITANIUM_LOG_WARN("ImageView.images only accepts String, Blob or File");
+					}
+				} else {
+					images.push_back(static_cast<std::string>(item));
+				}
 			}
 
-			set_images(images);
+			if (useBlob) {
+				set_imagesAsBlob(imagesAsBlob);
+			} else if (useFile) {
+				set_imagesAsFile(imagesAsFile);
+			} else {
+				set_images(images);
+			}
 
 			return true;
 		}

--- a/Source/UI/include/TitaniumWindows/UI/ImageView.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/ImageView.hpp
@@ -12,12 +12,14 @@
 #include "TitaniumWindows_UI_EXPORT.h"
 #include "Titanium/UI/ImageView.hpp"
 #include "TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp"
+#include <collection.h>
 
 namespace TitaniumWindows
 {
 	namespace UI
 	{
 		using namespace HAL;
+		using SetBitmapImageCallback_t = std::function<void(Windows::UI::Xaml::Media::Imaging::BitmapImage^)> ;
 
 		class TITANIUMWINDOWS_UI_EXPORT WindowsImageViewLayoutDelegate : public WindowsViewLayoutDelegate {
 		public:
@@ -79,17 +81,38 @@ namespace TitaniumWindows
 
 			// properties
 			virtual void set_image(const std::string& image) TITANIUM_NOEXCEPT override final;
+			virtual void set_imageAsBlob(const std::shared_ptr<Titanium::Blob>& image) TITANIUM_NOEXCEPT override final;
+			virtual void set_imageAsFile(const std::shared_ptr<Titanium::Filesystem::File>& image) TITANIUM_NOEXCEPT override final;
+			virtual void set_images(const std::vector<std::string>&) TITANIUM_NOEXCEPT override final;
+			virtual void set_imagesAsBlob(const std::vector<std::shared_ptr<Titanium::Blob>>&) TITANIUM_NOEXCEPT override final;
+			virtual void set_imagesAsFile(const std::vector<std::shared_ptr<Titanium::Filesystem::File>>&) TITANIUM_NOEXCEPT override final;
 			virtual void set_defaultImage(const std::string&) TITANIUM_NOEXCEPT override final;
 		private:
 
+#pragma warning(push)
+#pragma warning(disable : 4251)
+
+			SetBitmapImageCallback_t set_image_fn__;
+
+			std::uint32_t bitmaps_loaded_count__{ 0 };
+			bool bitmaps_waiting__ { false };
+			bool bitmaps_loaded__ { false };
+			::Platform::Collections::Vector<Windows::UI::Xaml::Media::Imaging::BitmapImage^>^ bitmaps__;
+
 			bool prepareImageParams();
-			void loadContentFromData(std::vector<std::uint8_t>& data);
+			void loadBitmap(std::vector<std::uint8_t>& data, SetBitmapImageCallback_t);
+			void loadBitmap(const std::string& path,         SetBitmapImageCallback_t);
+			void loadBitmaps();
+
+			void set_image(Windows::UI::Xaml::Media::Imaging::BitmapImage^);
 
 			Windows::UI::Xaml::Controls::Border^ border__{ nullptr };
 			Windows::UI::Xaml::Controls::Image^ image__{ nullptr };
 			Windows::UI::Xaml::Media::Animation::Storyboard^ storyboard__;
 			bool propertiesSet__{ false };
 			bool sizeChanged__{ true };
+
+#pragma warning(pop)
 		};
 	} // namespace UI
 } // namespace TitaniumWindow


### PR DESCRIPTION
Fix for [TIMOB-23115](https://jira.appcelerator.org/browse/TIMOB-23115)

```javascript
var win = Ti.UI.createWindow({ backgroundColor: 'green' });

var file0 = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, "Logo.png");
var file1 = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, "SmallLogo.png");
var file2 = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, "StoreLogo.png");

var imageview = Ti.UI.createImageView({
    width: Ti.UI.FILL, height: Ti.UI.FILL,
    duration: 1000
});
var url0 = "http://api.randomuser.me/portraits/women/0.jpg",
    url1 = "http://api.randomuser.me/portraits/women/1.jpg",
    url2 = "http://api.randomuser.me/portraits/women/2.jpg";

imageview.images = [ file0, file1, file2 ]; // File
// imageview.images = [ file0.read(), file1.read(), file2.read() ]; // Blob
// imageview.images = [url0, url1, url2]; // URL

win.addEventListener('open', function () {
    imageview.start();
});
win.add(imageview);
win.open();
```