### PR TITLE
Use return value from Collection.IndexOf to check if it's found

### DIFF
--- a/Source/UI/src/ListView.cpp
+++ b/Source/UI/src/ListView.cpp
@@ -94,9 +94,9 @@ namespace TitaniumWindows
 					[this, ctx](Platform::Object^ sender, Controls::ItemClickEventArgs^ e) {
 					auto listview = safe_cast<Controls::ListView^>(sender);
 
-					uint32_t selectedIndex = -1;
-					listview->Items->IndexOf(e->ClickedItem, &selectedIndex);
-					if (selectedIndex == -1) return;
+					uint32_t selectedIndex;
+					const bool found = listview->Items->IndexOf(e->ClickedItem, &selectedIndex);
+					if (!found) return;
 
 					const auto result  = model__->searchRowBySelectedIndex(selectedIndex);
 					if (result.found) {

--- a/Source/UI/src/TabGroup.cpp
+++ b/Source/UI/src/TabGroup.cpp
@@ -67,9 +67,9 @@ namespace TitaniumWindows
 				[this](Platform::Object^ sender, Controls::ItemClickEventArgs^ e) {
 				const auto listview = safe_cast<Controls::ListView^>(sender);
 
-				uint32_t selectedIndex = -1;
-				listview->Items->IndexOf(e->ClickedItem, &selectedIndex);
-				if (selectedIndex == -1) return;
+				uint32_t selectedIndex;
+				const bool found = listview->Items->IndexOf(e->ClickedItem, &selectedIndex);
+				if (!found) return;
 
 				TITANIUM_LOG_WARN(tabs__.size() > selectedIndex);
 				set_activeTab(tabs__.at(selectedIndex));

--- a/Source/UI/src/TableView.cpp
+++ b/Source/UI/src/TableView.cpp
@@ -265,9 +265,9 @@ namespace TitaniumWindows
 
 					const auto listview = safe_cast<Controls::ListView^>(sender);
 
-					uint32_t selectedIndex = -1;
-					listview->Items->IndexOf(e->ClickedItem, &selectedIndex);
-					if (selectedIndex == -1) return;
+					uint32_t selectedIndex;
+					const auto found = listview->Items->IndexOf(e->ClickedItem, &selectedIndex);
+					if (!found) return;
 
 					const auto result = model__->searchRowBySelectedIndex(selectedIndex);
 

--- a/Source/Utility/src/Utility.cpp
+++ b/Source/Utility/src/Utility.cpp
@@ -315,9 +315,11 @@ namespace TitaniumWindows
 						const auto content = static_cast<Windows::UI::Xaml::Controls::Panel^>(page->Content);
 						if (content) {
 							std::uint32_t index;
-							content->Children->IndexOf(view, &index);
-							TITANIUM_ASSERT_AND_THROW(index >= 0, "Could not find view from current Window");
-							content->Children->RemoveAt(index);
+							if (content->Children->IndexOf(view, &index)) {
+								content->Children->RemoveAt(index);
+							} else {
+								TITANIUM_LOG_WARN("Could not find view from current Window");
+							}
 						}
 					}
 				}


### PR DESCRIPTION
Fix logical error.

The `boolean` return value from `UIElementCollection.IndexOf` should be used to check if element has been found. `index` parameter for `IndexOf` never be negative because it's unsigned int.