### PR TITLE
Fix: "no matching function to call transform" on VS 2015

### DIFF
--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -1611,7 +1611,7 @@ namespace TitaniumWindows
 		inline std::string toLowerCase(const std::string& string)
 		{
 			std::string copy(string);
-			std::transform(string.begin(), string.end(), copy.begin(), std::tolower);
+			std::transform(string.begin(), string.end(), copy.begin(), tolower);
 			return copy;
 		}
 


### PR DESCRIPTION
I have experienced `no matching function to call std::transform` compile error for UWP 10.0 app project on freshly-installed Windows 10 + Visual Studio 2015. It looks like we have a workaround (See thread in [stackoverflow](http://stackoverflow.com/questions/7131858/stdtransform-and-toupper-no-matching-function) for details) and see how it goes.