### PR TITLE
[TIMOB-23251] Fix module build process for appc run

### DIFF
--- a/cli/commands/_buildModule.js
+++ b/cli/commands/_buildModule.js
@@ -51,7 +51,7 @@ WindowsModuleBuilder.prototype.run = function run(logger, config, cli, finished)
 
 	appc.async.series(this, [
 		function (next) {
-			cli.emit('build.pre.construct', this, next);
+			cli.emit('build.module.pre.construct', this, next);
 		},
 
 		'doAnalytics',
@@ -59,18 +59,17 @@ WindowsModuleBuilder.prototype.run = function run(logger, config, cli, finished)
 		'loginfo',
 
 		function (next) {
-			cli.emit('build.pre.compile', this, next);
+			cli.emit('build.module.pre.compile', this, next);
 		},
 
 		'compileModule',
 		'packageZip',
 
 		function (next) {
-			//TODO: FIX THIS
-			//cli.emit('build.post.compile', this, next);
+			cli.emit('build.module.post.compile', this, next);
 		}
 	], function (err) {
-		cli.emit('build.finalize', this, function () {
+		cli.emit('build.module.finalize', this, function () {
 			finished(err);
 		});
 	});


### PR DESCRIPTION
- Use correct build events for module build process

###### TEST CASE
```
appc new -t timodule -n module --id com.win.module
cd module\windows
appc run -p windows --build-only
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23251)