### PR TITLE
[TIMOB-23293] Fix layout issue on Corporate Directory App

### DIFF
--- a/Source/TitaniumKit/src/UI/Constants.cpp
+++ b/Source/TitaniumKit/src/UI/Constants.cpp
@@ -990,9 +990,9 @@ namespace Titanium
 			static std::unordered_map<TEXT_ALIGNMENT, std::string> map;
 			static std::once_flag of;
 			std::call_once(of, []() {
-      map[TEXT_ALIGNMENT::CENTER] = "TEXT_ALIGNMENT_CENTER";
-      map[TEXT_ALIGNMENT::LEFT]   = "TEXT_ALIGNMENT_LEFT";
-      map[TEXT_ALIGNMENT::RIGHT]  = "TEXT_ALIGNMENT_RIGHT";
+      map[TEXT_ALIGNMENT::CENTER] = "center";
+      map[TEXT_ALIGNMENT::LEFT]   = "left";
+      map[TEXT_ALIGNMENT::RIGHT]  = "right";
 			});
 
 			std::string string = unknown_string;
@@ -1009,9 +1009,9 @@ namespace Titanium
 			static std::unordered_map<std::string, TEXT_ALIGNMENT> map;
 			static std::once_flag of;
 			std::call_once(of, []() {
-      map["TEXT_ALIGNMENT_CENTER"] = TEXT_ALIGNMENT::CENTER;
-      map["TEXT_ALIGNMENT_LEFT"]   = TEXT_ALIGNMENT::LEFT;
-      map["TEXT_ALIGNMENT_RIGHT"]  = TEXT_ALIGNMENT::RIGHT;
+      map["center"] = TEXT_ALIGNMENT::CENTER;
+      map["left"]   = TEXT_ALIGNMENT::LEFT;
+      map["right"]  = TEXT_ALIGNMENT::RIGHT;
 			});
 
 			TEXT_ALIGNMENT textAlignment = TEXT_ALIGNMENT::LEFT;

--- a/Source/UI/src/ScrollView.cpp
+++ b/Source/UI/src/ScrollView.cpp
@@ -80,10 +80,10 @@ namespace TitaniumWindows
 
 			Titanium::UI::ScrollView::setLayoutDelegate<ScrollViewLayoutDelegate>(this, content->getViewLayoutDelegate<WindowsViewLayoutDelegate>());
 
-			layoutDelegate__->set_defaultHeight(Titanium::UI::LAYOUT::SIZE);
-			layoutDelegate__->set_defaultWidth(Titanium::UI::LAYOUT::SIZE);
-			layoutDelegate__->set_autoLayoutForHeight(Titanium::UI::LAYOUT::SIZE);
-			layoutDelegate__->set_autoLayoutForWidth(Titanium::UI::LAYOUT::SIZE);
+			layoutDelegate__->set_defaultHeight(Titanium::UI::LAYOUT::FILL);
+			layoutDelegate__->set_defaultWidth(Titanium::UI::LAYOUT::FILL);
+			layoutDelegate__->set_autoLayoutForHeight(Titanium::UI::LAYOUT::FILL);
+			layoutDelegate__->set_autoLayoutForWidth(Titanium::UI::LAYOUT::FILL);
 
 			getViewLayoutDelegate<ScrollViewLayoutDelegate>()->setComponent(scroll_viewer__);
 


### PR DESCRIPTION
[TIMOB-23293](https://jira.appcelerator.org/browse/TIMOB-23293)

Corporate Directory App had layout issue. Pushing some improvements:

- ScrollView should fill views
- Label.textAlign should accept "center","left","right"

It still doesn't look very beautiful but pushing since that's not a regression for 5.3.x.

<img width="252" alt="capture" src="https://cloud.githubusercontent.com/assets/1661068/14973309/072a6bda-1121-11e6-8bc0-112abf56df33.PNG">
