### PR TITLE
[TIMOB-23222] Fix crash at Ti.Codec.decodeNumber - variable length of bytes to read

### DIFF
--- a/Source/Ti/src/Codec.cpp
+++ b/Source/Ti/src/Codec.cpp
@@ -107,8 +107,7 @@ namespace TitaniumWindows
 	{
 		using namespace Windows::Storage::Streams;
 
-		const auto data = options.source->get_data();
-		auto source_data = std::vector<std::uint8_t>(data.begin() + options.position, data.end());
+		auto source_data = options.source->get_data(options.position, 8 /* we only need 8 bytes at most */);
 
 		Platform::ArrayReference<std::uint8_t> data_ref(&source_data[0], source_data.size());
 		const auto buffer = CryptographicBuffer::CreateFromByteArray(data_ref);

--- a/Source/Ti/src/Codec.cpp
+++ b/Source/Ti/src/Codec.cpp
@@ -107,15 +107,32 @@ namespace TitaniumWindows
 	{
 		using namespace Windows::Storage::Streams;
 
-		auto source_data = options.source->get_data(options.position, 8 /* we only need 8 bytes at most */);
+		auto length = 8;
+		switch (options.type) {
+		case Type::Byte:
+			length = 1;
+			break;
+		case Type::Short:
+			length = 2;
+			break;
+		case Type::Int:
+		case Type::Float:
+			length = 4;
+			break;
+		case Type::Double:
+		case Type::Long:
+			length = 8; // Do we always use 8 byte for long? Note that iOS-32bit uses 4 bytes for long.
+			break;
+		}
 
+		auto source_data = options.source->get_data(options.position, length);
 		Platform::ArrayReference<std::uint8_t> data_ref(&source_data[0], source_data.size());
 		const auto buffer = CryptographicBuffer::CreateFromByteArray(data_ref);
 		const auto reader = DataReader::FromBuffer(buffer);
-
 		reader->ByteOrder = GetWindowsByteOrder(options.byteOrder);
+
 		switch (options.type) {
-		case Type::Byte: 
+		case Type::Byte:
 			return static_cast<double>(reader->ReadByte());
 		case Type::Double:
 			return static_cast<double>(reader->ReadDouble());
@@ -126,7 +143,7 @@ namespace TitaniumWindows
 		case Type::Int:
 			return static_cast<double>(reader->ReadInt32());
 		case Type::Long:
-			return static_cast<double>(reader->ReadInt64()); // Do we always use 8 byte for long? Note that iOS-32bit uses 4 bytes for long.
+			return static_cast<double>(reader->ReadInt64());
 		}
 
 		return 0;
@@ -203,7 +220,7 @@ namespace TitaniumWindows
 		return TitaniumWindows::Utility::ConvertUTF8String(decoded);
 	}
 
-	BinaryStringEncoding Codec::GetWindowsEncoding(const Titanium::Codec::CharSet& charset, const ByteOrder& byteOrder) 
+	BinaryStringEncoding Codec::GetWindowsEncoding(const Titanium::Codec::CharSet& charset, const ByteOrder& byteOrder)
 	{
 		switch (charset) {
 		case CharSet::UTF8:
@@ -220,7 +237,7 @@ namespace TitaniumWindows
 		}
 	}
 
-	Windows::Storage::Streams::ByteOrder Codec::GetWindowsByteOrder(const ByteOrder& byteOrder) 
+	Windows::Storage::Streams::ByteOrder Codec::GetWindowsByteOrder(const ByteOrder& byteOrder)
 	{
 		return byteOrder == ByteOrder::BigEndian ? Windows::Storage::Streams::ByteOrder::BigEndian : Windows::Storage::Streams::ByteOrder::LittleEndian;
 	}

--- a/Source/TitaniumKit/include/Titanium/Buffer.hpp
+++ b/Source/TitaniumKit/include/Titanium/Buffer.hpp
@@ -72,6 +72,13 @@ namespace Titanium
 		TITANIUM_PROPERTY_IMPL_DEF(std::vector<std::uint8_t>, data);
 
 		/*!
+		@method
+		@abstract get_data
+		@discussion Return data partical representation of this buffer
+		*/
+		virtual std::vector<std::uint8_t> get_data(const std::uint32_t& offset, const std::uint32_t& size) TITANIUM_NOEXCEPT;
+
+		/*!
 		  @method
 		  @abstract append
 		  @discussion Appends `sourceBuffer` to the this buffer.

--- a/Source/TitaniumKit/src/Buffer.cpp
+++ b/Source/TitaniumKit/src/Buffer.cpp
@@ -100,6 +100,11 @@ namespace Titanium
 		data__.resize(length, 0);
 	}
 
+	std::vector<std::uint8_t> Buffer::get_data(const std::uint32_t& offset, const std::uint32_t& size) TITANIUM_NOEXCEPT
+	{
+		return std::vector<std::uint8_t>(data__.begin() + offset, data__.begin() + std::min(offset + size, static_cast<std::uint32_t>(data__.size())));
+	}
+
 	std::uint32_t Buffer::append(const std::shared_ptr<Buffer>& sourceBuffer, const std::uint32_t& sourceOffset, const std::uint32_t& sourceLength) TITANIUM_NOEXCEPT
 	{
 		const auto source = sourceBuffer->get_data();


### PR DESCRIPTION
Additional commit on top of #631 