### PR TITLE
[TIMOB-23241] Logging macros for native module

### DIFF
--- a/Source/Ti/src/API.cpp
+++ b/Source/Ti/src/API.cpp
@@ -5,169 +5,36 @@
 * Licensed under the terms of the Apache Public License.
 * Please see the LICENSE included with this distribution for details.
 */
-#define _SCL_SECURE_NO_WARNINGS
-
-#include "Titanium/detail/TiLogger.hpp"
 #include "TitaniumWindows/API.hpp"
-#include "TitaniumWindows/Utility.hpp"
-
-#include <iostream>
-#include <boost/algorithm/string.hpp>
-#include <boost/property_tree/ptree.hpp>
-#include <boost/property_tree/ini_parser.hpp>
 
 namespace TitaniumWindows
 {
-
-	concurrency::unbounded_buffer <std::string> API::buffer__;
-	bool API::done__ { false };
-
-	void log_forwarder::run()
-	{
-		using namespace Windows::Storage;
-		using namespace concurrency;
-
-		Windows::Storage::Streams::DataWriter^ writer = nullptr;
-		auto tcp_socket = ref new Windows::Networking::Sockets::StreamSocket();
-		try {
-			concurrency::event read_event;
-			// Get a handle on titanium_settings.ini file
-			create_task(Windows::ApplicationModel::Package::Current->InstalledLocation->GetFileAsync("titanium_settings.ini"), task_continuation_context::use_arbitrary())
-			.then([](StorageFile^ file) { // don't wrap in task, so next continuation handles any exception from file not existing
-				return FileIO::ReadTextAsync(file);
-			}, task_continuation_context::use_arbitrary())
-			.then([&writer, &read_event, &tcp_socket](task<Platform::String^> task) {
-				Platform::String^ content;
-				try {
-					content = task.get();
-				}
-				catch (...) {
-					read_event.set();
-					return; // file didn't exist (non-CLI run?) or we had trouble reading it. We'll log to std::clog.
-				}
-
-				std::stringstream ss(TitaniumWindows::Utility::ConvertString(content)); // put string into stream
-
-				// Parse stream with INI parser
-				boost::property_tree::ptree pt;
-				try {
-					boost::property_tree::ini_parser::read_ini(ss, pt);
-				}
-				catch (...) {
-					read_event.set();
-					return; // file wasn't expected format
-				}
-
-				// Now pull out the ips/secret/port from the map
-				auto port = std::make_shared<Platform::String^>(TitaniumWindows::Utility::ConvertString(pt.get<std::string>("tcpPort", "8666")));
-				auto server_token = std::make_shared<Platform::String^>(TitaniumWindows::Utility::ConvertString(pt.get<std::string>("serverToken")));
-				// timeout value
-				std::chrono::milliseconds timeout((std::int64_t)pt.get<double>("logConnectionTimeout", 2000));
-				std::chrono::duration<std::chrono::nanoseconds::rep, std::ratio_multiply<std::ratio<100>, std::nano>> timer_interval_ticks = timeout;
-				Windows::Foundation::TimeSpan time_span;
-				time_span.Duration = timer_interval_ticks.count();
-
-				std::vector<std::string> hosts;
-				std::string ip_address_list = pt.get<std::string>("ipAddressList", "127.0.0.1");
-				boost::algorithm::split(hosts, ip_address_list, boost::algorithm::is_any_of(","));
-
-				for (auto ip_address : hosts) {
-					try {
-						auto host = std::make_shared<Windows::Networking::HostName^>(ref new Windows::Networking::HostName(TitaniumWindows::Utility::ConvertString(ip_address)));
-						// Create token to use to hold cencellation for tasks
-						auto cancel_token_source = cancellation_token_source();
-						// Now create a timer to fire cancellation on token after timeout
-						Windows::System::Threading::ThreadPoolTimer::CreateTimer(ref new Windows::System::Threading::TimerElapsedHandler([cancel_token_source](Windows::System::Threading::ThreadPoolTimer^ timer) {
-							cancel_token_source.cancel();
-						}), time_span);
-
-						concurrency::event connect_event;
-						// emtpy task so we can set the context for connection
-						create_task([]() {})
-						// try to connect to host, use current thread, use token to cancel based on timeout
-						.then([host, port, &tcp_socket]() {
-							return tcp_socket->ConnectAsync(*host, *port);
-						}, cancel_token_source.get_token(), concurrency::task_continuation_context::use_current())
-						// get connection, attach writer to stream
-						.then([&writer, &tcp_socket, &connect_event, server_token](concurrency::task<void> connectTask) {
-							try {
-								connectTask.get();
-								writer = ref new Windows::Storage::Streams::DataWriter(tcp_socket->OutputStream);
-								// we write the server token to see if this log relay is really the log relay we're looking for
-								writer->WriteString(*server_token + "\n");  // Logger assumes \n for newlines!
-								writer->StoreAsync();
-							}
-							catch (...) {} // TODO delete writer?
-							connect_event.set();
-						}, concurrency::task_continuation_context::use_current());
-						connect_event.wait();
-
-						if (writer != nullptr) { // did we get a connection? If so, don't try other IPs
-							break;
-						}
-					}
-					catch (...) {
-						// try next ip!
-						TITANIUM_LOG_DEBUG("API::connect: Trying to connect failed, trying next IP...");
-					}
-				}
-				read_event.set();
-			}, concurrency::task_continuation_context::use_current());
-			read_event.wait();
-		}
-		catch (...) {
-			TITANIUM_LOG_DEBUG("API::connect: will use console log...");
-		}
-
-		// Main logging loop
-		try {
-			std::string message;
-			while (!API::done__) {
-				message = concurrency::receive(API::buffer__); // wait for next message to log
-				if (writer == nullptr) { // no TCP connection
-					for (size_t max = 255, i = 0; i < message.length(); i += max) {
-						std::wclog << TitaniumWindows::Utility::ConvertUTF8String(message.substr(i, max))->Data() << std::flush;
-					}
-					std::wclog << std::endl;
-				} else { // forward over tcp socket
-					writer->WriteString(TitaniumWindows::Utility::ConvertUTF8String(message) + "\n");  // Logger assumes \n for newlines!
-					writer->StoreAsync();
-				}
-			}
-		}
-		catch (...) {
-			TITANIUM_LOG_ERROR("API::connect: Error");
-		}
-		// TODO Clean up the socket and writer!
-		done();
-	}
-
 	API::API(const JSContext& js_context) TITANIUM_NOEXCEPT
-		: Titanium::API(js_context) {
+		: Titanium::API(js_context) 
+		, logger__(std::make_shared<LogForwarder>())
+	{
+
 	}
 
 	API::~API() TITANIUM_NOEXCEPT
 	{
-		done__ = true;
+
 	}
 
 	void API::log(const std::string& message) const TITANIUM_NOEXCEPT
 	{
-		concurrency::asend(buffer__, message);
+		logger__->log(message);
 	}
 
-	void API::JSExportInitialize() {
+	void API::JSExportInitialize() 
+	{
 		JSExport<API>::SetClassVersion(1);
 		JSExport<API>::SetParent(JSExport<Titanium::API>::Class());
 	}
 
 	void API::postInitialize(JSObject& this_object) 
 	{
-		connect();
+		logger__->connect();
 	}
 
-	void API::connect() {
-		done__ = false;
-		reader__.start();
-	}
 }  // namespace TitaniumWindows

--- a/Source/Utility/CMakeLists.txt
+++ b/Source/Utility/CMakeLists.txt
@@ -48,6 +48,8 @@ set(SOURCE_Utility
   src/Utility.cpp
   include/TitaniumWindows/WindowsMacros.hpp
   src/TitaniumEntryPoint.cpp
+  include/TitaniumWindows/LogForwarder.hpp
+  src/LogForwarder.cpp
   )
 
 source_group(Titanium\\Utility FILES ${SOURCE_Utility})

--- a/Source/Utility/include/TitaniumWindows/LogForwarder.hpp
+++ b/Source/Utility/include/TitaniumWindows/LogForwarder.hpp
@@ -1,0 +1,85 @@
+/**
+ * Log forwarder for Titanium CLI
+ *
+ * Copyright (c) 2016 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License.
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#ifndef _TITANIUMWINDOWS_LOGFORWARDER_HPP_
+#define _TITANIUMWINDOWS_LOGFORWARDER_HPP_
+
+#include "TitaniumWindows_Utility_EXPORT.h"
+#include <agents.h>
+
+// 
+// Logging macro for module debugging:
+// TITANIUM_MODULE_LOG_INFO("value: " << value);
+//
+#define TITANIUM_MODULE_LOG(level, expr) \
+	{ const auto message = static_cast<::std::ostringstream&>(std::ostringstream() << level << expr).str();  concurrency::asend(TitaniumWindows::LogForwarder::buffer__, message); }
+#define TITANIUM_MODULE_LOG_TRACE(expr) TITANIUM_MODULE_LOG("[TRACE] ", expr)
+#define TITANIUM_MODULE_LOG_DEBUG(expr) TITANIUM_MODULE_LOG("[DEBUG] ", expr)
+#define TITANIUM_MODULE_LOG_INFO(expr)  TITANIUM_MODULE_LOG("[INFO] ",  expr)
+#define TITANIUM_MODULE_LOG_WARN(expr)  TITANIUM_MODULE_LOG("[WARN] ",  expr)
+#define TITANIUM_MODULE_LOG_ERROR(expr) TITANIUM_MODULE_LOG("[ERROR] ", expr)
+
+// 
+// Logging macro for background module debugging: 
+// TITANIUM_MODULE_LOG_INFO_BACKGROUND("value: " << value);
+//
+#define TITANIUM_MODULE_LOG_BACKGROUND(level, expr) \
+	{ const auto message = static_cast<::std::ostringstream&>(std::ostringstream() << level << expr).str(); const auto logger = std::make_shared<TitaniumWindows::LogForwarder>(); logger->logSync(message); }
+#define TITANIUM_MODULE_LOG_TRACE_BACKGROUND(expr) TITANIUM_MODULE_LOG_BACKGROUND("[TRACE] ", expr)
+#define TITANIUM_MODULE_LOG_DEBUG_BACKGROUND(expr) TITANIUM_MODULE_LOG_BACKGROUND("[DEBUG] ", expr)
+#define TITANIUM_MODULE_LOG_INFO_BACKGROUND(expr)  TITANIUM_MODULE_LOG_BACKGROUND("[INFO] ",  expr)
+#define TITANIUM_MODULE_LOG_WARN_BACKGROUND(expr)  TITANIUM_MODULE_LOG_BACKGROUND("[WARN] ",  expr)
+#define TITANIUM_MODULE_LOG_ERROR_BACKGROUND(expr) TITANIUM_MODULE_LOG_BACKGROUND("[ERROR] ", expr)
+
+namespace TitaniumWindows
+{
+	/*!
+	  This is an agent that is meant to connect over TCP to the CLi and forward logs over the socket. If unable to make a connection,
+	  or not running under CLI we will forward logs to std::clog.
+	*/
+	class log_forwarder : public concurrency::agent
+	{
+	public:
+		explicit log_forwarder() {}
+
+		// Retrieves any error that occurs during the life of the agent.
+		bool get_error(std::exception& e)
+		{
+			return try_receive(_error, e);
+		}
+
+	protected:
+		void run();
+
+	private:
+		concurrency::overwrite_buffer<std::exception> _error;
+	};
+
+	class TITANIUMWINDOWS_UTILITY_EXPORT LogForwarder final
+	{
+	public:
+		static bool done__;
+
+#pragma warning(push)
+#pragma warning(disable : 4251)
+		static concurrency::unbounded_buffer<std::string> buffer__; // Buffer used to store log messages that we haven't written yet
+		log_forwarder reader__; // agent/thread that writes the actual log messages to CLI/debug
+#pragma warning(pop)
+
+		LogForwarder();
+		virtual ~LogForwarder();
+
+		void logSync(const std::string& message);
+		void log(const std::string& message);
+		void connect();
+	};
+
+}  // namespace TitaniumWindows
+
+
+#endif  // _TITANIUMWINDOWS_LOGFORWARDER_HPP_

--- a/Source/Utility/src/LogForwarder.cpp
+++ b/Source/Utility/src/LogForwarder.cpp
@@ -1,0 +1,180 @@
+/**
+ * Log forwarder for Titanium CLI
+ *
+ * Copyright (c) 2016 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License.
+ * Please see the LICENSE included with this distribution for details.
+ */
+#define _SCL_SECURE_NO_WARNINGS
+
+#include "TitaniumWindows/LogForwarder.hpp"
+#include "TitaniumWindows/Utility.hpp"
+#include "Titanium/detail/TiLogger.hpp"
+#include <windows.h>
+#include <iostream>
+#include <boost/algorithm/string.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/ini_parser.hpp>
+
+namespace TitaniumWindows
+{
+	concurrency::unbounded_buffer <std::string> LogForwarder::buffer__;
+	bool LogForwarder::done__ { false };
+
+	static Windows::Storage::Streams::DataWriter^ get_writer(Windows::Networking::Sockets::StreamSocket^ tcp_socket)
+	{
+		using namespace Windows::Storage;
+		using namespace concurrency;
+
+		Windows::Storage::Streams::DataWriter^ writer = nullptr;
+		try {
+			concurrency::event read_event;
+			// Get a handle on titanium_settings.ini file
+			create_task(Windows::ApplicationModel::Package::Current->InstalledLocation->GetFileAsync("titanium_settings.ini"), task_continuation_context::use_arbitrary())
+				.then([](StorageFile^ file) { // don't wrap in task, so next continuation handles any exception from file not existing
+				return FileIO::ReadTextAsync(file);
+			}, task_continuation_context::use_arbitrary())
+				.then([&writer, &read_event, &tcp_socket](task<Platform::String^> task) {
+				Platform::String^ content;
+				try {
+					content = task.get();
+				} catch (...) {
+					read_event.set();
+					return; // file didn't exist (non-CLI run?) or we had trouble reading it. We'll log to std::clog.
+				}
+
+				std::stringstream ss(TitaniumWindows::Utility::ConvertString(content)); // put string into stream
+
+				// Parse stream with INI parser
+				boost::property_tree::ptree pt;
+				try {
+					boost::property_tree::ini_parser::read_ini(ss, pt);
+				} catch (...) {
+					read_event.set();
+					return; // file wasn't expected format
+				}
+
+				// Now pull out the ips/secret/port from the map
+				auto port = std::make_shared<Platform::String^>(TitaniumWindows::Utility::ConvertString(pt.get<std::string>("tcpPort", "8666")));
+				auto server_token = std::make_shared<Platform::String^>(TitaniumWindows::Utility::ConvertString(pt.get<std::string>("serverToken")));
+				// timeout value
+				std::chrono::milliseconds timeout((std::int64_t)pt.get<double>("logConnectionTimeout", 2000));
+				std::chrono::duration<std::chrono::nanoseconds::rep, std::ratio_multiply<std::ratio<100>, std::nano>> timer_interval_ticks = timeout;
+				Windows::Foundation::TimeSpan time_span;
+				time_span.Duration = timer_interval_ticks.count();
+
+				std::vector<std::string> hosts;
+				std::string ip_address_list = pt.get<std::string>("ipAddressList", "127.0.0.1");
+				boost::algorithm::split(hosts, ip_address_list, boost::algorithm::is_any_of(","));
+
+				for (auto ip_address : hosts) {
+					try {
+						auto host = std::make_shared<Windows::Networking::HostName^>(ref new Windows::Networking::HostName(TitaniumWindows::Utility::ConvertString(ip_address)));
+						// Create token to use to hold cencellation for tasks
+						auto cancel_token_source = cancellation_token_source();
+						// Now create a timer to fire cancellation on token after timeout
+						Windows::System::Threading::ThreadPoolTimer::CreateTimer(ref new Windows::System::Threading::TimerElapsedHandler([cancel_token_source](Windows::System::Threading::ThreadPoolTimer^ timer) {
+							cancel_token_source.cancel();
+						}), time_span);
+
+						concurrency::event connect_event;
+						// emtpy task so we can set the context for connection
+						create_task([]() {})
+							// try to connect to host, use current thread, use token to cancel based on timeout
+							.then([host, port, &tcp_socket]() {
+							return tcp_socket->ConnectAsync(*host, *port);
+						}, cancel_token_source.get_token(), concurrency::task_continuation_context::use_current())
+							// get connection, attach writer to stream
+							.then([&writer, &tcp_socket, &connect_event, server_token](concurrency::task<void> connectTask) {
+							try {
+								connectTask.get();
+								writer = ref new Windows::Storage::Streams::DataWriter(tcp_socket->OutputStream);
+								// we write the server token to see if this log relay is really the log relay we're looking for
+								writer->WriteString(*server_token + "\n");  // Logger assumes \n for newlines!
+								writer->StoreAsync();
+							} catch (...) {} // TODO delete writer?
+							connect_event.set();
+						}, concurrency::task_continuation_context::use_current());
+						connect_event.wait();
+
+						if (writer != nullptr) { // did we get a connection? If so, don't try other IPs
+							break;
+						}
+					} catch (...) {
+						// try next ip!
+						TITANIUM_LOG_DEBUG("LogForwarder::connect: Trying to connect failed, trying next IP...");
+					}
+				}
+				read_event.set();
+			}, concurrency::task_continuation_context::use_current());
+			read_event.wait();
+		} catch (...) {
+			TITANIUM_LOG_DEBUG("LogForwarder::connect: will use console log...");
+		}
+		return writer;
+	}
+
+	static void forward_log(Windows::Storage::Streams::DataWriter^ writer, const std::string& message)
+	{
+		if (writer == nullptr) { // no TCP connection
+			for (size_t max = 255, i = 0; i < message.length(); i += max) {
+				std::wclog << TitaniumWindows::Utility::ConvertUTF8String(message.substr(i, max))->Data() << std::flush;
+			}
+			std::wclog << std::endl;
+		} else { // forward over tcp socket
+			writer->WriteString(TitaniumWindows::Utility::ConvertUTF8String(message) + "\n");  // Logger assumes \n for newlines!
+			writer->StoreAsync();
+		}
+	}
+
+	void log_forwarder::run()
+	{
+		using namespace Windows::Storage;
+		using namespace concurrency;
+
+		const auto tcp_socket = ref new Windows::Networking::Sockets::StreamSocket();
+		const auto writer = get_writer(tcp_socket);
+
+		// Main logging loop
+		try {
+			std::string message;
+			while (!LogForwarder::done__) {
+				message = concurrency::receive(LogForwarder::buffer__); // wait for next message to log
+				forward_log(writer, message);
+			}
+		} catch (...) {
+			TITANIUM_LOG_ERROR("LogForwarder::connect: Error");
+		}
+		// TODO Clean up the socket and writer!
+		done();
+	}
+
+	LogForwarder::LogForwarder()
+	{
+		TITANIUM_LOG_DEBUG("LogForwarder::ctor");
+	}
+
+	LogForwarder::~LogForwarder()
+	{
+		TITANIUM_LOG_DEBUG("LogForwarder::dtor");
+		done__ = true;
+	}
+
+	void LogForwarder::logSync(const std::string& message) 
+	{
+		const auto tcp_socket = ref new Windows::Networking::Sockets::StreamSocket();
+		forward_log(get_writer(tcp_socket), message);
+	}
+
+	void LogForwarder::log(const std::string& message)
+	{
+		concurrency::asend(buffer__, message);
+	}
+
+	void LogForwarder::connect() 
+	{
+		done__ = false;
+		reader__.start();
+	}
+
+}  // namespace TitaniumWindows

--- a/templates/module/default/hooks/windows-module.js
+++ b/templates/module/default/hooks/windows-module.js
@@ -55,7 +55,7 @@ exports.init = function (logger, config, cli) {
 			var cmakeDir = path.resolve(data.sdk.path, 'windows', 'cli', 'vendor', 'cmake'),
 				cmake = path.join(cmakeDir, 'bin', 'cmake.exe'),
 				projectDir = path.join(data.projectDir, 'windows'),
-				cmakeFinds = ['HAL', 'JavascriptCore', 'TitaniumKit'],
+				cmakeFinds = ['HAL', 'JavascriptCore', 'TitaniumKit', 'TitaniumWindows_Utility'],
 				cmakeFindDirSrc = path.join(data.sdk.path, 'windows', 'templates', 'build', 'cmake'),
 				cmakeFindDirDst = path.join(projectDir, 'cmake');
 

--- a/templates/module/default/template/windows/CMakeLists.txt.ejs
+++ b/templates/module/default/template/windows/CMakeLists.txt.ejs
@@ -38,6 +38,7 @@ list(INSERT CMAKE_MODULE_PATH 0 ${APPCELERATOR_CMAKE_MODULE_PATH})
 
 find_package(HAL REQUIRED)
 find_package(TitaniumKit REQUIRED)
+find_package(TitaniumWindows_Utility REQUIRED)
 
 enable_testing()
 
@@ -63,11 +64,13 @@ target_include_directories(<%- moduleIdAsIdentifier %> PUBLIC
   ${PROJECT_SOURCE_DIR}/include
   $<TARGET_PROPERTY:HAL,INTERFACE_INCLUDE_DIRECTORIES>
   $<TARGET_PROPERTY:TitaniumKit,INTERFACE_INCLUDE_DIRECTORIES>
+  $<TARGET_PROPERTY:TitaniumWindows_Utility,INTERFACE_INCLUDE_DIRECTORIES>
   )
 
 target_link_libraries(<%- moduleIdAsIdentifier %>
   HAL
   TitaniumKit
+  TitaniumWindows_Utility
   )
 
 set_target_properties(<%- moduleIdAsIdentifier %> PROPERTIES VS_WINRT_COMPONENT TRUE)

--- a/templates/module/default/template/windows/src/{{moduleIdAsIdentifier}}.cpp.ejs
+++ b/templates/module/default/template/windows/src/{{moduleIdAsIdentifier}}.cpp.ejs
@@ -7,6 +7,7 @@
  */
 #include "<%- moduleIdAsIdentifier %>.hpp"
 #include "Titanium/detail/TiImpl.hpp"
+#include "TitaniumWindows/LogForwarder.hpp"
 
 using namespace Windows::ApplicationModel::Background;
 


### PR DESCRIPTION
[TIMOB-23241](https://jira.appcelerator.org/browse/TIMOB-23241)

Logging macros for native module debugging. 

```c++
// Logging macro for module debugging: 
TITANIUM_MODULE_LOG_TRACE("value: " << value);

// Logging macro for background module debugging: 
TITANIUM_MODULE_LOG_INFO_BACKGROUND("value: " << value);
```

Background service classes needs special macro because it's independent from app.
