### PR TITLE
[5_3_X][TIMOB-23278] Windows: Ti.Map does not use the region when specified on Windows 10

### DIFF
--- a/Source/Map/src/View.cpp
+++ b/Source/Map/src/View.cpp
@@ -119,7 +119,7 @@ namespace TitaniumWindows
 		{
 			Titanium::Map::View::set_region(region);
 
-#if defined(IS_WINDOWS_PHONE)
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			using namespace Windows::Devices::Geolocation;
 
 			// set center to supplied lat/long


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-23278

Once merged, this needs to be cherry-picked over to master