### PR TITLE
[TIMOB-23127] HTTPClient.setRequestHeader should be case-insensitive

### DIFF
--- a/Examples/NMocha/src/Assets/ti.network.httpclient.test.js
+++ b/Examples/NMocha/src/Assets/ti.network.httpclient.test.js
@@ -67,6 +67,21 @@ describe("Titanium.Network.HTTPClient", function () {
         xhr.send();
     });
 
+    it("TIMOB-23127", function (finish) {
+        this.timeout(6e4);
+
+        var xhr = Ti.Network.createHTTPClient();
+        xhr.setTimeout(6e4);
+
+        xhr.onload = function (e) {
+            finish();
+        };
+
+        xhr.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
+        xhr.open("POST", "http://www.appcelerator.com/");
+        xhr.send("TIMOB-23127");
+    });
+
     it("TIMOB-19042", function (finish) {
         this.timeout(6e4);
 

--- a/Source/Network/include/TitaniumWindows/Network/HTTPClient.hpp
+++ b/Source/Network/include/TitaniumWindows/Network/HTTPClient.hpp
@@ -11,6 +11,7 @@
 #include "Titanium/Network/HTTPClient.hpp"
 #include <ppltasks.h>
 #include <Robuffer.h>
+#include <boost/algorithm/string.hpp>
 
 using namespace Concurrency;
 
@@ -86,8 +87,14 @@ namespace TitaniumWindows
 			// contentLength__ - the value in the Content-Length attribute of the response header
 			// If no length is returned the server has returned the data using chunked encoding
 			long contentLength__ { 0 }; // -1 if response is using chunked encoding
-			// requestHeaders__ - the collection of key value pairs to be sent to the server
-			std::map<const std::string, std::string> requestHeaders__;
+
+			struct lexicographicalComparator : public std::binary_function<std::string, std::string, bool> {
+				bool operator()(const std::string &lhs, const std::string &rhs) const {
+					return boost::algorithm::lexicographical_compare(lhs, rhs, boost::algorithm::is_iless());
+				}
+			};
+			// requestHeaders__ - the case-insensitive collection of key value pairs to be sent to the server
+			std::map<const std::string, std::string, lexicographicalComparator> requestHeaders__;
 
 			bool disposed__ { false };
 #pragma warning(pop)


### PR DESCRIPTION
Fix for [TIMOB-23127](https://jira.appcelerator.org/browse/TIMOB-23127)

```javascript
var win = Ti.UI.createWindow({backgroundColor:'green'});

win.addEventListener('open', function() {
    var http = Ti.Network.createHTTPClient({
        onload: function() {
            Ti.API.info('API: step onload');
            var res = JSON.parse(this.responseText);
        },
        onerror: function(error) {
            Ti.API.info('API: step onerror');
			
        },
        timeout: 90000
    });
	
    http.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
    http.open('POST', 'http://www.appcelerator.com/');
	
    http.send('TIMOB-23127');
});
win.open();
```