### PR TITLE
[TIMOB-23262] Fix: Ti.Media.showCamera() doesn't launch in full screen

### DIFF
--- a/Source/Media/include/TitaniumWindows/Media.hpp
+++ b/Source/Media/include/TitaniumWindows/Media.hpp
@@ -9,9 +9,11 @@
 
 #include "TitaniumWindows_Media_EXPORT.h"
 #include "Titanium/MediaModule.hpp"
+#include "Titanium/Media/CameraOptionsType.hpp"
 #include "Titanium/Media/PhotoGalleryOptionsType.hpp"
 #include "Titanium/Media/MusicLibraryOptionsType.hpp"
 #include "Titanium/detail/TiBase.hpp"
+#include "Titanium/UI/View.hpp"
 #include "TitaniumWindows/WindowsMacros.hpp"
 #include <agile.h>
 #include <collection.h>
@@ -19,6 +21,16 @@
 namespace TitaniumWindows
 {
 	using namespace HAL;
+
+	ref class TakingPictureState sealed
+	{
+	internal:
+		Windows::Storage::StorageFile^ file;
+		Windows::Graphics::Imaging::BitmapDecoder^ decoder;
+		Windows::Graphics::Imaging::BitmapEncoder^ encoder;
+		Windows::Storage::Streams::IRandomAccessStream^ outstream;
+		Windows::Storage::FileProperties::PhotoOrientation orientation;
+	};
 
 	/*!
 	  @class MediaModule
@@ -164,6 +176,11 @@ namespace TitaniumWindows
 		void takeScreenshotDone(JSObject callback, const std::string& file = "", const bool& hasError = true);
 		void clearScreenshotResources();
 		void takeScreenshotToFile(JSObject callback);
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
+		void updatePreviewOrientation();
+#endif
+		Windows::Storage::FileProperties::PhotoOrientation toPhotoOrientation();
+		std::uint32_t orientationToDegrees();
 
 		std::vector<std::shared_ptr<Titanium::Media::Item>> getMusicProperties(const std::vector<std::string>& files);
 
@@ -176,14 +193,20 @@ namespace TitaniumWindows
 		Titanium::Media::MusicLibraryOptionsType openMusicLibraryOptionsState__;
 		JSFunction js_beep__;
 #if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
+		Titanium::Media::CameraOptionsTypeCallbacks cameraCallbacks__;
+		std::shared_ptr<Titanium::UI::View> cameraOverlay__;
 		bool screenCaptureStarted__{ false };
 		bool cameraPreviewStarted__ { false };
+		bool shouldHideAfterTakingShot__{ false };
+		bool shouldRemoveRotationEvent__{ false };
 		JSFunction fileOpenForMusicLibraryCallback__;
 		JSFunction fileOpenForPhotoGalleryCallback__;
 		::Platform::Agile<Windows::Media::Capture::MediaCapture> mediaCapture__;
 		::Platform::Collections::Vector<Windows::UI::Xaml::DispatcherTimer^>^ vibrate_timers__;
 		Windows::UI::Xaml::Controls::CaptureElement^ captureElement__;
 		Windows::Foundation::EventRegistrationToken camera_navigated_event__;
+		Windows::Foundation::EventRegistrationToken camera_orientation_event__;
+		TakingPictureState^ takingPictureState__;
 #endif
 #pragma warning(pop)
 	};

--- a/Source/TitaniumKit/include/Titanium/Media/CameraMediaItemType.hpp
+++ b/Source/TitaniumKit/include/Titanium/Media/CameraMediaItemType.hpp
@@ -35,9 +35,12 @@ namespace Titanium
 			std::shared_ptr<Titanium::Blob> media;
 			MediaType mediaType;
 			bool success { true };
+
+			// we don't want to instantiate Blob object when file exists. 
+			// in that case we just hold file name, and create Blob object only on demand.
+			std::string media_filename;
 		};
 		
-		TITANIUMKIT_EXPORT CameraMediaItemType js_to_CameraMediaItemType(const JSObject& object);
 		TITANIUMKIT_EXPORT JSObject CameraMediaItemType_to_js(const JSContext& js_context, const CameraMediaItemType& config);
 		
 	} // namespace Media

--- a/Source/TitaniumKit/include/Titanium/Media/CameraOptionsType.hpp
+++ b/Source/TitaniumKit/include/Titanium/Media/CameraOptionsType.hpp
@@ -64,6 +64,7 @@ namespace Titanium
 			CameraOptionsTypeCallbacks callbacks;
 		};
 		
+		TITANIUMKIT_EXPORT CameraOptionsTypeCallbacks create_empty_CameraOptionsTypeCallbacks(const JSContext& js_context);
 		TITANIUMKIT_EXPORT CameraOptionsType js_to_CameraOptionsType(const JSObject& object);
 		TITANIUMKIT_EXPORT JSObject CameraOptionsType_to_js(const JSContext& js_context, const CameraOptionsType& config);
 		

--- a/Source/TitaniumKit/include/Titanium/UI/Constants.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/Constants.hpp
@@ -621,11 +621,11 @@ namespace Titanium
 		  @constant PX Unit constant representing units in pixels.
 		*/
 		enum class TITANIUMKIT_EXPORT UNIT {
-			CM,
-			DIP,
-			IN,
-			MM,
-			PX
+			Cm,
+			Dip,
+			In,
+			Mm,
+			Px
 		};
 
 		/*!

--- a/Source/TitaniumKit/src/Media/CameraMediaItemType.cpp
+++ b/Source/TitaniumKit/src/Media/CameraMediaItemType.cpp
@@ -16,33 +16,27 @@ namespace Titanium
 	{
 		using namespace HAL;
 
-		CameraMediaItemType js_to_CameraMediaItemType(const JSObject& object)
-		{
-			CameraMediaItemType config;
-
-			config.code = static_cast<std::int32_t>(object.GetProperty("code"));
-			if (object.HasProperty("cropRect")) {
-				config.cropRect = Titanium::UI::js_to_Dimension(static_cast<JSObject>(object.GetProperty("cropRect")));
-			}
-			if (object.HasProperty("error")) {
-				config.error = static_cast<std::string>(object.GetProperty("error"));
-			}
-			const auto js_media = object.GetProperty("media");
-			ENSURE_MODULE_OBJECT(js_media, media, Titanium::Blob);
-			config.media = media;
-			config.mediaType = static_cast<MediaType>(static_cast<std::uint32_t>(object.GetProperty("mediaType")));
-			config.success = static_cast<bool>(object.GetProperty("success"));
-			return config;
-		};
-
 		JSObject CameraMediaItemType_to_js(const JSContext& js_context, const CameraMediaItemType& config)
 		{
-			auto object = js_context.CreateObject();
+			// Lazy load blob object based on file name whenever possible.
+			auto exportObj = js_context.CreateObject();
+			auto object = static_cast<JSObject>(js_context.JSEvaluateScript(R"(
+				var item = { get media() {
+                    if (this._media_filename) {
+						return Ti.Filesystem.getFile(this._media_filename).read();
+				    }
+					return null;
+				}};
+				item;
+			)", exportObj));
 			object.SetProperty("code", js_context.CreateNumber(config.code));
 			object.SetProperty("cropRect", Titanium::UI::Dimension_to_js(js_context, config.cropRect));
 			object.SetProperty("error", js_context.CreateString(config.error));
 			if (config.media != nullptr) {
 				object.SetProperty("media", config.media->get_object());
+			}
+			if (!config.media_filename.empty()) {
+				object.SetProperty("_media_filename", js_context.CreateString(config.media_filename));
 			}
 			object.SetProperty("mediaType", js_context.CreateNumber(static_cast<std::uint32_t>(config.mediaType)));
 			object.SetProperty("success", js_context.CreateBoolean(config.success));

--- a/Source/TitaniumKit/src/Media/CameraOptionsType.cpp
+++ b/Source/TitaniumKit/src/Media/CameraOptionsType.cpp
@@ -17,6 +17,17 @@ namespace Titanium
 	{
 		using namespace HAL;
 		
+		CameraOptionsTypeCallbacks create_empty_CameraOptionsTypeCallbacks(const JSContext& js_context)
+		{
+			auto empty = js_context.CreateNull();
+			CameraOptionsTypeCallbacks callbacks{
+				empty,
+				empty,
+				empty
+			};
+			return callbacks;
+		}
+
 		CameraOptionsType js_to_CameraOptionsType(const JSObject& object)
 		{
 			std::vector<MediaType> mediaTypes;
@@ -91,7 +102,7 @@ namespace Titanium
 				JSOBJECT_GETPROPERTY(object, allowEditing, bool, false),
 				JSOBJECT_GETPROPERTY(object, animated, bool, true),
 				JSOBJECT_GETPROPERTY(object, arrowDirection, std::uint32_t, 0),
-				JSOBJECT_GETPROPERTY(object, autohide, bool, false),
+				JSOBJECT_GETPROPERTY(object, autohide, bool, true),
 				JSOBJECT_GETPROPERTY(object, autorotate, bool, true),
 				JSOBJECT_GETPROPERTY(object, isPopOver, bool, false),
 				mediaTypes,

--- a/Source/TitaniumKit/src/UI/Constants.cpp
+++ b/Source/TitaniumKit/src/UI/Constants.cpp
@@ -1623,11 +1623,11 @@ namespace Titanium
 			static std::unordered_map<UNIT, std::string> map;
 			static std::once_flag of;
 			std::call_once(of, []() {
-      map[UNIT::CM]  = "UNIT_CM";
-      map[UNIT::DIP] = "UNIT_DIP";
-      map[UNIT::IN]  = "UNIT_IN";
-      map[UNIT::MM]  = "UNIT_MM";
-      map[UNIT::PX]  = "UNIT_PX";
+      map[UNIT::Cm]  = "UNIT_CM";
+      map[UNIT::Dip] = "UNIT_DIP";
+      map[UNIT::In]  = "UNIT_IN";
+      map[UNIT::Mm]  = "UNIT_MM";
+      map[UNIT::Px]  = "UNIT_PX";
 			});
 
 			std::string string = unknown_string;
@@ -1644,14 +1644,14 @@ namespace Titanium
 			static std::unordered_map<std::string, UNIT> map;
 			static std::once_flag of;
 			std::call_once(of, []() {
-      map["UNIT_CM"]  = UNIT::CM;
-      map["UNIT_DIP"] = UNIT::DIP;
-      map["UNIT_IN"]  = UNIT::IN;
-      map["UNIT_MM"]  = UNIT::MM;
-      map["UNIT_PX"]  = UNIT::PX;
+      map["UNIT_CM"]  = UNIT::Cm;
+      map["UNIT_DIP"] = UNIT::Dip;
+      map["UNIT_IN"]  = UNIT::In;
+      map["UNIT_MM"]  = UNIT::Mm;
+      map["UNIT_PX"]  = UNIT::Px;
 			});
 
-			UNIT unit = UNIT::DIP;
+			UNIT unit = UNIT::Dip;
 			const auto position = map.find(unitName);
 			if (position != map.end()) {
 				unit = position->second;
@@ -1667,14 +1667,14 @@ namespace Titanium
 			static std::unordered_map<std::underlying_type<UNIT>::type, UNIT> map;
 			static std::once_flag of;
 			std::call_once(of, []() {
-      map[static_cast<std::underlying_type<UNIT>::type>(UNIT::CM)]  = UNIT::CM;
-      map[static_cast<std::underlying_type<UNIT>::type>(UNIT::DIP)] = UNIT::DIP;
-      map[static_cast<std::underlying_type<UNIT>::type>(UNIT::IN)]  = UNIT::IN;
-      map[static_cast<std::underlying_type<UNIT>::type>(UNIT::MM)]  = UNIT::MM;
-      map[static_cast<std::underlying_type<UNIT>::type>(UNIT::PX)]  = UNIT::PX;
+      map[static_cast<std::underlying_type<UNIT>::type>(UNIT::Cm)]  = UNIT::Cm;
+      map[static_cast<std::underlying_type<UNIT>::type>(UNIT::Dip)] = UNIT::Dip;
+      map[static_cast<std::underlying_type<UNIT>::type>(UNIT::In)]  = UNIT::In;
+      map[static_cast<std::underlying_type<UNIT>::type>(UNIT::Mm)]  = UNIT::Mm;
+      map[static_cast<std::underlying_type<UNIT>::type>(UNIT::Px)]  = UNIT::Px;
 			});
 
-			UNIT unit = UNIT::DIP;
+			UNIT unit = UNIT::Dip;
 			const auto position = map.find(unit_underlying_type);
 			if (position != map.end()) {
 				unit = position->second;

--- a/Source/TitaniumKit/src/UIModule.cpp
+++ b/Source/TitaniumKit/src/UIModule.cpp
@@ -392,23 +392,23 @@ namespace Titanium
 	}
 	TITANIUM_PROPERTY_GETTER(UIModule, UNIT_CM)
 	{
-		return get_context().CreateString(Titanium::UI::Constants::to_string(Titanium::UI::UNIT::CM));
+		return get_context().CreateString(Titanium::UI::Constants::to_string(Titanium::UI::UNIT::Cm));
 	}
 	TITANIUM_PROPERTY_GETTER(UIModule, UNIT_DIP)
 	{
-		return get_context().CreateString(Titanium::UI::Constants::to_string(Titanium::UI::UNIT::DIP));
+		return get_context().CreateString(Titanium::UI::Constants::to_string(Titanium::UI::UNIT::Dip));
 	}
 	TITANIUM_PROPERTY_GETTER(UIModule, UNIT_IN)
 	{
-		return get_context().CreateString(Titanium::UI::Constants::to_string(Titanium::UI::UNIT::IN));
+		return get_context().CreateString(Titanium::UI::Constants::to_string(Titanium::UI::UNIT::In));
 	}
 	TITANIUM_PROPERTY_GETTER(UIModule, UNIT_MM)
 	{
-		return get_context().CreateString(Titanium::UI::Constants::to_string(Titanium::UI::UNIT::MM));
+		return get_context().CreateString(Titanium::UI::Constants::to_string(Titanium::UI::UNIT::Mm));
 	}
 	TITANIUM_PROPERTY_GETTER(UIModule, UNIT_PX)
 	{
-		return get_context().CreateString(Titanium::UI::Constants::to_string(Titanium::UI::UNIT::PX));
+		return get_context().CreateString(Titanium::UI::Constants::to_string(Titanium::UI::UNIT::Px));
 	}
 	TITANIUM_PROPERTY_GETTER(UIModule, UNKNOWN)
 	{

--- a/Source/Utility/include/TitaniumWindows/Utility.hpp
+++ b/Source/Utility/include/TitaniumWindows/Utility.hpp
@@ -159,17 +159,17 @@ namespace TitaniumWindows
 		//
 		// Add view onto current Window
 		//
-		TITANIUMWINDOWS_UTILITY_EXPORT void SetViewForCurrentWindow(Windows::UI::Xaml::UIElement^ view, Windows::Foundation::EventRegistrationToken& token, const bool& visible = true);
+		TITANIUMWINDOWS_UTILITY_EXPORT void SetViewForCurrentWindow(Windows::UI::Xaml::FrameworkElement^ view, Windows::Foundation::EventRegistrationToken& token, const bool& visible, const bool& fullscreen);
 
 		//
 		// Add hidden view onto current Window
 		//
-		TITANIUMWINDOWS_UTILITY_EXPORT void SetHiddenViewForCurrentWindow(Windows::UI::Xaml::UIElement^ view, Windows::Foundation::EventRegistrationToken& token);
+		TITANIUMWINDOWS_UTILITY_EXPORT void SetHiddenViewForCurrentWindow(Windows::UI::Xaml::FrameworkElement^ view, Windows::Foundation::EventRegistrationToken& token);
 
 		//
 		// Remove view from current Window
 		//
-		TITANIUMWINDOWS_UTILITY_EXPORT void RemoveViewFromCurrentWindow(Windows::UI::Xaml::UIElement^ view);
+		TITANIUMWINDOWS_UTILITY_EXPORT void RemoveViewFromCurrentWindow(Windows::UI::Xaml::FrameworkElement^ view);
 
 		//
 		// Construct Ti.Blob from given path

--- a/Source/Utility/src/Utility.cpp
+++ b/Source/Utility/src/Utility.cpp
@@ -304,7 +304,7 @@ namespace TitaniumWindows
 			return std::chrono::time_point<std::chrono::system_clock>(std::chrono::milliseconds(static_cast<std::chrono::milliseconds::rep>(base_date_msec + time_msec)));
 		}
 
-		void RemoveViewFromCurrentWindow(Windows::UI::Xaml::UIElement^ view) 
+		void RemoveViewFromCurrentWindow(Windows::UI::Xaml::FrameworkElement^ view)
 		{
 			const auto rootFrame = dynamic_cast<Windows::UI::Xaml::Controls::Frame^>(Windows::UI::Xaml::Window::Current->Content);
 			TITANIUM_ASSERT_AND_THROW(rootFrame->Content, "Could not get content from current Window");
@@ -329,21 +329,26 @@ namespace TitaniumWindows
 
 
 		// Add hidden UI onto current Window
-		void SetHiddenViewForCurrentWindow(Windows::UI::Xaml::UIElement^ view, Windows::Foundation::EventRegistrationToken& token) 
+		void SetHiddenViewForCurrentWindow(Windows::UI::Xaml::FrameworkElement^ view, Windows::Foundation::EventRegistrationToken& token)
 		{
-			SetViewForCurrentWindow(view, token, false);
+			SetViewForCurrentWindow(view, token, false, false);
 		}
 
-		void SetViewForCurrentWindow(Windows::UI::Xaml::UIElement^ view, Windows::Foundation::EventRegistrationToken& token, const bool& visible)
+		void SetViewForCurrentWindow(Windows::UI::Xaml::FrameworkElement^ view, Windows::Foundation::EventRegistrationToken& token, const bool& visible, const bool& fullscreen)
 		{
 			view->Visibility = visible ? Windows::UI::Xaml::Visibility::Visible : Windows::UI::Xaml::Visibility::Collapsed;
 			const auto rootFrame = dynamic_cast<Windows::UI::Xaml::Controls::Frame^>(Windows::UI::Xaml::Window::Current->Content);
-			const auto registerUI = ref new Windows::UI::Core::DispatchedHandler([view, rootFrame]() {
+			const auto registerUI = ref new Windows::UI::Core::DispatchedHandler([view, rootFrame, fullscreen]() {
 				if (rootFrame->Content) {
 					const auto page = dynamic_cast<Windows::UI::Xaml::Controls::Page^>(rootFrame->Content);
 					if (page && page->Content) {
 						const auto content = static_cast<Windows::UI::Xaml::Controls::Panel^>(page->Content);
 						if (content) {
+							if (fullscreen) {
+								const auto currentBounds = Windows::UI::Xaml::Window::Current->Bounds;
+								view->Width = currentBounds.Width;
+								view->Height = currentBounds.Height;
+							}
 							content->Children->Append(view);
 						}
 					}


### PR DESCRIPTION
Fix [TIMOB-23262](https://jira.appcelerator.org/browse/TIMOB-23262)

- Camera preview should launch in full screen
- Camera preview should be placed at the bottom of the screen z order to accept overlaying view

```javascript
var win = Ti.UI.createWindow({ backgroundColor: 'green', layout: 'vertical' });

var overlay = Ti.UI.createView({ backgroundColor: 'blue', layout: 'vertical', height:'20%', width:Ti.UI.FILL }),
    takeButton = Ti.UI.createButton({ title: 'TAKE A PHOTO', backgroundColor: 'red' }),
    hideButton = Ti.UI.createButton({ title:'HIDE PREVIEW' , backgroundColor:'red'});

takeButton.addEventListener('click', function () {
    Ti.Media.takePicture();
});
hideButton.addEventListener('click', function () {
    Ti.Media.hideCamera();
});
overlay.add(takeButton);
overlay.add(hideButton);

win.addEventListener('open', function () {
    Ti.Media.showCamera({
        mediaTypes: [Ti.Media.MEDIA_TYPE_PHOTO],
    });
});

win.add(overlay);
win.open();
```

Note that in order to `showCamera` work, you need to set `webcam` capability, and also `takePicture` requires `videosLibrary` capability. 

```xml
  <windows>
    <manifest>
    <Capabilities>
      <Capability Name="internetClient" />
      <!-- Capability Name="videosLibrary" / -->
      <Capability Name="picturesLibrary" / >
      <DeviceCapability Name="webcam" />
    </Capabilities>
    </manifest>
  </windows>
```