### PR TITLE
[TIMOB-23275] Windows: Deprecate Ti.UI.View.enabled, rename to touchEnabled

### DIFF
--- a/Source/Ti/include/TitaniumWindows/API.hpp
+++ b/Source/Ti/include/TitaniumWindows/API.hpp
@@ -42,10 +42,11 @@ namespace TitaniumWindows
 
 		static void JSExportInitialize();
 
+		virtual void log(const std::string& message) const TITANIUM_NOEXCEPT override final;
+
 	protected:
 #pragma warning(push)
 #pragma warning(disable : 4251)
-		virtual void log(const std::string& message) const TITANIUM_NOEXCEPT override final;
 		std::shared_ptr<LogForwarder> logger__;
 #pragma warning(pop)
 

--- a/Source/TitaniumKit/CMakeLists.txt
+++ b/Source/TitaniumKit/CMakeLists.txt
@@ -335,6 +335,8 @@ set(SOURCE_TiLogger_detail
   include/Titanium/detail/TiLoggerPolicyInterface.hpp
   include/Titanium/detail/TiLoggerPolicyConsole.hpp
   include/Titanium/detail/TiLoggerPolicyFile.hpp
+  include/Titanium/detail/TiLoggerPolicyAPI.hpp
+  src/detail/TiLoggerPolicyAPI.cpp
   )
 
 set(SOURCE_App

--- a/Source/TitaniumKit/include/Titanium/API.hpp
+++ b/Source/TitaniumKit/include/Titanium/API.hpp
@@ -10,6 +10,7 @@
 #define _TITANIUM_API_HPP_
 
 #include "Titanium/Module.hpp"
+#include "Titanium/detail/TiBase.hpp"
 
 namespace Titanium
 {
@@ -112,6 +113,7 @@ namespace Titanium
 		  @result void
 		*/
 		virtual void log(const std::string& level, const std::string& message) const TITANIUM_NOEXCEPT final;
+		virtual void log(const std::string& message) const TITANIUM_NOEXCEPT;
 
 		API(const JSContext&) TITANIUM_NOEXCEPT;
 		virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;
@@ -133,9 +135,6 @@ namespace Titanium
 		TITANIUM_FUNCTION_DEF(debug);
 		TITANIUM_FUNCTION_DEF(trace);
 		TITANIUM_FUNCTION_DEF(log);
-
-	protected:
-		virtual void log(const std::string& message) const TITANIUM_NOEXCEPT;
 
 	private:
 		enum class LogSeverityLevel {

--- a/Source/TitaniumKit/include/Titanium/UI/View.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/View.hpp
@@ -19,7 +19,7 @@
 namespace Titanium
 {
 	class Blob;
-	
+
 	namespace UI
 	{
 		using namespace HAL;
@@ -181,7 +181,7 @@ namespace Titanium
 			TITANIUM_PROPERTY_DEF(borderRadius);
 			TITANIUM_PROPERTY_DEF(borderWidth);
 			TITANIUM_PROPERTY_DEF(clipMode);
-			TITANIUM_PROPERTY_DEF(enabled);
+			TITANIUMKIT_DEPRECATED TITANIUM_PROPERTY_DEF(enabled);
 			TITANIUM_PROPERTY_DEF(focusable);
 			TITANIUM_PROPERTY_DEF(opacity);
 			TITANIUM_PROPERTY_DEF(overrideCurrentAnimation);
@@ -318,7 +318,7 @@ namespace Titanium
 
 			TITANIUM_FUNCTION_DEF(insertAt);
 			TITANIUM_FUNCTION_DEF(replaceAt);
-			
+
 			virtual void postInitialize(JSObject& this_object) override;
 			virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;
 			virtual void disableEvent(const std::string& event_name) TITANIUM_NOEXCEPT override;

--- a/Source/TitaniumKit/include/Titanium/UI/View.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/View.hpp
@@ -181,7 +181,7 @@ namespace Titanium
 			TITANIUM_PROPERTY_DEF(borderRadius);
 			TITANIUM_PROPERTY_DEF(borderWidth);
 			TITANIUM_PROPERTY_DEF(clipMode);
-			TITANIUMKIT_DEPRECATED TITANIUM_PROPERTY_DEF(enabled);
+			TITANIUM_PROPERTY_DEF(enabled);
 			TITANIUM_PROPERTY_DEF(focusable);
 			TITANIUM_PROPERTY_DEF(opacity);
 			TITANIUM_PROPERTY_DEF(overrideCurrentAnimation);

--- a/Source/TitaniumKit/include/Titanium/UI/ViewLayoutDelegate.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/ViewLayoutDelegate.hpp
@@ -26,7 +26,7 @@ namespace Titanium
 	{
 		class View;
 		class Animation;
-		
+
 		using namespace HAL;
 
 		class TITANIUMKIT_EXPORT ViewLayoutEventDelegate
@@ -84,7 +84,7 @@ namespace Titanium
 
 			  @discussion Hides the view and it's chldren in the view's hierarchy.
 
-			  @param 
+			  @param
 
 			  @result void
 			*/
@@ -95,9 +95,9 @@ namespace Titanium
 
 			  @abstract show() : void
 
-			  @discussion Causes the view and the view's hierarchy to be displayed. 
+			  @discussion Causes the view and the view's hierarchy to be displayed.
 
-			  @param 
+			  @param
 
 			  @result void
 			*/
@@ -116,27 +116,15 @@ namespace Titanium
 			virtual void set_visible(const bool& visible) TITANIUM_NOEXCEPT;
 
 			/*!
-			  @method
-
-			  @abstract enabled : Boolean
-
-			  @discussion Determines whether the view is enabled.
-
-			  Default: true
-			*/
-			virtual bool get_enabled() const TITANIUM_NOEXCEPT;
-			virtual void set_enabled(const bool& enabled) TITANIUM_NOEXCEPT;
-
-			/*!
 			@method
 
 			@abstract backgroundImage : String
 
 			@discussion Background image for the view, specified as a local file path or URL.
 
-			Default: Default behavior when `backgroundImage` is unspecified depends on the type of view and the platform. 
-			
-			For generic views, no image is used. For most controls (buttons, text fields, and so on), platform-specific default images are used. 
+			Default: Default behavior when `backgroundImage` is unspecified depends on the type of view and the platform.
+
+			For generic views, no image is used. For most controls (buttons, text fields, and so on), platform-specific default images are used.
 			*/
 			virtual std::string get_backgroundImage() const TITANIUM_NOEXCEPT;
 			virtual void set_backgroundImage(const std::string& backgroundImage) TITANIUM_NOEXCEPT;
@@ -665,7 +653,7 @@ namespace Titanium
 			std::string viewShadowColor__;
 			Point viewShadowOffset__;
 			bool horizontalWrap__ { true };
-			
+
 			Point anchorPoint__;
 			Point animatedCenter__;
 

--- a/Source/TitaniumKit/include/Titanium/detail/TiLoggerPolicyAPI.hpp
+++ b/Source/TitaniumKit/include/Titanium/detail/TiLoggerPolicyAPI.hpp
@@ -1,0 +1,50 @@
+/**
+ * TiLoggerPolicyAPI
+ *
+ * Copyright (c) 2016 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License.
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#ifndef _TITANIUM_DETAIL_TILOGGERPOLICYAPI_HPP_
+#define _TITANIUM_DETAIL_TILOGGERPOLICYAPI_HPP_
+
+#include "Titanium/detail/TiLoggerPolicyInterface.hpp"
+#include "HAL/HAL.hpp"
+#include <iostream>
+
+namespace Titanium
+{
+	class API;
+
+	namespace detail
+	{
+		using namespace HAL;
+
+		class TITANIUMKIT_EXPORT TiLoggerPolicyAPI final : public TiLoggerPolicyInterface
+		{
+		public:
+			TiLoggerPolicyAPI(const JSContext& js_context);
+
+			~TiLoggerPolicyAPI() = default;
+			TiLoggerPolicyAPI(const TiLoggerPolicyAPI&) = default;
+			TiLoggerPolicyAPI& operator=(const TiLoggerPolicyAPI&) = default;
+#ifdef TITANIUM_MOVE_CTOR_AND_ASSIGN_DEFAULT_ENABLE
+			TiLoggerPolicyAPI(TiLoggerPolicyAPI&&) = default;
+			TiLoggerPolicyAPI& operator=(TiLoggerPolicyAPI&&) = default;
+#endif
+
+			virtual void Write(const std::string& message) override final;
+
+		private:
+#pragma warning(push)
+#pragma warning(disable : 4251)
+			JSContext js_context__;
+			std::shared_ptr<Titanium::API> api__;
+#pragma warning(pop)
+		};
+
+	} // namespace detail
+}  // namespace Titanium
+
+#endif  // _TITANIUM_DETAIL_TILOGGERPOLICYAPI_HPP_

--- a/Source/TitaniumKit/include/Titanium/detail/TiLoggerPolicyConsole.hpp
+++ b/Source/TitaniumKit/include/Titanium/detail/TiLoggerPolicyConsole.hpp
@@ -19,11 +19,10 @@ namespace Titanium
 		class TITANIUMKIT_EXPORT TiLoggerPolicyConsole final : public TiLoggerPolicyInterface
 		{
 		public:
-			TiLoggerPolicyConsole(const std::string& name)
+			TiLoggerPolicyConsole()
 			{
 			}
 
-			TiLoggerPolicyConsole() = delete;
 			~TiLoggerPolicyConsole() = default;
 			TiLoggerPolicyConsole(const TiLoggerPolicyConsole&) = default;
 			TiLoggerPolicyConsole& operator=(const TiLoggerPolicyConsole&) = default;

--- a/Source/TitaniumKit/src/App/Properties.cpp
+++ b/Source/TitaniumKit/src/App/Properties.cpp
@@ -109,7 +109,7 @@ namespace Titanium
 			if (defaultValue) {
 				return *defaultValue;
 			}
-			return nullptr;
+			return boost::none;
 		}
 
 		bool Properties::hasProperty(const std::string& property) TITANIUM_NOEXCEPT

--- a/Source/TitaniumKit/src/UI/View.cpp
+++ b/Source/TitaniumKit/src/UI/View.cpp
@@ -829,13 +829,13 @@ namespace Titanium
 
 		TITANIUM_PROPERTY_GETTER(View, enabled)
 		{
-			TITANIUM_MODULE_LOG_WARN("Ti.UI.View.enabled property is deprecated. Please use touchEnabled.");
+			TITANIUM_API_LOG_WARN("Ti.UI.View.enabled property is deprecated. Please use touchEnabled.");
 			return js_get_touchEnabled();
 		}
 
 		TITANIUM_PROPERTY_SETTER(View, enabled)
 		{
-			TITANIUM_MODULE_LOG_WARN("Ti.UI.View.enabled property is deprecated. Please use touchEnabled.");
+			TITANIUM_API_LOG_WARN("Ti.UI.View.enabled property is deprecated. Please use touchEnabled.");
 			return js_set_touchEnabled(argument);
 		}
 

--- a/Source/TitaniumKit/src/UI/View.cpp
+++ b/Source/TitaniumKit/src/UI/View.cpp
@@ -1,7 +1,7 @@
 /**
  * TitaniumKit
  *
- * Copyright (c) 2014 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2014-2016 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License.
  * Please see the LICENSE included with this distribution for details.
  */
@@ -35,7 +35,7 @@ namespace Titanium
 
 		void View::postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments)
 		{
-			Titanium::Module::postCallAsConstructor(js_context, arguments);	
+			Titanium::Module::postCallAsConstructor(js_context, arguments);
 			setLayoutDelegate();
 		}
 
@@ -71,12 +71,12 @@ namespace Titanium
 			layoutDelegate__->animate(animation, callback, get_object());
 		}
 
-		void View::blur() 
+		void View::blur()
 		{
 			layoutDelegate__->blur();
 		}
 
-		void View::focus() 
+		void View::focus()
 		{
 			layoutDelegate__->focus();
 		}
@@ -84,7 +84,7 @@ namespace Titanium
 		void View::add(const JSObject& view) TITANIUM_NOEXCEPT
 		{
 			auto view_ptr = view.GetPrivate<View>();
-			
+
 			// For mixing Ti.Ui.View and native view.
 			if (view_ptr == nullptr) {
 				view_ptr = layoutDelegate__->rescueGetView(view);
@@ -555,15 +555,15 @@ namespace Titanium
 				JSValue Titanium_property = get_context().get_global_object().GetProperty("Titanium");
 				TITANIUM_ASSERT(Titanium_property.IsObject());
 				JSObject Titanium = static_cast<JSObject>(Titanium_property);
-					
+
 				JSValue UI_property = Titanium.GetProperty("UI");
 				TITANIUM_ASSERT(UI_property.IsObject());
 				JSObject UI = static_cast<JSObject>(UI_property);
-					
+
 				JSValue Animation_property = UI.GetProperty("Animation");
 				TITANIUM_ASSERT(Animation_property.IsObject());
 				JSObject Animation_Class = static_cast<JSObject>(Animation_property);
-				
+
 				auto instance = Animation_Class.CallAsConstructor();
 				Titanium::Module::applyProperties(object, instance);
 				animation = instance.GetPrivate<Titanium::UI::Animation>();
@@ -610,12 +610,12 @@ namespace Titanium
 			return get_context().CreateUndefined();
 		}
 
-		TITANIUM_PROPERTY_GETTER(View, backgroundImage) 
+		TITANIUM_PROPERTY_GETTER(View, backgroundImage)
 		{
 			return get_context().CreateString(layoutDelegate__->get_backgroundImage());
 		}
 
-		TITANIUM_PROPERTY_SETTER(View, backgroundImage) 
+		TITANIUM_PROPERTY_SETTER(View, backgroundImage)
 		{
 			TITANIUM_ASSERT(argument.IsString());
 			layoutDelegate__->set_backgroundImage(static_cast<std::string>(argument));
@@ -688,7 +688,7 @@ namespace Titanium
 			layoutDelegate__->set_center(js_to_Point(static_cast<JSObject>(argument)));
 			return true;
 		}
-		
+
 		TITANIUM_PROPERTY_GETTER(View, center)
 		{
 			return Point_to_js(get_context(), layoutDelegate__->get_center());
@@ -829,14 +829,14 @@ namespace Titanium
 
 		TITANIUM_PROPERTY_GETTER(View, enabled)
 		{
-			return get_context().CreateBoolean(layoutDelegate__->get_enabled());
+			TITANIUM_MODULE_LOG_WARN("Ti.UI.View.enabled property is deprecated. Please use touchEnabled.");
+			return js_get_touchEnabled();
 		}
 
 		TITANIUM_PROPERTY_SETTER(View, enabled)
 		{
-			TITANIUM_ASSERT(argument.IsBoolean());
-			layoutDelegate__->set_enabled(static_cast<bool>(argument));
-			return true;
+			TITANIUM_MODULE_LOG_WARN("Ti.UI.View.enabled property is deprecated. Please use touchEnabled.");
+			return js_set_touchEnabled(argument);
 		}
 
 		TITANIUM_PROPERTY_GETTER(View, width)
@@ -851,12 +851,12 @@ namespace Titanium
 			return true;
 		}
 
-		TITANIUM_PROPERTY_GETTER(View, zIndex) 
+		TITANIUM_PROPERTY_GETTER(View, zIndex)
 		{
 			return get_context().CreateNumber(layoutDelegate__->get_zIndex());
 		}
 
-		TITANIUM_PROPERTY_SETTER(View, zIndex) 
+		TITANIUM_PROPERTY_SETTER(View, zIndex)
 		{
 			TITANIUM_ASSERT(argument.IsNumber());
 			layoutDelegate__->set_zIndex(static_cast<std::int32_t>(argument));

--- a/Source/TitaniumKit/src/UI/ViewLayoutDelegate.cpp
+++ b/Source/TitaniumKit/src/UI/ViewLayoutDelegate.cpp
@@ -20,7 +20,6 @@ namespace Titanium
 			borderWidth__(0),
 			touchEnabled__(true),
 			visible__(true),
-			enabled__(true),
 			defaultWidth__(Titanium::UI::LAYOUT::SIZE),
 			defaultHeight__(Titanium::UI::LAYOUT::SIZE),
 			autoLayoutForHeight__(defaultHeight__),
@@ -29,7 +28,7 @@ namespace Titanium
 			TITANIUM_LOG_DEBUG("ViewLayoutDelegate::ctor ", this);
 		}
 
-		ViewLayoutDelegate::~ViewLayoutDelegate() 
+		ViewLayoutDelegate::~ViewLayoutDelegate()
 		{
 			TITANIUM_LOG_DEBUG("ViewLayoutDelegate::dtor ", this, " with ", children__.size(), " children");
 		}
@@ -307,16 +306,6 @@ namespace Titanium
 			visible__ = visible;
 		}
 
-		bool ViewLayoutDelegate::get_enabled() const TITANIUM_NOEXCEPT
-		{
-			return enabled__;
-		}
-
-		void ViewLayoutDelegate::set_enabled(const bool& enabled) TITANIUM_NOEXCEPT
-		{
-			enabled__ = enabled;
-		}
-
 		std::string ViewLayoutDelegate::get_tintColor() const TITANIUM_NOEXCEPT
 		{
 			return tintColor__;
@@ -491,14 +480,14 @@ namespace Titanium
 		{
 			TITANIUM_LOG_WARN("ViewLayoutDelegate::disableEvent: Unimplemented");
 		}
-		
+
 		void ViewLayoutDelegate::enableEvent(const std::string& event_name) TITANIUM_NOEXCEPT
 		{
 			TITANIUM_LOG_WARN("ViewLayoutDelegate::enableEvent: Unimplemented");
 		}
 
 		ViewLayoutEventDelegate::ViewLayoutEventDelegate(View* view) TITANIUM_NOEXCEPT :
-			view__(view)	
+			view__(view)
 		{
 
 		}
@@ -512,7 +501,7 @@ namespace Titanium
 		{
 			return view__->get_context();
 		}
-		
+
 		void ViewLayoutEventDelegate::fireEvent(const std::string& name, const JSObject& e)
 		{
 			view__->fireEvent(name, e);

--- a/Source/TitaniumKit/src/detail/TiLoggerPolicyAPI.cpp
+++ b/Source/TitaniumKit/src/detail/TiLoggerPolicyAPI.cpp
@@ -16,7 +16,7 @@ namespace Titanium
 		TiLoggerPolicyAPI::TiLoggerPolicyAPI(const JSContext& js_context) :
 			js_context__(js_context)
 		{
-			auto api = js_context__.JSEvaluateScript("Ti.API");
+			auto api = js_context__.JSEvaluateScript("Titanium.API");
 			if (api.IsObject()) {
 				api__ = static_cast<JSObject>(api).GetPrivate<Titanium::API>();
 			}

--- a/Source/TitaniumKit/src/detail/TiLoggerPolicyAPI.cpp
+++ b/Source/TitaniumKit/src/detail/TiLoggerPolicyAPI.cpp
@@ -1,0 +1,35 @@
+/**
+ * TiLoggerPolicyAPI
+ *
+ * Copyright (c) 2016 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License.
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#include "Titanium/detail/TiLoggerPolicyAPI.hpp"
+#include "Titanium/API.hpp"
+
+namespace Titanium
+{
+	namespace detail
+	{
+		TiLoggerPolicyAPI::TiLoggerPolicyAPI(const JSContext& js_context) :
+			js_context__(js_context)
+		{
+			auto api = js_context__.JSEvaluateScript("Ti.API");
+			if (api.IsObject()) {
+				api__ = static_cast<JSObject>(api).GetPrivate<Titanium::API>();
+			}
+		}
+
+		void TiLoggerPolicyAPI::Write(const std::string& message)
+		{
+			if (api__) {
+				api__->log(message);
+			} else {
+				// defaults to std::clog
+				std::clog << message << std::endl;
+			}
+		}
+	} // namespace detail
+}  // namespace Titanium

--- a/Source/TitaniumKit/src/detail/TiLoggerPolicyAPI.cpp
+++ b/Source/TitaniumKit/src/detail/TiLoggerPolicyAPI.cpp
@@ -16,9 +16,13 @@ namespace Titanium
 		TiLoggerPolicyAPI::TiLoggerPolicyAPI(const JSContext& js_context) :
 			js_context__(js_context)
 		{
-			auto api = js_context__.JSEvaluateScript("Titanium.API");
-			if (api.IsObject()) {
-				api__ = static_cast<JSObject>(api).GetPrivate<Titanium::API>();
+			try {
+				auto api = js_context__.JSEvaluateScript("Titanium.API");
+				if (api.IsObject()) {
+					api__ = static_cast<JSObject>(api).GetPrivate<Titanium::API>();
+				}
+			} catch (...) {
+				// make sure logging does not throw any exception
 			}
 		}
 

--- a/Source/UI/include/TitaniumWindows/UI/View.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/View.hpp
@@ -41,20 +41,17 @@ namespace TitaniumWindows
 			TITANIUM_PROPERTY_UNIMPLEMENTED(backgroundLeftCap);
 			TITANIUM_PROPERTY_UNIMPLEMENTED(backgroundTopCap);
 			TITANIUM_PROPERTY_UNIMPLEMENTED(clipMode);
-			TITANIUM_PROPERTY_UNIMPLEMENTED(enabled);
 			TITANIUM_PROPERTY_UNIMPLEMENTED(focusable);
 			TITANIUM_PROPERTY_UNIMPLEMENTED(overrideCurrentAnimation);
 			TITANIUM_PROPERTY_UNIMPLEMENTED(pullBackgroundColor);
 			TITANIUM_PROPERTY_UNIMPLEMENTED(softKeyboardOnFocus);
 			TITANIUM_PROPERTY_UNIMPLEMENTED(tintColor);
-			TITANIUM_PROPERTY_UNIMPLEMENTED(touchEnabled);
 			TITANIUM_PROPERTY_UNIMPLEMENTED(transform);
 			TITANIUM_PROPERTY_UNIMPLEMENTED(viewShadowRadius);
 			TITANIUM_PROPERTY_UNIMPLEMENTED(viewShadowColor);
 			TITANIUM_PROPERTY_UNIMPLEMENTED(viewShadowOffset);
 			TITANIUM_PROPERTY_UNIMPLEMENTED(horizontalWrap);
 			TITANIUM_PROPERTY_UNIMPLEMENTED(keepScreenOn);
-			TITANIUM_FUNCTION_UNIMPLEMENTED(convertPointToView);
 
 			// Implemented, works with some components which uses Xaml.Controls.Control
 			// But it doesn't work on TI.UI.View because it's Xaml.Controls.Panel

--- a/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
@@ -147,7 +147,7 @@ namespace TitaniumWindows
 
 			  Default: true
 			*/
-			virtual void set_enabled(const bool& enabled) TITANIUM_NOEXCEPT override;
+			virtual void set_touchEnabled(const bool& enabled) TITANIUM_NOEXCEPT override;
 
 			/*!
 			  @method
@@ -286,7 +286,7 @@ namespace TitaniumWindows
 			  This is an input property for specifying where the view should be positioned, and does not represent the view's calculated position.
 			*/
 			virtual void set_top(const std::string& top) TITANIUM_NOEXCEPT override;
-			
+
 			/*!
 			  @method
 
@@ -436,7 +436,7 @@ namespace TitaniumWindows
 			virtual Titanium::LayoutEngine::Node* getLayoutNode() const TITANIUM_NOEXCEPT
 			{
 				return layout_node__;
-			}	
+			}
 
 			virtual bool isLoaded() const TITANIUM_NOEXCEPT
 			{
@@ -447,7 +447,7 @@ namespace TitaniumWindows
 
 			// compute its fixed size when either width or height (not both) is Ti.UI.SIZE
 			virtual Titanium::LayoutEngine::Rect computeRelativeSize(const double& x, const double& y,  const double& baseWidth, const double& baseHeight);
- 
+
 			static Windows::UI::Color ColorForName(const std::string& colorName);
 			static Windows::UI::Color ColorForHexCode(const std::string& hexCode);
 

--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -161,7 +161,7 @@ namespace TitaniumWindows
 				try {
 					auto nativeView = dynamic_cast<Controls::Panel^>(component__);
 					nativeView->Children->Append(nativeChildView);
-					newView->set_enabled(get_enabled() && newView->get_enabled());
+					newView->set_touchEnabled(get_touchEnabled() && newView->get_touchEnabled());
 				} catch (Platform::Exception^ e) {
 					detail::ThrowRuntimeError("add", Utility::ConvertString(e->Message));
 				}
@@ -248,7 +248,7 @@ namespace TitaniumWindows
 						// write encoded PNG stream to PNG buffer
 						concurrency::create_task(pngStream->ReadAsync(pngBuffer, pngBuffer->Capacity, Windows::Storage::Streams::InputStreamOptions::None)).then(
 							[this_object, callback, pngBuffer](IBuffer^) {
-								
+
 								// create Titanium.Blob from PNG buffer
 								const auto blob = this_object.get_context().CreateObject(JSExport<Titanium::Blob>::Class()).CallAsConstructor();
 								const auto blob_ptr = blob.GetPrivate<Titanium::Blob>();
@@ -594,7 +594,7 @@ namespace TitaniumWindows
 
 				//
 				// Make sure to update the position of the view because StoryBoard doesn't change actual position of it.
-				// 
+				//
 				const auto top = animation->get_top();
 				if (top) {
 					setLayoutProperty(Titanium::LayoutEngine::ValueName::Top, std::to_string(*top));
@@ -732,7 +732,7 @@ namespace TitaniumWindows
 
 		void WindowsViewLayoutDelegate::updateDisabledBackground()
 		{
-			if (get_enabled()) {
+			if (get_touchEnabled()) {
 				if (previousBackgroundBrush__ != nullptr) {
 					updateBackground(previousBackgroundBrush__);
 				}
@@ -761,7 +761,7 @@ namespace TitaniumWindows
 		{
 			Titanium::UI::ViewLayoutDelegate::set_backgroundImage(backgroundImage);
 			backgroundImageBrush__ = CreateImageBrushFromPath(backgroundImage);
-			if (get_enabled()) {
+			if (get_touchEnabled()) {
 				updateBackground(backgroundImageBrush__);
 			}
 		}
@@ -770,7 +770,7 @@ namespace TitaniumWindows
 		{
 			Titanium::UI::ViewLayoutDelegate::set_backgroundImage("");
 			backgroundImageBrush__ = CreateImageBrushFromBlob(backgroundImage);
-			if (get_enabled()) {
+			if (get_touchEnabled()) {
 				updateBackground(backgroundImageBrush__);
 			}
 		}
@@ -780,7 +780,7 @@ namespace TitaniumWindows
 			Titanium::UI::ViewLayoutDelegate::set_backgroundColor(backgroundColor);
 
 			backgroundColorBrush__ = ref new Media::SolidColorBrush(ColorForName(backgroundColor));
-			if (get_enabled()) {
+			if (get_touchEnabled()) {
 				updateBackground(backgroundColorBrush__);
 			}
 		}
@@ -846,7 +846,7 @@ namespace TitaniumWindows
 			borderColorBrush__ = ref new SolidColorBrush(ColorForName(color));
 
 			if (is_control__ || underlying_control__) {
-				// Xaml::Control descendant has its own border property. 
+				// Xaml::Control descendant has its own border property.
 				// Use it then, it usually works better than Xaml::Border. Note that it doesn't support border radius though...
 				const auto control = underlying_control__ ? underlying_control__ : dynamic_cast<Control^>(component__);
 				control->BorderBrush = borderColorBrush__;
@@ -915,9 +915,9 @@ namespace TitaniumWindows
 			setLayoutProperty(Titanium::LayoutEngine::ValueName::CenterY, std::to_string(center.y));
 		}
 
-		void WindowsViewLayoutDelegate::set_enabled(const bool& enabled) TITANIUM_NOEXCEPT
+		void WindowsViewLayoutDelegate::set_touchEnabled(const bool& enabled) TITANIUM_NOEXCEPT
 		{
-			Titanium::UI::ViewLayoutDelegate::set_enabled(enabled);
+			Titanium::UI::ViewLayoutDelegate::set_touchEnabled(enabled);
 			if (is_control__ || underlying_control__) {
 				if (underlying_control__) {
 					underlying_control__->IsEnabled = enabled;
@@ -928,7 +928,7 @@ namespace TitaniumWindows
 			updateDisabledBackground();
 
 			for (auto child : get_children()) {
-				child->getViewLayoutDelegate()->set_enabled(enabled);
+				child->getViewLayoutDelegate()->set_touchEnabled(enabled);
 			}
 		}
 
@@ -1177,7 +1177,7 @@ namespace TitaniumWindows
 
 		void WindowsViewLayoutDelegate::setDefaultBackground()
 		{
-			if (get_enabled()) {
+			if (get_touchEnabled()) {
 				if (backgroundImageBrush__) {
 					updateBackground(backgroundImageBrush__);
 				} else if (backgroundColorBrush__) {

--- a/Source/Utility/include/TitaniumWindows/LogForwarder.hpp
+++ b/Source/Utility/include/TitaniumWindows/LogForwarder.hpp
@@ -61,11 +61,10 @@ namespace TitaniumWindows
 	class TiLoggerPolicyAsyncLogRelay final : public Titanium::detail::TiLoggerPolicyInterface
 	{
 	public:
-		TiLoggerPolicyAsyncLogRelay(const std::string& name)
+		TiLoggerPolicyAsyncLogRelay()
 		{
 		}
 
-		TiLoggerPolicyAsyncLogRelay()  = delete;
 		~TiLoggerPolicyAsyncLogRelay() = default;
 		TiLoggerPolicyAsyncLogRelay(const TiLoggerPolicyAsyncLogRelay&) = default;
 		TiLoggerPolicyAsyncLogRelay& operator=(const TiLoggerPolicyAsyncLogRelay&) = default;
@@ -84,11 +83,10 @@ namespace TitaniumWindows
 	class TiLoggerPolicyAsyncBackgroundLogRelay final : public Titanium::detail::TiLoggerPolicyInterface
 	{
 	public:
-		TiLoggerPolicyAsyncBackgroundLogRelay(const std::string& name)
+		TiLoggerPolicyAsyncBackgroundLogRelay()
 		{
 		}
 
-		TiLoggerPolicyAsyncBackgroundLogRelay()  = delete;
 		~TiLoggerPolicyAsyncBackgroundLogRelay() = default;
 		TiLoggerPolicyAsyncBackgroundLogRelay(const TiLoggerPolicyAsyncBackgroundLogRelay&) = default;
 		TiLoggerPolicyAsyncBackgroundLogRelay& operator=(const TiLoggerPolicyAsyncBackgroundLogRelay&) = default;


### PR DESCRIPTION
#666 + Add `TITANIUM_API_LOG` to enable output to log relay from TitaniumKit. Note that `TITANIUM_API_LOG` is available only where `get_context()` can be used.