### PR TITLE
[TIMOB-23349] Fix: Closing Windows via Ti.UI.Tab.open() does not work

### DIFF
--- a/Source/TitaniumKit/include/Titanium/UI/Window.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/Window.hpp
@@ -21,6 +21,7 @@ namespace Titanium
 
 		class OpenWindowParams;
 		class CloseWindowParams;
+		class Tab;
 
 		/*!
 		  @class
@@ -45,11 +46,6 @@ namespace Titanium
 			*/
 			virtual void close(const std::shared_ptr<CloseWindowParams>& params) TITANIUM_NOEXCEPT;
 
-			/*
-			 * Closes the view of the Window, used by Ti.UI.TabGroup 
-			*/
-			virtual void closeAsView();
-
 			/*!
 			  @method
 
@@ -63,11 +59,6 @@ namespace Titanium
 			  @result void
 			*/
 			virtual void open(const std::shared_ptr<OpenWindowParams>& params) TITANIUM_NOEXCEPT;
-
-			/*
-			* Opens the view of the Window, used by Ti.UI.TabGroup
-			*/
-			virtual void openAsView();
 
 			/*!
 			  @method
@@ -233,6 +224,16 @@ namespace Titanium
 			*/
 			TITANIUM_PROPERTY_IMPL_DEF(bool, translucent);
 
+			/*!
+			@method
+
+			@abstract tab : Tab
+
+			@discussion Tab that attaches this Window
+			*/
+			TITANIUM_PROPERTY_IMPL_DEF(std::shared_ptr<Tab>, tab);
+
+
 			Window(const JSContext&) TITANIUM_NOEXCEPT;
 
 			virtual ~Window() TITANIUM_NOEXCEPT;  //= default;
@@ -316,6 +317,8 @@ namespace Titanium
 
 			JSObject openWindowParams_ctor__;
 			JSObject closeWindowParams_ctor__;
+
+			std::shared_ptr<Tab> tab__;
 #pragma warning(pop)
 		};
 	} // namespace UI

