### PR TITLE
Add example method/propery in module template

### DIFF
--- a/templates/module/default/template/windows/include/{{moduleIdAsIdentifier}}.hpp.ejs
+++ b/templates/module/default/template/windows/include/{{moduleIdAsIdentifier}}.hpp.ejs
@@ -50,6 +50,9 @@ var MODULE_NAME = moduleIdAsIdentifier.toUpperCase();
 #endif
 
 <%- indent %>			static void JSExportInitialize();
+
+<%- indent %>			TITANIUM_PROPERTY_DEF(exampleProp);
+<%- indent %>			TITANIUM_FUNCTION_DEF(example);
 <%- indent %>	};
 <%  for(var i = namespaces.length-1; i > 0; i--) { -%>
 <%- 	Array(i).join('\t') %>}

--- a/templates/module/default/template/windows/src/{{moduleIdAsIdentifier}}.cpp.ejs
+++ b/templates/module/default/template/windows/src/{{moduleIdAsIdentifier}}.cpp.ejs
@@ -49,18 +49,59 @@
 <%- indent %>	TITANIUM_PROPERTY_GETTER(<%- className %>, exampleProp)
 <%- indent %>	{
 <%- indent %>		// example property getter
+<%- indent %>		// 
+<%- indent %>		// Getter should return JavaScript value (JSValue).
+<%- indent %>		// 
+<%- indent %>		// For more information on how to use JSContext / JSValue / JSObject, check out HAL:
+<%- indent %>		//      https://github.com/appcelerator/HAL
+<%- indent %>		// 
 <%- indent %>		return get_context().CreateString("hello world");
 <%- indent %>	}
 
 <%- indent %>	TITANIUM_PROPERTY_SETTER(<%- className %>, exampleProp)
 <%- indent %>	{
 <%- indent %>		// example property setter
-<%- indent %>		return true; // Return true if the property was set, otherwise false.
+<%- indent %>		// 
+<%- indent %>		// There are a variable expanded from TITANIUM_PROPERTY_SETTER macro here:
+<%- indent %>		//     JSValue argument ... JavaScript value that is passed to this setter
+<%- indent %>		// 
+<%- indent %>		// Example:
+<%- indent %>		//   # Check if it's a string
+<%- indent %>		//      auto _0 = argument.IsString();
+<%- indent %>		// 
+<%- indent %>		//   # Convert argument to std::string
+<%- indent %>		//      auto _0 = static_cast<std::string>(argument);    
+<%- indent %>		// 
+<%- indent %>		//   For more information on how to use JSContext / JSValue / JSObject, check out HAL:
+<%- indent %>		//      https://github.com/appcelerator/HAL
+<%- indent %>		// 
+<%- indent %>		// Setter should return true if the property was set, otherwise false.
+<%- indent %>   // 
+<%- indent %>		return true;
 <%- indent %>	}
 
 <%- indent %>	TITANIUM_FUNCTION(<%- className %>, example)
 <%- indent %>	{
 <%- indent %>		// example method
+<%- indent %>		// 
+<%- indent %>		// There are variables expanded from TITANIUM_FUNCTION macro here:
+<%- indent %>		//     std::vector<JSValue> arguments ... list of arguments that is passed to this function
+<%- indent %>		//     JSObject this_object           ... "this" JavaScript object
+<%- indent %>		// 
+<%- indent %>		// Example: 
+<%- indent %>		//    # Get first argument and convert to std::string
+<%- indent %>		//      auto _0 = static_cast<std::string>(arguments.at(0));    
+<%- indent %>		// 
+<%- indent %>		//    # Get first argument and convert to double
+<%- indent %>		//      auto _0 = static_cast<double>(arguments.at(0));    
+<%- indent %>		// 
+<%- indent %>		//    # Get first argument and convert to std::uint32_t
+<%- indent %>		//      auto _0 = static_cast<std::uint32_t>(arguments.at(0));    
+<%- indent %>		// 
+<%- indent %>		//   Function should return JSValue.
+<%- indent %>		//   For more information on how to use JSContext / JSValue / JSObject, check out HAL:
+<%- indent %>		//      https://github.com/appcelerator/HAL
+<%- indent %>		// 
 <%- indent %>		return get_context().CreateString("hello world");
 <%- indent %>	}
 

--- a/templates/module/default/template/windows/src/{{moduleIdAsIdentifier}}.cpp.ejs
+++ b/templates/module/default/template/windows/src/{{moduleIdAsIdentifier}}.cpp.ejs
@@ -42,7 +42,28 @@
 <%- indent %>	{
 <%- indent %>		JSExport<<%- className %>>::SetClassVersion(1);
 <%- indent %>		JSExport<<%- className %>>::SetParent(JSExport<JSExportObject>::Class());
+<%- indent %>		TITANIUM_ADD_PROPERTY(<%- className %>, exampleProp);
+<%- indent %>		TITANIUM_ADD_FUNCTION(<%- className %>, example);
 <%- indent %>	}
+
+<%- indent %>	TITANIUM_PROPERTY_GETTER(<%- className %>, exampleProp)
+<%- indent %>	{
+<%- indent %>		// example property getter
+<%- indent %>		return get_context().CreateString("hello world");
+<%- indent %>	}
+
+<%- indent %>	TITANIUM_PROPERTY_SETTER(<%- className %>, exampleProp)
+<%- indent %>	{
+<%- indent %>		// example property setter
+<%- indent %>		return true; // Return true if the property was set, otherwise false.
+<%- indent %>	}
+
+<%- indent %>	TITANIUM_FUNCTION(<%- className %>, example)
+<%- indent %>	{
+<%- indent %>		// example method
+<%- indent %>		return get_context().CreateString("hello world");
+<%- indent %>	}
+
 <%  for(var i = namespaces.length-1; i > 0; i--) { -%>
 <%- 	Array(i).join('\t') %>}
 <%  } -%>


### PR DESCRIPTION
Add example method and property for Windows module template to align with iOS/Android templates.

See also: [iOS Module Quick Start ](http://docs.appcelerator.com/platform/latest/#!/guide/iOS_Module_Quick_Start)

```javascript
var test = require('com.example.test');
Ti.API.info("module is => " + test);
Ti.API.info("module example() method returns => " + test.example());
Ti.API.info("module exampleProp is => " + test.exampleProp);
test.exampleProp = "This is a test value";
```