### PR TITLE
[TIMOB-20571] Use device or emulator wpsdk when possible

### DIFF
--- a/cli/commands/_build/config/deviceID.js
+++ b/cli/commands/_build/config/deviceID.js
@@ -43,6 +43,11 @@ module.exports = function configOptionDeviceID(order) {
 			return callback(new Error(__('Invalid device id "%s"', value)));
 		}
 
+		// use wpsdk specified for device
+		if (dev.wpsdk) {
+			cli.argv['wp-sdk'] = dev.wpsdk;
+		}
+
 		// check the device
 		if (cli.argv.target === 'wp-device') {
 			// try connecting to the device to detect no device or more than 1 device

--- a/cli/commands/_build/config/deviceID.js
+++ b/cli/commands/_build/config/deviceID.js
@@ -18,20 +18,22 @@ module.exports = function configOptionDeviceID(order) {
 			return callback(new Error(__('Invalid device id')));
 		}
 
-		var devices = this.getTargetDevices();
+		var devices = this.getTargetDevices(),
+			dev = null;
 
-		if (cli.argv.target === 'wp-emulator' && value === 'xd' && devices[0]) {
-			// pick first emulator
+		// xd: first emulator
+		// de: first device
+		if (cli.argv.target === 'wp-emulator' && value === 'xd' ||
+			cli.argv.target === 'wp-device' && value === 'de' && devices[0]) {
+			
+			// use wpsdk for device
+			if (devices[0].wpsdk) {
+				cli.argv['wp-sdk'] = devices[0].wpsdk;
+			}
 			return callback(null, devices[0].udid);
 		}
 
-		if (cli.argv.target === 'wp-device' && value === 'de' && devices[0]) {
-			// pick first device
-			return callback(null, devices[0].udid);
-		}
-
-		var dev;
-
+		// validate device
 		if (!devices.some(function (d) {
 				if (d.udid == value || d.name === value) {
 					dev = d;

--- a/cli/commands/_build/utils.js
+++ b/cli/commands/_build/utils.js
@@ -30,10 +30,20 @@ function getTargetDevices() {
 	}
 
 	var target = this.cli.argv.target,
-		wpsdk = this.cli.argv['wp-sdk'];
+		wpsdk = this.cli.argv['wp-sdk'],
+		wpsdkDefault = this.cli.argv['$_'].indexOf('-S') === -1 && this.cli.argv['$_'].indexOf('--wp-sdk') === -1;
 
-	if (target === 'wp-emulator' && this.windowsInfo.emulators && Array.isArray(this.windowsInfo.emulators[wpsdk])) {
-		return this.deviceCache = this.windowsInfo.emulators[wpsdk];
+	if (target === 'wp-emulator' && this.windowsInfo.emulators) {
+		Object.keys(this.windowsInfo.emulators).forEach(function (sdk) {
+			if (wpsdkDefault || sdk === wpsdk) {
+				if (this.deviceCache) {
+					this.deviceCache = this.windowsInfo.emulators[sdk].concat(this.deviceCache);
+				} else {
+					this.deviceCache = this.windowsInfo.emulators[sdk];
+				}
+			}
+		}, this);
+		return this.deviceCache;
 	} else if (target === 'wp-device' && Array.isArray(this.windowsInfo.devices)) {
 		return this.deviceCache = this.windowsInfo.devices;
 	}


### PR DESCRIPTION
- Use device specified ``wpsdk`` when possible
- List all emulators when both ``-S`` or ``--wp-sdk`` are unspecified

##### NOTE: This requires https://github.com/appcelerator/windowslib/pull/37

###### TEST CASE
```
appc new -t app -n TIMOB-20571 --id com.win.test --no-services
cd TIMOB-20571
appc run -p windows -T wp-emulator
appc run -p windows -T wp-device
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-20571)