--- a/Source/TitaniumKit/src/UI/Tab.cpp
+++ b/Source/TitaniumKit/src/UI/Tab.cpp
@@ -70,7 +70,8 @@ namespace Titanium
 		void Tab::open(const std::shared_ptr<OpenWindowParams>& options) TITANIUM_NOEXCEPT
 		{
 			if (window__) {
-				window__->openAsView();
+				window__->set_tab(get_object().GetPrivate<Tab>());
+				window__->open(options);
 			} else {
 				TITANIUM_LOG_WARN("Tab::open() failed: no window is attached");
 			}
@@ -85,7 +86,7 @@ namespace Titanium
 		void Tab::close(const std::shared_ptr<CloseWindowParams>& options) TITANIUM_NOEXCEPT
 		{
 			if (window__) {
-				window__->closeAsView();
+				window__->close(options);
 			} else {
 				TITANIUM_LOG_WARN("Tab::close() failed: no window is attached");
 			}

--- a/Source/TitaniumKit/src/UI/Window.cpp
+++ b/Source/TitaniumKit/src/UI/Window.cpp
@@ -10,6 +10,7 @@
 #include "Titanium/UIModule.hpp"
 #include "Titanium/UI/OpenWindowParams.hpp"
 #include "Titanium/UI/CloseWindowParams.hpp"
+#include "Titanium/UI/Tab.hpp"
 #include "Titanium/detail/TiImpl.hpp"
 
 #define GET_UI() \
@@ -38,7 +39,8 @@ namespace Titanium
 		      navTintColor__(""),
 		      orientationModes__(),
 		      theme__(""),
-		      translucent__(false)
+		      translucent__(false),
+		      tab__(nullptr)
 		{
 			TITANIUM_LOG_DEBUG("Window:: ctor ", this);
 		}
@@ -50,6 +52,7 @@ namespace Titanium
 
 		void Window::close(const std::shared_ptr<CloseWindowParams>& params) TITANIUM_NOEXCEPT
 		{
+			tab__ = nullptr;
 		}
 
 		void Window::open(const std::shared_ptr<OpenWindowParams>& params) TITANIUM_NOEXCEPT
@@ -57,16 +60,6 @@ namespace Titanium
 			GET_UI();
 			const auto ui_ptr = UI.GetPrivate<Titanium::UIModule>();
 			ui_ptr->set_currentWindow(this->get_object().GetPrivate<Titanium::UI::Window>());
-		}
-
-		void Window::closeAsView()
-		{
-			fireEvent("close");
-		}
-
-		void Window::openAsView()
-		{
-			fireEvent("open");
 		}
 
 		TITANIUM_PROPERTY_READWRITE(Window, bool, exitOnClose)
@@ -81,6 +74,7 @@ namespace Titanium
 		TITANIUM_PROPERTY_READWRITE(Window, TitleAttributesParams, titleAttributes)
 		TITANIUM_PROPERTY_READWRITE(Window, bool, translucent)
 		TITANIUM_PROPERTY_READWRITE(Window, std::string, barColor)
+		TITANIUM_PROPERTY_READWRITE(Window, std::shared_ptr<Tab>, tab)
 
 		void Window::JSExportInitialize()
 		{

--- a/Source/UI/include/TitaniumWindows/UI/Tab.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/Tab.hpp
@@ -20,6 +20,8 @@ namespace TitaniumWindows
 	{
 		using namespace HAL;
 
+		class Window;
+
 		/*!
 		  @class Tab
 		  @ingroup Titanium.UI.Tab
@@ -65,14 +67,25 @@ namespace TitaniumWindows
 			virtual void blur()  override;
 			virtual void focus() override;
 
+			void openWindow(const std::shared_ptr<Window>& window);
+			void closeWindow(const std::shared_ptr<Window>& window);
+
+			bool isLastWindow() 
+			{
+				return (window_stack__.size() == 0);
+			}
 		private:
 			void set_titleColorByState();
+#pragma warning(push)
+#pragma warning(disable : 4251)
+			std::vector<std::shared_ptr<Window>> window_stack__;
 #if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			Windows::UI::Xaml::Controls::PivotItem^ pivotItem__;
 			Windows::UI::Xaml::Media::Brush^ defaultForeground__;
 #else
 			Windows::UI::Xaml::Controls::Grid^  grid__;
 #endif
+#pragma warning(pop)
 		};
 	}  // namespace UI
 }  // namespace TitaniumWindows

--- a/Source/UI/include/TitaniumWindows/UI/Window.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/Window.hpp
@@ -12,6 +12,7 @@
 #include "TitaniumWindows_UI_EXPORT.h"
 #include "Titanium/UI/Window.hpp"
 #include "TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp"
+#include "TitaniumWindows/WindowsMacros.hpp"
 
 namespace TitaniumWindows
 {
@@ -88,15 +89,14 @@ namespace TitaniumWindows
 
 			virtual std::shared_ptr<TitaniumWindows::UI::WindowsXaml::CommandBar> getBottomAppBar() TITANIUM_NOEXCEPT;
 
-			virtual void enableEvents()  TITANIUM_NOEXCEPT override;
-			virtual void disableEvents() TITANIUM_NOEXCEPT override;
-
-			virtual void enableEvent(const std::string& event_name) TITANIUM_NOEXCEPT override;
-			virtual void disableEvent(const std::string& event_name) TITANIUM_NOEXCEPT override;
-
 			void updateWindowsCommandBar(const std::shared_ptr<TitaniumWindows::UI::WindowsXaml::CommandBar>& commandbar);
-			void updateWindowSize() TITANIUM_NOEXCEPT;
 
+#if defined(IS_WINDOWS_10)
+			void updateWindowSize() TITANIUM_NOEXCEPT;
+#endif
+
+			static void SetActiveTabWindow(const std::shared_ptr<TitaniumWindows::UI::Window>& window);
+			static void ExitApp(const JSContext& js_context);
 		private:
 #pragma warning(push)
 #pragma warning(disable : 4251)
@@ -104,8 +104,6 @@ namespace TitaniumWindows
 			static std::vector<std::shared_ptr<Window>> window_stack__;
 			std::shared_ptr<TitaniumWindows::UI::WindowsXaml::CommandBar> bottomAppBar__;
 			Windows::Foundation::EventRegistrationToken backpressed_event__;
-			bool is_custom_backpress_event__ { false };
-			bool is_window_event_active__ { false };
 			bool is_tabgroup_container__ { false };
 #pragma warning(pop)
 		};

--- a/Source/UI/src/Tab.cpp
+++ b/Source/UI/src/Tab.cpp
@@ -30,7 +30,7 @@ namespace TitaniumWindows
 
 		void Tab::postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments)
 		{
-			Titanium::UI::Tab::postCallAsConstructor(js_context, arguments);	
+			Titanium::UI::Tab::postCallAsConstructor(js_context, arguments);
 
 #if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			pivotItem__ = ref new PivotItem();
@@ -54,6 +54,35 @@ namespace TitaniumWindows
 #else
 
 #endif
+		}
+
+		void Tab::openWindow(const std::shared_ptr<Window>& window)
+		{
+			window_stack__.push_back(window);
+		}
+
+		void Tab::closeWindow(const std::shared_ptr<Window>& window)
+		{
+			if (window_stack__.size() == 1) {
+				window_stack__.pop_back();
+			} else if (window_stack__.size() > 1) {
+				const auto top_window = window_stack__.back();
+				const auto is_top_window = (top_window.get() == window.get());
+				if (is_top_window) {
+					window_stack__.pop_back();
+					const auto next_window = window_stack__.back();
+					set_window(next_window);
+					next_window->focus();
+				} else {
+					// Window is not on top. Just closing it then.
+					for (std::size_t i = 0; i < window_stack__.size(); i++) {
+						if (window_stack__.at(i).get() == window.get()) {
+							window_stack__.erase(window_stack__.begin() + i);
+							break;
+						}
+					}
+				}
+			}
 		}
 
 		void Tab::set_window(const std::shared_ptr<Titanium::UI::Window>& window) TITANIUM_NOEXCEPT

--- a/Source/UI/src/Window.cpp
+++ b/Source/UI/src/Window.cpp
@@ -10,7 +10,6 @@
 #include "Titanium/App.hpp"
 #include "Titanium/detail/TiImpl.hpp"
 #include "Titanium/UIModule.hpp"
-#include "TitaniumWindows/WindowsMacros.hpp"
 #include <windows.h>
 #include "TitaniumWindows/UI/View.hpp"
 #include "TitaniumWindows/UI/Windows/CommandBar.hpp"
@@ -22,6 +21,7 @@ namespace TitaniumWindows
 	namespace UI
 	{
 		using namespace Windows::Foundation;
+		using namespace Windows::UI::Core;
 
 		std::vector<std::shared_ptr<Window>> Window::window_stack__;
 
@@ -45,27 +45,43 @@ namespace TitaniumWindows
 			// Don't set Border to Xaml Frame content, otherwise you'll see runtime exception.
 			getViewLayoutDelegate<WindowsViewLayoutDelegate>()->setComponent(canvas__, nullptr, false);
 
+#if defined(IS_WINDOWS_10)
 			const auto rootFrame = dynamic_cast<Windows::UI::Xaml::Controls::Frame^>(Windows::UI::Xaml::Window::Current->Content);
 			rootFrame->Navigated += ref new Windows::UI::Xaml::Navigation::NavigatedEventHandler([this](Platform::Object^, Windows::UI::Xaml::Navigation::NavigationEventArgs^) {
-				updateWindowSize();
-			});
-
-#if defined(IS_WINDOWS_PHONE)
-			using namespace Windows::Phone::UI::Input;
-
-			backpressed_event__ = HardwareButtons::BackPressed += ref new EventHandler<BackPressedEventArgs^>([this](Platform::Object ^sender, BackPressedEventArgs ^e) {
-				if (is_window_event_active__) {
-					// close current window when there's no back button listener
-					if (is_custom_backpress_event__) {
-						fireEvent("windows:back");
-					} else {
-						close(nullptr);
-					}
-					e->Handled = true;
+				// Resizing Window should be available only on Windows 10 Store App
+				if (!IS_WINDOWS_MOBILE) {
+					updateWindowSize();
 				}
+				// Update back button visibility. Note that back button is available on Store App too.
+				SystemNavigationManager::GetForCurrentView()->AppViewBackButtonVisibility = AppViewBackButtonVisibility::Visible;
 			});
 #endif
-		}
+
+#if defined(IS_WINDOWS_10) || defined(IS_WINDOWS_PHONE)
+			// Setup back button press event
+			static std::once_flag of;
+			std::call_once(of, [this]() {
+#if defined(IS_WINDOWS_10)
+				SystemNavigationManager::GetForCurrentView()->BackRequested += ref new EventHandler<BackRequestedEventArgs^>([](Platform::Object^ sender, BackRequestedEventArgs^ e) {
+#elif defined(IS_WINDOWS_PHONE)
+				using namespace Windows::Phone::UI::Input;
+				backpressed_event__ = HardwareButtons::BackPressed += ref new EventHandler<BackPressedEventArgs^>([](Platform::Object ^sender, BackPressedEventArgs ^e) {
+#endif
+					if (TitaniumWindows::UI::Window::window_stack__.size() > 0) {
+						// Issue back event on the top window
+						const auto top_window = TitaniumWindows::UI::Window::window_stack__.back();
+
+						// For backward complatibility, we fires "windows:back" as well as "back".
+						top_window->fireEvent("windows:back");
+						top_window->fireEvent("back");
+
+						top_window->close(nullptr);
+					}
+					e->Handled = true;
+				});
+			});	
+#endif
+	}
 
 		Window::~Window() 
 		{
@@ -120,14 +136,30 @@ namespace TitaniumWindows
 		void Window::focus() 
 		{
 			updateWindowsCommandBar(getBottomAppBar());
+
+			SetActiveTabWindow(get_object().GetPrivate<Window>());
+
 			// Xaml Canvas doesn't actually fire GotFocus. Let's fire Ti event manually
 			fireEvent("focus");
 		}
 
+		void Window::SetActiveTabWindow(const std::shared_ptr<TitaniumWindows::UI::Window>& window)
+		{
+			// Tracking Window of active Tab
+			if (window->tab__) {
+				// Current Window of active Tab will be always on top of the stack
+				if (window_stack__.size() > 0) {
+					const auto top_window = window_stack__.back();
+					if (top_window->tab__) {
+						window_stack__.pop_back();
+					}
+				}
+				window_stack__.push_back(window);
+			}
+		}
+
 		void Window::close(const std::shared_ptr<Titanium::UI::CloseWindowParams>& params) TITANIUM_NOEXCEPT
 		{
-			Titanium::UI::Window::close(params);
-
 			// Fire blur & close event on this window
 			blur();
 			fireEvent("close");
@@ -135,7 +167,14 @@ namespace TitaniumWindows
 			// disable all events further because it doesn't make sense.
 			disableEvents();
 
-			const auto rootFrame = dynamic_cast<Windows::UI::Xaml::Controls::Frame^>(Windows::UI::Xaml::Window::Current->Content);
+			bool is_last_window = false;
+			if (tab__) {
+				const auto tab = std::dynamic_pointer_cast<Tab>(tab__);
+				tab->closeWindow(get_object().GetPrivate<Window>());
+				is_last_window = tab->isLastWindow();
+				tab__ = nullptr;
+			}
+
 			const auto top_window = window_stack__.back();
 			const auto is_top_window = (top_window.get() == this); // check if window.close has been issued onto the top window
 
@@ -165,45 +204,58 @@ namespace TitaniumWindows
 
 				} else {
 					window_stack__.pop_back();
-					rootFrame->GoBack();
-					
 					const auto next_window = window_stack__.back();
 
-					try {
-						rootFrame->Navigate(Windows::UI::Xaml::Controls::Page::typeid);
-						auto page = dynamic_cast<Windows::UI::Xaml::Controls::Page^>(rootFrame->Content);
-						page->Content = next_window->getComponent();
-					} catch (Platform::COMException^ e) {
-						// This may happen when current window is not actually opened yet. In this case we just can skip it.
-						// TODO: Is there any way to avoid this exception by checking if page content is valid?
-						TITANIUM_LOG_ERROR("Window.close: failed to set content for the new Window");
+					if (is_last_window) {
+						ExitApp(get_context());
+						return;
+					} else {
+						const auto rootFrame = dynamic_cast<Windows::UI::Xaml::Controls::Frame^>(Windows::UI::Xaml::Window::Current->Content);
+						rootFrame->GoBack();
+
+						try {
+							rootFrame->Navigate(Windows::UI::Xaml::Controls::Page::typeid);
+							auto page = dynamic_cast<Windows::UI::Xaml::Controls::Page^>(rootFrame->Content);
+							page->Content = next_window->getComponent();
+						} catch (Platform::COMException^ e) {
+							// This may happen when current window is not actually opened yet. In this case we just can skip it.
+							// TODO: Is there any way to avoid this exception by checking if page content is valid?
+							TITANIUM_LOG_ERROR("Window.close: failed to set content for the new Window");
+						}
 					}
 
 					// start accepting events for the new Window
 					next_window->enableEvents();
 					next_window->focus();
 				}
+
+				Titanium::UI::Window::close(params);
 			} else if (is_top_window) {
-				JSValue Titanium_property = get_context().get_global_object().GetProperty("Titanium");
-				TITANIUM_ASSERT(Titanium_property.IsObject());
-				JSObject Titanium = static_cast<JSObject>(Titanium_property);
-				JSValue App_property = Titanium.GetProperty("App");
-				TITANIUM_ASSERT(App_property.IsObject());
-				std::shared_ptr<Titanium::AppModule> App = static_cast<JSObject>(App_property).GetPrivate<Titanium::AppModule>();
-
-				// fire pause events
-				App->fireEvent("pause");
-				App->fireEvent("paused");
-
-				// exit the app because there's no window to navigate back
-				window_stack__.clear();
-				Windows::UI::Xaml::Application::Current->Exit();
+				ExitApp(get_context());
 			}
 		}
 
+		void Window::ExitApp(const JSContext& js_context) 
+		{
+			JSValue Titanium_property = js_context.get_global_object().GetProperty("Titanium");
+			TITANIUM_ASSERT(Titanium_property.IsObject());
+			JSObject Titanium = static_cast<JSObject>(Titanium_property);
+			JSValue App_property = Titanium.GetProperty("App");
+			TITANIUM_ASSERT(App_property.IsObject());
+			std::shared_ptr<Titanium::AppModule> App = static_cast<JSObject>(App_property).GetPrivate<Titanium::AppModule>();
+
+			// fire pause events
+			App->fireEvent("pause");
+			App->fireEvent("paused");
+
+			// exit the app because there's no window to navigate back
+			window_stack__.clear();
+			Windows::UI::Xaml::Application::Current->Exit();
+		}
+
+#if defined(IS_WINDOWS_10)
 		void Window::updateWindowSize() TITANIUM_NOEXCEPT
 		{
-#if defined(IS_WINDOWS_10)
 			const auto currentBounds = Windows::UI::Xaml::Window::Current->Bounds;
 
 			const auto layout    = getViewLayoutDelegate();
@@ -225,17 +277,22 @@ namespace TitaniumWindows
 			if (!Windows::UI::ViewManagement::ApplicationView::GetForCurrentView()->TryResizeView(Size(width, height))) {
 				TITANIUM_LOG_WARN("Titanium::Window: Unable to resize root Window with size ", width, "x", height);
 			}
-#endif
 		}
+#endif
 
 		void Window::open(const std::shared_ptr<Titanium::UI::OpenWindowParams>& params) TITANIUM_NOEXCEPT
 		{
 			Titanium::UI::Window::open(params);
 
-			auto rootFrame = dynamic_cast<Windows::UI::Xaml::Controls::Frame^>(Windows::UI::Xaml::Window::Current->Content);
-			rootFrame->Navigate(Windows::UI::Xaml::Controls::Page::typeid);
-			auto page = dynamic_cast<Windows::UI::Xaml::Controls::Page^>(rootFrame->Content);
-			page->Content = canvas__;
+			if (tab__) {
+				const auto tab = std::dynamic_pointer_cast<Tab>(tab__);
+				tab->openWindow(get_object().GetPrivate<Window>());
+			} else {
+				auto rootFrame = dynamic_cast<Windows::UI::Xaml::Controls::Frame^>(Windows::UI::Xaml::Window::Current->Content);
+				rootFrame->Navigate(Windows::UI::Xaml::Controls::Page::typeid);
+				auto page = dynamic_cast<Windows::UI::Xaml::Controls::Page^>(rootFrame->Content);
+				page->Content = canvas__;
+			}
 
 			if (window_stack__.size() > 0) {
 				// Fire blur on the last window
@@ -246,7 +303,10 @@ namespace TitaniumWindows
 				lastwin->disableEvents();
 			}
 
-			window_stack__.push_back(this->get_object().GetPrivate<Window>());
+			// Tab.open should not increase window stack. Tab.focus event does it instead.
+			if (tab__ == nullptr) {
+				window_stack__.push_back(this->get_object().GetPrivate<Window>());
+			}
 
 			// start accepting events
 			enableEvents();
@@ -338,34 +398,6 @@ namespace TitaniumWindows
 			auto view = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
 			fullscreen ? view->TryEnterFullScreenMode() : view->ExitFullScreenMode();
 #endif
-		}
-
-		void Window::enableEvents() TITANIUM_NOEXCEPT
-		{
-			Titanium::Module::enableEvents();
-			is_window_event_active__ = true;
-		}
-
-		void Window::disableEvents() TITANIUM_NOEXCEPT
-		{
-			Titanium::Module::disableEvents();
-			is_window_event_active__ = false;
-		}
-
-		void Window::enableEvent(const std::string& event_name) TITANIUM_NOEXCEPT
-		{
-			Titanium::UI::Window::enableEvent(event_name);
-			if (event_name == "windows:back") {
-				is_custom_backpress_event__ = true;
-			}
-		}
-
-		void Window::disableEvent(const std::string& event_name) TITANIUM_NOEXCEPT
-		{
-			Titanium::UI::Window::disableEvent(event_name);
-			if (event_name == "windows:back") {
-				is_custom_backpress_event__ = false;
-			}
 		}
 
 		WindowLayoutDelegate::WindowLayoutDelegate() TITANIUM_NOEXCEPT


### PR DESCRIPTION
[TIMOB-23349](https://jira.appcelerator.org/browse/TIMOB-23349)

```javascript
var colors = ['blue', 'gray', 'red'];

function createWindow(depth) {

    var win = Ti.UI.createWindow({
        layout: 'vertical',
        backgroundColor: colors[depth % colors.length]
    });

    win.add(Ti.UI.createLabel({
        text: 'Depth ' + depth
    }));

    var openBtn = Ti.UI.createButton({
        top: 20,
        title: 'Open Child'
    });

    openBtn.addEventListener('click', function () {
        tabA.open(createWindow(depth + 1));
    });

    win.add(openBtn);

    if (depth > 0) {
        var closeViaWinBtn = Ti.UI.createButton({
            top: 20,
            title: 'Close via Window'
        });

        closeViaWinBtn.addEventListener('click', function () {
            win.close();
        });

        win.add(closeViaWinBtn);

        var closeViaTabBtn = Ti.UI.createButton({
            top: 20,
            title: 'Close via Tab'
        });

        closeViaTabBtn.addEventListener('click', function () {
            tabA.close(win);
        });

        win.add(closeViaTabBtn);

        var backViaWinButton = Ti.UI.Windows.createAppBarButton({
            icon: Ti.UI.Windows.SystemIcon.BACK
        });

        backViaWinButton.addEventListener('click', function () {
            win.close();
        });

        var backViaTabButton = Ti.UI.Windows.createAppBarButton({
            icon: Ti.UI.Windows.SystemIcon.BACKTOWINDOW
        });

        backViaTabButton.addEventListener('click', function () {
            tabA.close(win);
        });

        win.add(Ti.UI.Windows.createCommandBar({
            items: [backViaWinButton, backViaTabButton]
        }));
    }

    return win;
}

var tabA = Ti.UI.createTab({
    title: 'Tab A',
    window: createWindow(0)
});

var tabB = Ti.UI.createTab({
    title: 'Tab B',
    window: Ti.UI.createWindow({
        backgroundColor: 'green'
    })
});

Ti.UI.createTabGroup({
    tabs: [tabA, tabB]
}).open();
```