### PR TITLE
[5_3_X] [TIMOB-23349] Fix: Closing Windows via Ti.UI.Tab.open() does not work

### DIFF
--- a/Source/Network/CMakeLists.txt
+++ b/Source/Network/CMakeLists.txt
@@ -114,6 +114,9 @@ set_target_properties(TitaniumWindows_Network PROPERTIES VS_WINRT_COMPONENT TRUE
 # configuration.
 set_property(TARGET TitaniumWindows_Network APPEND_STRING PROPERTY LINK_FLAGS_DEBUG "/OPT:NOREF /OPT:NOICF")
 
+# Fix error C4996: 'std::_Copy_impl': Function call with parameters that may be unsafe (needed by boost::signals used in HTTPClient and Network)
+set_property(TARGET TitaniumWindows_Network APPEND_STRING PROPERTY COMPILE_FLAGS " -D_SCL_SECURE_NO_WARNINGS")
+
 if (NOT TitaniumWindows_Network_DISABLE_TESTS)
   add_subdirectory(test)
 endif()

--- a/Source/Ti/include/TitaniumWindows/App/Properties.hpp
+++ b/Source/Ti/include/TitaniumWindows/App/Properties.hpp
@@ -45,7 +45,7 @@ namespace TitaniumWindows
 			virtual bool getBool(const std::string& property, bool default) TITANIUM_NOEXCEPT override;
 			virtual double getDouble(const std::string& property, double default) TITANIUM_NOEXCEPT override;
 			virtual double getInt(const std::string& property, double default) TITANIUM_NOEXCEPT override;
-			virtual boost::optional<std::string> getString(const std::string& property, const boost::optional<std::string>& default = nullptr) TITANIUM_NOEXCEPT override;
+			virtual boost::optional<std::string> getString(const std::string& property, const boost::optional<std::string>& default = boost::none) TITANIUM_NOEXCEPT override;
 			virtual bool hasProperty(const std::string& property) TITANIUM_NOEXCEPT override;
 			virtual std::vector<std::string> listProperties() TITANIUM_NOEXCEPT override;
 			virtual void removeProperty(const std::string& property) TITANIUM_NOEXCEPT override;

--- a/Source/TitaniumKit/include/Titanium/UI/Window.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/Window.hpp
@@ -21,6 +21,7 @@ namespace Titanium
 
 		class OpenWindowParams;
 		class CloseWindowParams;
+		class Tab;
 
 		/*!
 		  @class
@@ -45,11 +46,6 @@ namespace Titanium
 			*/
 			virtual void close(const std::shared_ptr<CloseWindowParams>& params) TITANIUM_NOEXCEPT;
 
-			/*
-			 * Closes the view of the Window, used by Ti.UI.TabGroup 
-			*/
-			virtual void closeAsView();
-
 			/*!
 			  @method
 
@@ -63,11 +59,6 @@ namespace Titanium
 			  @result void
 			*/
 			virtual void open(const std::shared_ptr<OpenWindowParams>& params) TITANIUM_NOEXCEPT;
-
-			/*
-			* Opens the view of the Window, used by Ti.UI.TabGroup
-			*/
-			virtual void openAsView();
 
 			/*!
 			  @method
@@ -233,6 +224,16 @@ namespace Titanium
 			*/
 			TITANIUM_PROPERTY_IMPL_DEF(bool, translucent);
 
+			/*!
+			@method
+
+			@abstract tab : Tab
+
+			@discussion Tab that attaches this Window
+			*/
+			TITANIUM_PROPERTY_IMPL_DEF(std::shared_ptr<Tab>, tab);
+
+
 			Window(const JSContext&) TITANIUM_NOEXCEPT;
 
 			virtual ~Window() TITANIUM_NOEXCEPT;  //= default;
@@ -316,6 +317,8 @@ namespace Titanium
 
 			JSObject openWindowParams_ctor__;
 			JSObject closeWindowParams_ctor__;
+
+			std::shared_ptr<Tab> tab__;
 #pragma warning(pop)
 		};
 	} // namespace UI

