### PR TITLE
[TIMOB-19988] Implement Titanium.View.toImage()

### DIFF
--- a/Source/TitaniumKit/include/Titanium/UI/ImageView.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/ImageView.hpp
@@ -99,7 +99,7 @@ namespace Titanium
 
 			  @result Titanium.Blob
 			*/
-			virtual std::shared_ptr<Titanium::Blob> toBlob(JSValue callback) TITANIUM_NOEXCEPT;
+			virtual std::shared_ptr<Titanium::Blob> toBlob(JSObject& callback) TITANIUM_NOEXCEPT;
 
 			/*!
 			  @method

--- a/Source/TitaniumKit/include/Titanium/UI/View.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/View.hpp
@@ -99,7 +99,7 @@ namespace Titanium
 			  @abstract toImage
 			  @discussion Returns an image of the rendered view, as a Blob.
 			*/
-			virtual std::shared_ptr<Titanium::Blob> toImage(JSValue callback, const bool& honorScaleFactor) TITANIUM_NOEXCEPT;
+			virtual std::shared_ptr<Titanium::Blob> toImage(JSObject& callback, const bool& honorScaleFactor) TITANIUM_NOEXCEPT;
 
 			/*!
 			  @method

--- a/Source/TitaniumKit/include/Titanium/UI/ViewLayoutDelegate.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/ViewLayoutDelegate.hpp
@@ -18,6 +18,7 @@
 #include "Titanium/UI/2DMatrix.hpp"
 #include "Titanium/UI/3DMatrix.hpp"
 #include "Titanium/UI/ViewInsertOrReplaceParams.hpp"
+#include "Titanium/Blob.hpp"
 
 namespace Titanium
 {
@@ -66,6 +67,15 @@ namespace Titanium
 			virtual void replaceAt(const ViewInsertOrReplaceParams& params) TITANIUM_NOEXCEPT;
 
 			virtual void animate(const std::shared_ptr<Titanium::UI::Animation>& animation, JSObject& callback, const JSObject& this_object) TITANIUM_NOEXCEPT;
+
+			/*!
+			  @method
+
+			  @abstract toImage
+
+			  @discussion Returns an image of the rendered view, as a Blob.
+			*/
+			virtual std::shared_ptr<Titanium::Blob> toImage(JSObject& callback, const bool& honorScaleFactor, const JSObject& this_object) TITANIUM_NOEXCEPT;
 
 			/*!
 			  @method

--- a/Source/TitaniumKit/src/UI/ImageView.cpp
+++ b/Source/TitaniumKit/src/UI/ImageView.cpp
@@ -51,7 +51,7 @@ namespace Titanium
 			TITANIUM_LOG_DEBUG("ImageView::resume unimplemented");
 		}
 
-		std::shared_ptr<Titanium::Blob> ImageView::toBlob(JSValue callback) TITANIUM_NOEXCEPT
+		std::shared_ptr<Titanium::Blob> ImageView::toBlob(JSObject& callback) TITANIUM_NOEXCEPT
 		{
 			return toImage(callback, false);
 		}

--- a/Source/TitaniumKit/src/UI/View.cpp
+++ b/Source/TitaniumKit/src/UI/View.cpp
@@ -48,10 +48,9 @@ namespace Titanium
 		TITANIUM_PROPERTY_READWRITE(View, bool, focusable)
 		TITANIUM_PROPERTY_READWRITE(View, bool, keepScreenOn)
 
-		std::shared_ptr<Titanium::Blob> View::toImage(JSValue callback, const bool& honorScaleFactor) TITANIUM_NOEXCEPT
+		std::shared_ptr<Titanium::Blob> View::toImage(JSObject& callback, const bool& honorScaleFactor) TITANIUM_NOEXCEPT
 		{
-			// TODO IMPLEMENT
-			return nullptr;
+			return layoutDelegate__->toImage(callback, honorScaleFactor, get_object());
 		}
 
 		Point View::convertPointToView(Point point, std::shared_ptr<View> destinationView) TITANIUM_NOEXCEPT

--- a/Source/TitaniumKit/src/UI/ViewLayoutDelegate.cpp
+++ b/Source/TitaniumKit/src/UI/ViewLayoutDelegate.cpp
@@ -68,6 +68,12 @@ namespace Titanium
 			TITANIUM_LOG_WARN("ViewLayoutDelegate::animate: Unimplemented");
 		}
 
+		std::shared_ptr<Titanium::Blob> ViewLayoutDelegate::toImage(JSObject& callback, const bool& honorScaleFactor, const JSObject& this_object) TITANIUM_NOEXCEPT
+		{
+			TITANIUM_LOG_WARN("ViewLayoutDelegate::toImage: Unimplemented");
+			return nullptr;
+		}
+
 		void ViewLayoutDelegate::hide() TITANIUM_NOEXCEPT
 		{
 			set_visible(false);

--- a/Source/UI/include/TitaniumWindows/UI/ImageView.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/ImageView.hpp
@@ -75,7 +75,7 @@ namespace TitaniumWindows
 			virtual void resume() TITANIUM_NOEXCEPT override final;
 			virtual void start() TITANIUM_NOEXCEPT override final;
 			virtual void stop() TITANIUM_NOEXCEPT override final;
-			virtual std::shared_ptr<Titanium::Blob> toImage(JSValue callback, const bool& honorScaleFactor) TITANIUM_NOEXCEPT override;
+			virtual std::shared_ptr<Titanium::Blob> toImage(JSObject& callback, const bool& honorScaleFactor) TITANIUM_NOEXCEPT override;
 
 			// properties
 			virtual void set_image(const std::string& image) TITANIUM_NOEXCEPT override final;

--- a/Source/UI/include/TitaniumWindows/UI/View.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/View.hpp
@@ -72,10 +72,8 @@ namespace TitaniumWindows
 
 			static void JSExportInitialize();
 			static Windows::UI::Xaml::Media::FontFamily^ LookupFont(const JSContext& js_context, const std::string& family);
-			static void ToImage(Windows::UI::Xaml::FrameworkElement^, JSValue, JSObject);
 
 			virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;
-			virtual std::shared_ptr<Titanium::Blob> toImage(JSValue callback, const bool& honorScaleFactor) TITANIUM_NOEXCEPT override;
 
 			virtual void registerNativeUIWrapHook(const std::function<JSObject(const JSContext&, const JSObject&)>& requireCallback);
 			virtual Windows::UI::Xaml::FrameworkElement^ getComponent() TITANIUM_NOEXCEPT;

--- a/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
@@ -47,6 +47,9 @@ namespace TitaniumWindows
 
 			virtual void animate(const std::shared_ptr<Titanium::UI::Animation>& animation, JSObject& callback, const JSObject& this_object) TITANIUM_NOEXCEPT override;
 
+			virtual void ToImage(Windows::UI::Xaml::FrameworkElement^ component, JSObject& callback, const JSObject& this_object);
+			virtual std::shared_ptr<Titanium::Blob> toImage(JSObject& callback, const bool& honorScaleFactor, const JSObject& this_object) TITANIUM_NOEXCEPT override;
+
 			/*!
 			@method
 

--- a/Source/UI/src/ImageView.cpp
+++ b/Source/UI/src/ImageView.cpp
@@ -308,15 +308,9 @@ namespace TitaniumWindows
 			image__->Source = ref new BitmapImage(TitaniumWindows::Utility::GetUriFromPath(path));
 		}
 
-		std::shared_ptr<Titanium::Blob> ImageView::toImage(JSValue callback, const bool& honorScaleFactor) TITANIUM_NOEXCEPT
+		std::shared_ptr<Titanium::Blob> ImageView::toImage(JSObject& callback, const bool& honorScaleFactor) TITANIUM_NOEXCEPT
 		{
-			if (callback.IsObject() && static_cast<JSObject>(callback).IsFunction()) {
-				TitaniumWindows::UI::View::ToImage(image__, callback, get_object());
-			} else {
-				HAL::detail::ThrowRuntimeError("ImageView.toImage", "ImageView.toImage only works with callback");
-			}
-
-			return nullptr;
+			return getViewLayoutDelegate()->toImage(callback, honorScaleFactor, get_object());
 		}
 	} // namespace UI
 } // namespace TitaniumWindows

--- a/Source/UI/src/View.cpp
+++ b/Source/UI/src/View.cpp
@@ -102,36 +102,6 @@ namespace TitaniumWindows
 			return ref new Windows::UI::Xaml::Media::FontFamily(Utility::ConvertUTF8String(path));
 		}
 
-		void View::ToImage(Windows::UI::Xaml::FrameworkElement^ component, JSValue callback, JSObject this_object)
-		{
-			const auto render = ref new Windows::UI::Core::DispatchedHandler([component, callback, this_object]() {
-				auto renderTarget = ref new Windows::UI::Xaml::Media::Imaging::RenderTargetBitmap();
-				concurrency::create_task(renderTarget->RenderAsync(component)).then([renderTarget](){
-					return renderTarget->GetPixelsAsync();
-				}).then([callback, this_object](concurrency::task<Windows::Storage::Streams::IBuffer^> task){
-					try {
-						const auto buffer = task.get();
-						const auto data = TitaniumWindows::Utility::GetContentFromBuffer(buffer);
-						if (callback.IsObject()) {
-							auto func = static_cast<JSObject>(callback);
-							if (func.IsFunction()) {
-								const auto blob = callback.get_context().CreateObject(JSExport<Titanium::Blob>::Class()).CallAsConstructor();
-								const auto blob_ptr = blob.GetPrivate<Titanium::Blob>();
-								blob_ptr->construct(data);
-
-								const std::vector<JSValue> args = { blob };
-								func(args, this_object);
-							}
-						}
-					} catch (Platform::COMException^ e) {
-						TITANIUM_LOG_WARN("ImageView.toImage: ", TitaniumWindows::Utility::ConvertString(e->Message));
-					}
-				});
-			});
-
-			Windows::UI::Xaml::Window::Current->Dispatcher->RunAsync(Windows::UI::Core::CoreDispatcherPriority::Normal, render);
-		}
-
 		void View::registerNativeUIWrapHook(const std::function<JSObject(const JSContext&, const JSObject&)>& requireHook)
 		{
 			//
@@ -145,17 +115,6 @@ namespace TitaniumWindows
 		Windows::UI::Xaml::FrameworkElement^ View::getComponent() TITANIUM_NOEXCEPT
 		{
 			return getViewLayoutDelegate<WindowsViewLayoutDelegate>()->getComponent();
-		}
-
-		std::shared_ptr<Titanium::Blob> View::toImage(JSValue callback, const bool& honorScaleFactor) TITANIUM_NOEXCEPT
-		{
-			if (callback.IsObject() && static_cast<JSObject>(callback).IsFunction()) {
-				TitaniumWindows::UI::View::ToImage(getComponent(), callback, get_object());
-			} else {
-				HAL::detail::ThrowRuntimeError("View.toImage", "View.toImage only works with callback");
-			}
-
-			return nullptr;
 		}
 	} // namespace UI
 } // namespace TitaniumWindows

--- a/Source/Utility/include/TitaniumWindows/Utility.hpp
+++ b/Source/Utility/include/TitaniumWindows/Utility.hpp
@@ -88,6 +88,11 @@ namespace TitaniumWindows
 		TITANIUMWINDOWS_UTILITY_EXPORT std::string HexString(unsigned char* data, size_t length);
 
 		//
+		// Get Platform::Array from IBuffer
+		//
+		TITANIUMWINDOWS_UTILITY_EXPORT::Platform::Array<std::uint8_t, 1U>^ GetArrayFromBuffer(Windows::Storage::Streams::IBuffer^ buffer);
+
+		//
 		// Get binary content from IBuffer
 		//
 		TITANIUMWINDOWS_UTILITY_EXPORT std::vector<std::uint8_t> GetContentFromBuffer(Windows::Storage::Streams::IBuffer^ buffer);

--- a/Source/Utility/src/Utility.cpp
+++ b/Source/Utility/src/Utility.cpp
@@ -106,6 +106,13 @@ namespace TitaniumWindows
 			return ss.str();
 		}
 
+		::Platform::Array<std::uint8_t, 1U>^ GetArrayFromBuffer(Windows::Storage::Streams::IBuffer^ buffer)
+		{
+			::Platform::Array<std::uint8_t, 1U>^ array = ref new ::Platform::Array<std::uint8_t, 1U>(buffer->Length);
+			Windows::Security::Cryptography::CryptographicBuffer::CopyToByteArray(buffer, &array);
+			return array;
+		}
+
 		std::vector<std::uint8_t> GetContentFromBuffer(Windows::Storage::Streams::IBuffer^ buffer) 
 		{
 			if (buffer == nullptr) {


### PR DESCRIPTION
- Implement ``Titanium.View.toImage()`` into ``ViewLayoutDelegate``
- Fixed use of ``JSValue`` for callbacks
- Fixed ``Titanium.ImageView.toBlob()``
- Fixed ``Titanium.ImageView.toImage()``

##### NOTE: This test case requires https://github.com/appcelerator/titanium_mobile_windows/pull/598

###### TEST CASE
```Javascript
var win = Ti.UI.createWindow({backgroundColor: 'red'}),
	lbl = Ti.UI.createLabel({text: 'TEST TEXT'});
	img = Ti.UI.createImageView({width: '80%', height: '80%'});

win.toImage(function(image) {
	img.image = image;
	win.backgroundColor = 'blue';
});
win.add(lbl);
win.add(img);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-19988)