### PR TITLE
[TIMOB-23192] Filter unsupported Windows SDK 8.0

### DIFF
--- a/cli/commands/_build/config/wpSDK.js
+++ b/cli/commands/_build/config/wpSDK.js
@@ -10,11 +10,14 @@ var appc = require('node-appc'),
  * @returns {Object}
  */
 module.exports = function configOptionWPSDK(order) {
-	var defaultTarget = '8.1';
+	var defaultTarget = '8.1',
+		sdkTargets = [],
+		unsupportedTargets = ['8.0'];
 
-	var sdkTargets = [];
 	for (var version in this.windowsInfo.windowsphone) {
-		sdkTargets.push(version);
+		if (unsupportedTargets.indexOf(version) === -1) {
+			sdkTargets.push(version);
+		}
 		if (this.windowsInfo.windowsphone[version].selected) {
 			defaultTarget = version;
 		}


### PR DESCRIPTION
- Add ability to filter unsupported Windows SDKs ``8.0``

###### TEST CASE
```
appc run -p windows --wp-sdk 8.0
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23192)