--- a/Source/TitaniumKit/src/App/Properties.cpp
+++ b/Source/TitaniumKit/src/App/Properties.cpp
@@ -90,7 +90,7 @@ namespace Titanium
 		JSObject Properties::getObject(const std::string& property, JSObject defaultValue) TITANIUM_NOEXCEPT
 		{
 			if (hasProperty(property)) {
-				const auto string = getString(property, nullptr);
+				const auto string = getString(property, boost::none);
 				if (string) {
 					auto value = get_context().CreateValueFromJSON(*string);
 					if (value.IsObject()) {

--- a/Source/TitaniumKit/src/UI/Tab.cpp
+++ b/Source/TitaniumKit/src/UI/Tab.cpp
@@ -68,7 +68,8 @@ namespace Titanium
 		void Tab::open(const std::shared_ptr<OpenWindowParams>& options) TITANIUM_NOEXCEPT
 		{
 			if (window__) {
-				window__->openAsView();
+				window__->set_tab(get_object().GetPrivate<Tab>());
+				window__->open(options);
 			} else {
 				TITANIUM_LOG_WARN("Tab::open() failed: no window is attached");
 			}
@@ -83,7 +84,7 @@ namespace Titanium
 		void Tab::close(const std::shared_ptr<CloseWindowParams>& options) TITANIUM_NOEXCEPT
 		{
 			if (window__) {
-				window__->closeAsView();
+				window__->close(options);
 			} else {
 				TITANIUM_LOG_WARN("Tab::close() failed: no window is attached");
 			}

--- a/Source/TitaniumKit/src/UI/Window.cpp
+++ b/Source/TitaniumKit/src/UI/Window.cpp
@@ -10,6 +10,7 @@
 #include "Titanium/UIModule.hpp"
 #include "Titanium/UI/OpenWindowParams.hpp"
 #include "Titanium/UI/CloseWindowParams.hpp"
+#include "Titanium/UI/Tab.hpp"
 #include "Titanium/detail/TiImpl.hpp"
 
 #define GET_UI() \
@@ -38,7 +39,8 @@ namespace Titanium
 		      navTintColor__(""),
 		      orientationModes__(),
 		      theme__(""),
-		      translucent__(false)
+		      translucent__(false),
+		      tab__(nullptr)
 		{
 			TITANIUM_LOG_DEBUG("Window:: ctor ", this);
 		}
@@ -50,6 +52,7 @@ namespace Titanium
 
 		void Window::close(const std::shared_ptr<CloseWindowParams>& params) TITANIUM_NOEXCEPT
 		{
+			tab__ = nullptr;
 		}
 
 		void Window::open(const std::shared_ptr<OpenWindowParams>& params) TITANIUM_NOEXCEPT
@@ -57,16 +60,6 @@ namespace Titanium
 			GET_UI();
 			const auto ui_ptr = UI.GetPrivate<Titanium::UIModule>();
 			ui_ptr->set_currentWindow(this->get_object().GetPrivate<Titanium::UI::Window>());
-		}
-
-		void Window::closeAsView()
-		{
-			fireEvent("close");
-		}
-
-		void Window::openAsView()
-		{
-			fireEvent("open");
 		}
 
 		TITANIUM_PROPERTY_READWRITE(Window, bool, exitOnClose)
@@ -81,6 +74,7 @@ namespace Titanium
 		TITANIUM_PROPERTY_READWRITE(Window, TitleAttributesParams, titleAttributes)
 		TITANIUM_PROPERTY_READWRITE(Window, bool, translucent)
 		TITANIUM_PROPERTY_READWRITE(Window, std::string, barColor)
+		TITANIUM_PROPERTY_READWRITE(Window, std::shared_ptr<Tab>, tab)
 
 		void Window::JSExportInitialize()
 		{

--- a/Source/UI/include/TitaniumWindows/UI/Tab.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/Tab.hpp
@@ -20,6 +20,8 @@ namespace TitaniumWindows
 	{
 		using namespace HAL;
 
+		class Window;
+
 		/*!
 		  @class Tab
 		  @ingroup Titanium.UI.Tab
@@ -63,12 +65,23 @@ namespace TitaniumWindows
 			virtual void blur()  override;
 			virtual void focus() override;
 
+			void openWindow(const std::shared_ptr<Window>& window);
+			void closeWindow(const std::shared_ptr<Window>& window);
+
+			bool isLastWindow() 
+			{
+				return (window_stack__.size() == 0);
+			}
 		private:
+#pragma warning(push)
+#pragma warning(disable : 4251)
+			std::vector<std::shared_ptr<Window>> window_stack__;
 #if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			Windows::UI::Xaml::Controls::PivotItem^ pivotItem__;
 #else
 			Windows::UI::Xaml::Controls::Grid^  grid__;
 #endif
+#pragma warning(pop)
 		};
 	}  // namespace UI
 }  // namespace TitaniumWindows

--- a/Source/UI/include/TitaniumWindows/UI/Window.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/Window.hpp
@@ -12,6 +12,7 @@
 #include "TitaniumWindows_UI_EXPORT.h"
 #include "Titanium/UI/Window.hpp"
 #include "TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp"
+#include "TitaniumWindows/WindowsMacros.hpp"
 
 namespace TitaniumWindows
 {
@@ -87,15 +88,14 @@ namespace TitaniumWindows
 
 			virtual std::shared_ptr<TitaniumWindows::UI::WindowsXaml::CommandBar> getBottomAppBar() TITANIUM_NOEXCEPT;
 
-			virtual void enableEvents()  TITANIUM_NOEXCEPT override;
-			virtual void disableEvents() TITANIUM_NOEXCEPT override;
-
-			virtual void enableEvent(const std::string& event_name) TITANIUM_NOEXCEPT override;
-			virtual void disableEvent(const std::string& event_name) TITANIUM_NOEXCEPT override;
-
 			void updateWindowsCommandBar(const std::shared_ptr<TitaniumWindows::UI::WindowsXaml::CommandBar>& commandbar);
-			void updateWindowSize() TITANIUM_NOEXCEPT;
 
+#if defined(IS_WINDOWS_10)
+			void updateWindowSize() TITANIUM_NOEXCEPT;
+#endif
+
+			static void SetActiveTabWindow(const std::shared_ptr<TitaniumWindows::UI::Window>& window);
+			static void ExitApp(const JSContext& js_context);
 		private:
 #pragma warning(push)
 #pragma warning(disable : 4251)
@@ -103,8 +103,6 @@ namespace TitaniumWindows
 			static std::vector<std::shared_ptr<Window>> window_stack__;
 			std::shared_ptr<TitaniumWindows::UI::WindowsXaml::CommandBar> bottomAppBar__;
 			Windows::Foundation::EventRegistrationToken backpressed_event__;
-			bool is_custom_backpress_event__ { false };
-			bool is_window_event_active__ { false };
 			bool is_tabgroup_container__ { false };
 #pragma warning(pop)
 		};

--- a/Source/UI/src/Tab.cpp
+++ b/Source/UI/src/Tab.cpp
@@ -51,6 +51,35 @@ namespace TitaniumWindows
 #endif
 		}
 
+		void Tab::openWindow(const std::shared_ptr<Window>& window)
+		{
+			window_stack__.push_back(window);
+		}
+
+		void Tab::closeWindow(const std::shared_ptr<Window>& window)
+		{
+			if (window_stack__.size() == 1) {
+				window_stack__.pop_back();
+			} else if (window_stack__.size() > 1) {
+				const auto top_window = window_stack__.back();
+				const auto is_top_window = (top_window.get() == window.get());
+				if (is_top_window) {
+					window_stack__.pop_back();
+					const auto next_window = window_stack__.back();
+					set_window(next_window);
+					next_window->focus();
+				} else {
+					// Window is not on top. Just closing it then.
+					for (std::size_t i = 0; i < window_stack__.size(); i++) {
+						if (window_stack__.at(i).get() == window.get()) {
+							window_stack__.erase(window_stack__.begin() + i);
+							break;
+						}
+					}
+				}
+			}
+		}
+
 		void Tab::set_window(const std::shared_ptr<Titanium::UI::Window>& window) TITANIUM_NOEXCEPT
 		{
 			if (window != window__) {

--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -1545,7 +1545,7 @@ namespace TitaniumWindows
 		inline std::string toLowerCase(const std::string& string)
 		{
 			std::string copy(string);
-			std::transform(string.begin(), string.end(), copy.begin(), std::tolower);
+			std::transform(string.begin(), string.end(), copy.begin(), tolower);
 			return copy;
 		}
 


### PR DESCRIPTION
Cherry-pick #680 for 5_3_X.
This also includes fix for compile error on Windows 10.