### PR TITLE
[TIMOB-23187] Fix: ListView.searchText doesn't work with searchableText

### DIFF
--- a/Source/TitaniumKit/include/Titanium/UI/ListSection.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/ListSection.hpp
@@ -43,8 +43,13 @@ namespace Titanium
 		TITANIUMKIT_EXPORT ListDataItem js_to_ListDataItem(const JSObject& object);
 		TITANIUMKIT_EXPORT JSObject ListDataItem_to_js(const JSContext& js_context, const ListDataItem& item);
 
-		// Case-insensitive query ListDataItem title 
-		TITANIUMKIT_EXPORT bool ListDataItem_contains(const ListDataItem& item, const std::string& query);
+		/*!
+		  Query ListDataItem title/searchableText
+		  @param item List data item
+		  @param query Query parameter. Should be lower-cased when caseInsensitive is true
+		  @param caseInsensitive Determines whether query is case insensitive
+		*/
+		TITANIUMKIT_EXPORT bool ListDataItem_contains(const ListDataItem& item, const std::string& query, const bool& caseInsensitive);
 
 		/*!
 		  @class

--- a/Source/TitaniumKit/src/UI/ListSection.cpp
+++ b/Source/TitaniumKit/src/UI/ListSection.cpp
@@ -61,14 +61,19 @@ namespace Titanium
 			return items;
 		}
 
-		bool ListDataItem_contains(const ListDataItem& item, const std::string& query)
+		bool ListDataItem_contains(const ListDataItem& item, const std::string& query, const bool& caseInsensitive)
 		{
-			if (item.properties.find("title") == item.properties.end()) {
+			const auto notFound = item.properties.end();
+			const auto searchableTextFound = (item.properties.find("searchableText") != notFound);
+			if (!searchableTextFound && (item.properties.find("title") == notFound)) {
 				return false;
 			}
-			const auto title = static_cast<std::string>(item.properties.at("title"));
-			const auto pos = boost::algorithm::to_lower_copy(title).find(boost::algorithm::to_lower_copy(query));
-			return pos != std::string::npos;
+			const auto content = searchableTextFound ? static_cast<std::string>(item.properties.at("searchableText")) : static_cast<std::string>(item.properties.at("title"));
+			if (caseInsensitive) {
+				return (boost::algorithm::to_lower_copy(content).find(query) != std::string::npos);
+			} else {
+				return (content.find(query) != std::string::npos);
+			}
 		}
 
 		ListSection::ListSection(const JSContext& js_context) TITANIUM_NOEXCEPT

--- a/Source/TitaniumKit/src/UI/ListView.cpp
+++ b/Source/TitaniumKit/src/UI/ListView.cpp
@@ -10,6 +10,7 @@
 #include "Titanium/UI/ListViewAnimationProperties.hpp"
 #include "Titanium/UI/SearchBar.hpp"
 #include "Titanium/UI/listview_js.hpp"
+#include <boost/algorithm/string.hpp>
 
 namespace Titanium
 {
@@ -102,10 +103,12 @@ namespace Titanium
 			// Create default section to show results
 			const auto section = static_cast<JSObject>(get_context().JSEvaluateScript("Ti.UI.createListSection({ headerTitle: 'Search Results' });")).GetPrivate<Titanium::UI::ListSection>();
 			const std::vector<std::shared_ptr<ListSection>> sections { section };
+			const auto caseInsensitive = get_caseInsensitiveSearch();
+			const auto normalizedQuery = caseInsensitive ? boost::algorithm::to_lower_copy(query) : query;
 			std::vector<ListDataItem> items;
 			for (const auto section : model__->get_saved_sections()) {
 				for (const auto item : section->get_items()) {
-					if (ListDataItem_contains(item, query)) {
+					if (ListDataItem_contains(item, normalizedQuery, caseInsensitive)) {
 						items.push_back(item);
 					}
 				}
@@ -120,10 +123,12 @@ namespace Titanium
 				model__->save();
 			}
 
+			const auto caseInsensitive = get_caseInsensitiveSearch();
+			const auto normalizedQuery = caseInsensitive ? boost::algorithm::to_lower_copy(query) : query;
 			std::vector<std::string> suggestions;
 			for (const auto section : model__->get_saved_sections()) {
 				for (const auto item : section->get_items()) {
-					if (ListDataItem_contains(item, query)) {
+					if (ListDataItem_contains(item, normalizedQuery, caseInsensitive)) {
 						suggestions.push_back(static_cast<std::string>(item.properties.at("title")));
 					}
 				}


### PR DESCRIPTION
[TIMOB-23187](https://jira.appcelerator.org/browse/TIMOB-23187)

- Fix: `ListView.searchText` doesn't work with `searchableText`
- Fix: `ListView.caseInsensitiveSearch` is ignored

```javascript
var win = Ti.UI.createWindow({ backgroundColor: 'green', layout: 'vertical' });
var searchText = Ti.UI.createTextField({width:Ti.UI.FILL, height: '10%'});

var listView = Ti.UI.createListView({width:Ti.UI.FILL, height: '90%', caseInsensitiveSearch: false});
var sections = [];

var fruitSection = Ti.UI.createListSection({ headerTitle: 'Fruits' });
var fruitDataSet = [
    { properties: { title: 'Apple', searchableText: 'Manzana' } },
    { properties: { title: 'Banana', searchableText: 'Plátano' } },
];
fruitSection.setItems(fruitDataSet);
sections.push(fruitSection);

var vegSection = Ti.UI.createListSection({ headerTitle: 'Vegetables' });
var vegDataSet = [
    { properties: { title: 'Carrots', searchableText: 'Zanahorias' } },
    { properties: { title: 'Potatoes', searchableText: 'Patatas' } },
];
vegSection.setItems(vegDataSet);
sections.push(vegSection);

listView.sections = sections;

searchText.addEventListener('change', function () {
    listView.searchText = searchText.value;
});

win.add(searchText);
win.add(listView);
win.open();
```