### PR TITLE
Fix Picker runtime error

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/PickerColumn.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/PickerColumn.hpp
@@ -44,6 +44,8 @@ namespace TitaniumWindows
 			static void JSExportInitialize();
 			virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;
 
+			virtual void addRow(const std::shared_ptr<Titanium::UI::PickerRow>& row) TITANIUM_NOEXCEPT override;
+
 			Windows::UI::Xaml::Controls::ComboBox^ getComponent() const TITANIUM_NOEXCEPT
 			{
 				return picker__;

--- a/Source/UI/src/Picker.cpp
+++ b/Source/UI/src/Picker.cpp
@@ -44,7 +44,7 @@ namespace TitaniumWindows
 			layoutDelegate__->set_defaultWidth(Titanium::UI::LAYOUT::FILL);
 			layoutDelegate__->set_autoLayoutForWidth(Titanium::UI::LAYOUT::FILL);
 
-			getViewLayoutDelegate<WindowsViewLayoutDelegate>()->setComponent(parent__);
+			getViewLayoutDelegate<WindowsViewLayoutDelegate>()->setComponent(parent__, nullptr, false);
 		}
 
 		void Picker::afterPropertiesSet() TITANIUM_NOEXCEPT

--- a/Source/UI/src/PickerColumn.cpp
+++ b/Source/UI/src/PickerColumn.cpp
@@ -38,7 +38,13 @@ namespace TitaniumWindows
 			resetPickerBinding();
 
 			Titanium::UI::PickerColumn::setLayoutDelegate<WindowsViewLayoutDelegate>();
-			getViewLayoutDelegate<WindowsViewLayoutDelegate>()->setComponent(picker__);
+			getViewLayoutDelegate<WindowsViewLayoutDelegate>()->setComponent(picker__, nullptr, false);
+		}
+
+		void PickerColumn::addRow(const std::shared_ptr<Titanium::UI::PickerRow>& row) TITANIUM_NOEXCEPT
+		{
+			Titanium::UI::PickerColumn::addRow(row);
+			refreshRows();
 		}
 
 		void PickerColumn::refreshRows() 

--- a/Source/UI/src/PickerRow.cpp
+++ b/Source/UI/src/PickerRow.cpp
@@ -33,7 +33,7 @@ namespace TitaniumWindows
 			Titanium::UI::PickerRow::postCallAsConstructor(js_context, arguments);
 			label__ = ref new Windows::UI::Xaml::Controls::TextBlock();
 			Titanium::UI::PickerRow::setLayoutDelegate<WindowsViewLayoutDelegate>();
-			getViewLayoutDelegate<WindowsViewLayoutDelegate>()->setComponent(label__);
+			getViewLayoutDelegate<WindowsViewLayoutDelegate>()->setComponent(label__, nullptr, false);
 		}
 
 		void PickerRow::set_color(const std::string& colorName) TITANIUM_NOEXCEPT


### PR DESCRIPTION
Small RP to fix runtime error on plain picker. Note that this does not fix rendering issue on Windows Phone 8.1.

```javascript
var win = Ti.UI.createWindow({
    layout: 'vertical'
});

var picker = Ti.UI.createPicker({
    backgroundColor:'blue',
    top: 50, height: '20%'
});

var fruit = ['Bananas', 'Strawberries', 'Mangos', 'Grapes'];
var color = ['red', 'green', 'blue', 'orange'];

var column1 = Ti.UI.createPickerColumn();

for (var i = 0, ilen = fruit.length; i < ilen; i++) {
    var row = Ti.UI.createPickerRow({
        title: fruit[i]
    });
    column1.addRow(row);
}

var column2 = Ti.UI.createPickerColumn();

for (var i = 0, ilen = color.length; i < ilen; i++) {
    var row = Ti.UI.createPickerRow({ title: color[i] });
    column2.addRow(row);
}

picker.add([column1, column2]);

picker.addEventListener('change', function (e) {
    Ti.API.info("User selected: " + JSON.stringify(e.selectedValue));
});

win.add(picker);
win.open();
```