### PR TITLE
Template: Module should extend Titanium::Module

### DIFF
--- a/templates/module/default/template/windows/include/{{moduleIdAsIdentifier}}.hpp.ejs
+++ b/templates/module/default/template/windows/include/{{moduleIdAsIdentifier}}.hpp.ejs
@@ -18,6 +18,7 @@ var MODULE_NAME = moduleIdAsIdentifier.toUpperCase();
 
 #include "<%- moduleIdAsIdentifier %>_EXPORT.h"
 #include "Titanium/detail/TiBase.hpp"
+#include "Titanium/Module.hpp"
 
 <%
   var namespaces = moduleId.split('.'),
@@ -34,7 +35,7 @@ var MODULE_NAME = moduleIdAsIdentifier.toUpperCase();
 -%>
 <%- indent %>	using namespace HAL;
 
-<%- indent %>	class <%- MODULE_NAME %>_EXPORT <%- className %> : public JSExportObject, public JSExport<<%- className %>>
+<%- indent %>	class <%- MODULE_NAME %>_EXPORT <%- className %> : public Titanium::Module, public JSExport<<%- className %>>
 <%- indent %>	{
 <%- indent %>		public:
 <%- indent %>			<%- className %>(const JSContext&) TITANIUM_NOEXCEPT;

--- a/templates/module/default/template/windows/src/{{moduleIdAsIdentifier}}.cpp.ejs
+++ b/templates/module/default/template/windows/src/{{moduleIdAsIdentifier}}.cpp.ejs
@@ -78,7 +78,7 @@ namespace <%- moduleIdAsIdentifier %>
   }
 -%>
 <%- indent %>	<%- className %>::<%- className %>(const JSContext& js_context) TITANIUM_NOEXCEPT
-<%- indent %>		: JSExportObject(js_context)
+<%- indent %>		: Titanium::Module(js_context, "<%- moduleId %>")
 <%- indent %>	{
 <%- indent %>		TITANIUM_LOG_DEBUG("<%- className %>::ctor Initialize");
 <%- indent %>	}
@@ -94,7 +94,7 @@ namespace <%- moduleIdAsIdentifier %>
 <%- indent %>	void <%- className %>::JSExportInitialize()
 <%- indent %>	{
 <%- indent %>		JSExport<<%- className %>>::SetClassVersion(1);
-<%- indent %>		JSExport<<%- className %>>::SetParent(JSExport<JSExportObject>::Class());
+<%- indent %>		JSExport<<%- className %>>::SetParent(JSExport<Titanium::Module>::Class());
 <%- indent %>		TITANIUM_ADD_PROPERTY(<%- className %>, exampleProp);
 <%- indent %>		TITANIUM_ADD_FUNCTION(<%- className %>, example);
 <%- indent %>	}


### PR DESCRIPTION
Update module template to support Ti event methods, to align with other platforms:

- Module should extend `Titanium::Module` to support event mechanics (`fireEvent`, `addEventListener` etc)
