### PR TITLE
[TIMOB-23222] Fix crash at Ti.Codec.decodeNumber

### DIFF
--- a/Source/Ti/src/Codec.cpp
+++ b/Source/Ti/src/Codec.cpp
@@ -107,8 +107,7 @@ namespace TitaniumWindows
 	{
 		using namespace Windows::Storage::Streams;
 
-		const auto data = options.source->get_data();
-		auto source_data = std::vector<std::uint8_t>(data.begin() + options.position, data.end());
+		auto source_data = options.source->get_data(options.position, 8 /* we only need 8 bytes at most */);
 
 		Platform::ArrayReference<std::uint8_t> data_ref(&source_data[0], source_data.size());
 		const auto buffer = CryptographicBuffer::CreateFromByteArray(data_ref);

--- a/Source/TitaniumKit/include/Titanium/Buffer.hpp
+++ b/Source/TitaniumKit/include/Titanium/Buffer.hpp
@@ -72,6 +72,13 @@ namespace Titanium
 		TITANIUM_PROPERTY_IMPL_DEF(std::vector<std::uint8_t>, data);
 
 		/*!
+		@method
+		@abstract get_data
+		@discussion Return data partical representation of this buffer
+		*/
+		virtual std::vector<std::uint8_t> get_data(const std::uint32_t& offset, const std::uint32_t& size) TITANIUM_NOEXCEPT;
+
+		/*!
 		  @method
 		  @abstract append
 		  @discussion Appends `sourceBuffer` to the this buffer.

--- a/Source/TitaniumKit/src/Buffer.cpp
+++ b/Source/TitaniumKit/src/Buffer.cpp
@@ -100,6 +100,11 @@ namespace Titanium
 		data__.resize(length, 0);
 	}
 
+	std::vector<std::uint8_t> Buffer::get_data(const std::uint32_t& offset, const std::uint32_t& size) TITANIUM_NOEXCEPT
+	{
+		return std::vector<std::uint8_t>(data__.begin() + offset, data__.begin() + std::min(offset + size, data__.size()));
+	}
+
 	std::uint32_t Buffer::append(const std::shared_ptr<Buffer>& sourceBuffer, const std::uint32_t& sourceOffset, const std::uint32_t& sourceLength) TITANIUM_NOEXCEPT
 	{
 		const auto source = sourceBuffer->get_data();

--- a/Source/TitaniumKit/src/Buffer.cpp
+++ b/Source/TitaniumKit/src/Buffer.cpp
@@ -102,7 +102,7 @@ namespace Titanium
 
 	std::vector<std::uint8_t> Buffer::get_data(const std::uint32_t& offset, const std::uint32_t& size) TITANIUM_NOEXCEPT
 	{
-		return std::vector<std::uint8_t>(data__.begin() + offset, data__.begin() + std::min(offset + size, data__.size()));
+		return std::vector<std::uint8_t>(data__.begin() + offset, data__.begin() + std::min(offset + size, static_cast<std::uint32_t>(data__.size())));
 	}
 
 	std::uint32_t Buffer::append(const std::shared_ptr<Buffer>& sourceBuffer, const std::uint32_t& sourceOffset, const std::uint32_t& sourceLength) TITANIUM_NOEXCEPT


### PR DESCRIPTION
Fix for [TIMOB-23222](https://jira.appcelerator.org/browse/TIMOB-23222)

```javascript
var win = Ti.UI.createWindow({backgroundColor:'blue'});
var file = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, "data.bin");

Ti.API.info('File meta:' + file.size);
var blob = file.read();
var length = blob.length;

// Convert Ti.Blob to Ti.Buffer
var stream = Ti.Stream.createStream({ source: blob, mode: Ti.Stream.MODE_READ });
var buffer = Ti.createBuffer({ length: length });
stream.read(buffer);
Ti.API.info("file loaded. size=" + buffer.length);

// Read and parse the data
var index = Ti.Codec.decodeNumber({ source: buffer, position: 0, type: Ti.Codec.TYPE_INT });

win.addEventListener('open', function () {
    Ti.API.info('Checkpoint');
    var myArray = [];
    for (var i = 0; i < 2048; i++) {
        myArray.push([
            Ti.Codec.decodeNumber({ source: buffer, position: 4 + i * 8 + 0, type: Ti.Codec.TYPE_INT }),
            Ti.Codec.decodeNumber({ source: buffer, position: 4 + i * 8 + 4, type: Ti.Codec.TYPE_INT })
        ]);
    };
    win.backgroundColor = 'green';
    Ti.API.info('Done');
});

win.open();
```