### PR TITLE
[5_3_X] Fix TIMOB-23217 Windows: Packaging for dist-winstore with 8.1 SDK fails - remove badge logo

### DIFF
--- a/templates/build/Package.store.appxmanifest.in.ejs
+++ b/templates/build/Package.store.appxmanifest.in.ejs
@@ -42,7 +42,6 @@
           Square150x150Logo="Logo.png"
           Square30x30Logo="SmallLogo.png"
           ToastCapable="true">
-        <m2:LockScreen Notification="badge" BadgeLogo="Square24x24Logo.png" />
         <m2:DefaultTile ShortName="ms-resource:app_name">
           <m2:ShowNameOnTiles>
             <m2:ShowOn Tile="square150x150Logo" />


### PR DESCRIPTION
This is an "experimental" fix. From https://social.msdn.microsoft.com/Forums/vstudio/en-US/f0339531-123d-4764-927d-8ed9251ce65a/why-do-i-have-to-specify-a-background-task?forum=csharpgeneral it appears if you set a badge logo, it thinks you have must intend to do notifications and must have a background service defined.

https://jira.appcelerator.org/browse/TIMOB-23217