### PR TITLE
[TIMOB-23253] Windows: Build errors when building to device and selecting second option in device prompt

### DIFF
--- a/cli/commands/_build/config/deviceID.js
+++ b/cli/commands/_build/config/deviceID.js
@@ -35,7 +35,8 @@ module.exports = function configOptionDeviceID(order) {
 
 		// validate device
 		if (!devices.some(function (d) {
-				if (d.udid == value || d.name === value) {
+			// because we specify ignorecase below, we may get the name lowercased!
+				if (d.udid == value || d.name.toLowerCase() === value.toLowerCase()) {
 					dev = d;
 					value = d.udid;
 					return true;

--- a/cli/commands/_build/config/deviceID.js
+++ b/cli/commands/_build/config/deviceID.js
@@ -25,7 +25,7 @@ module.exports = function configOptionDeviceID(order) {
 		// de: first device
 		if (((cli.argv.target === 'wp-emulator' && value === 'xd') ||
 			 (cli.argv.target === 'wp-device' && value === 'de')) && devices[0]) {
-			
+
 			// use wpsdk for device
 			if (devices[0].wpsdk) {
 				cli.argv['wp-sdk'] = devices[0].wpsdk;
@@ -52,22 +52,9 @@ module.exports = function configOptionDeviceID(order) {
 
 		// check the device
 		if (cli.argv.target === 'wp-device') {
-			// try connecting to the device to detect no device or more than 1 device
 			this.windowslibOptions['wpsdk'] = cli.argv['wp-sdk'];
-			windowslib.device.connect(dev.udid, this.windowslibOptions)
-				.on('connected', function () {
-					callback(null, value);
-				})
-				.on('error', function (err) {
-					this.logger.log();
-					this.logger.error(err.message || err.toString());
-					this.logger.log();
-					process.exit(1);
-				}.bind(this));
-		} else {
-			// must be emulator then
-			callback(null, value);
 		}
+		callback(null, value);
 	}
 
 	return {

--- a/cli/commands/_build/config/wpSDK.js
+++ b/cli/commands/_build/config/wpSDK.js
@@ -10,7 +10,7 @@ var appc = require('node-appc'),
  * @returns {Object}
  */
 module.exports = function configOptionWPSDK(order) {
-	var defaultTarget = '8.1',
+	var defaultTarget = '10.0',
 		sdkTargets = [],
 		unsupportedTargets = ['8.0'];
 

--- a/cli/hooks/wp-run.js
+++ b/cli/hooks/wp-run.js
@@ -215,6 +215,7 @@ exports.init = function (logger, config, cli) {
 
 				function installApp(deviceId, xapFile, opts, next) {
 					// Now install the real app
+					logger.info(__('Installing the application...'));
 					windowslib.install(deviceId, xapFile, appc.util.mix({
 								appGuid: builder.phoneProductId,
 								// launching an app on Win 10 device fails right now!
@@ -272,6 +273,7 @@ exports.init = function (logger, config, cli) {
 				});
 				possibleDependencies.forEach(function(file) {
 					installs.push(function (next) {
+						logger.info(__('Installing dependency: %s', file));
 						windowslib.install(builder.deviceId, path.resolve(dependenciesDir, file), installOnlyOpts)
 						.on('installed', function (handle) {
 							next();


### PR DESCRIPTION
Requires appcelerator/windowslib#41 and then we'll need to bump the version and update packaged windowslib on titanium_mobile 5_3_X branch.

- don't connect to device as part of deviceId validation. Seems good enough if the udid can be found in our listing. Connecting slows down the start of the build by a good amount.
- Don't report the build time twice
- Don't try to launch the apps on Windows 10 mobile as this always fails now. Instead spit out a warning message asking user to launch manually. This actually fixes https://jira.appcelerator.org/browse/TIMOB-20611
- log when we start installing dependencies and the app itself to give a little better indicator of progress