### PR TITLE
[TIMOB-23273] Fix initialization of Ti.UI.ImageView imageAsBlob() and imageAsFile()

### DIFF
--- a/Source/UI/src/ImageView.cpp
+++ b/Source/UI/src/ImageView.cpp
@@ -134,6 +134,10 @@ namespace TitaniumWindows
 			// Initialize image
 			if (!get_image().empty()) {
 				set_image(get_image());
+			} else if (get_imageAsBlob()) {
+				set_imageAsBlob(get_imageAsBlob());
+			} else if (get_imageAsFile()) {
+				set_imageAsFile(get_imageAsFile());
 			}
 		}
 


### PR DESCRIPTION
- Add initialization for ``imageAsBlob()`` and ``imageAsFile``

###### TEST CASE
```Javascript
var win = Ti.UI.createWindow({ backgroundColor: 'black' }),
    file = Ti.Filesystem.getFile('Logo.png'),
    imgA = Ti.UI.createImageView({ image: file.read(), top:'33%', width: 200, height: 200 }),
    imgB = Ti.UI.createImageView({ image: 'Logo.png', top:'66%', width: 200, height: 200 });
win.add(imgA);
win.add(imgB);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23273)