### PR TITLE
[TIMOB-23283] Fix ProgressBar with FILL should fill the view

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/ProgressBar.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/ProgressBar.hpp
@@ -78,7 +78,6 @@ namespace TitaniumWindows
 			Windows::UI::Xaml::Controls::ProgressBar^ bar__;
 			Windows::UI::Xaml::Controls::TextBlock^ label__;
 
-			bool sizeChanged__{ true };
 			Windows::Foundation::EventRegistrationToken sizechanged_event__;
 
 		};

--- a/Source/UI/src/ProgressBar.cpp
+++ b/Source/UI/src/ProgressBar.cpp
@@ -50,17 +50,23 @@ namespace TitaniumWindows
 			bar__->Background = ref new Windows::UI::Xaml::Media::SolidColorBrush(Windows::UI::Colors::Gray);
 
 			sizechanged_event__ = panel__->SizeChanged += ref new SizeChangedEventHandler([this](Platform::Object^ sender, SizeChangedEventArgs^ e) {
-				// Make sure to resize this only when it's requested.
-				if (!sizeChanged__) {
-					return;
-				}
 				const auto fill = Titanium::UI::Constants::to_string(Titanium::UI::LAYOUT::FILL);
 				const auto layout = getViewLayoutDelegate<WindowsViewLayoutDelegate>();
+
 				if (layout->get_height() != fill) {
+					// relative position from container should start from top & left
+					panel__->VerticalAlignment = VerticalAlignment::Top;
 					layout->set_height(std::to_string(e->NewSize.Height));
+				} else {
+					panel__->VerticalAlignment = VerticalAlignment::Stretch;
 				}
+
 				if (layout->get_width() != fill) {
+					// relative position from container should start from top & left
+					panel__->HorizontalAlignment = HorizontalAlignment::Left;
 					layout->set_width(std::to_string(e->NewSize.Width));
+				} else {
+					panel__->HorizontalAlignment = HorizontalAlignment::Stretch;
 				}
 			});
 
@@ -68,10 +74,6 @@ namespace TitaniumWindows
 			label__->Text = "";
 
 			label__->FontSize = TitaniumWindows::UI::Label::DefaultFontSize;
-
-			// relative position from container should start from top & left
-			panel__->VerticalAlignment = VerticalAlignment::Top;
-			panel__->HorizontalAlignment = HorizontalAlignment::Left;
 			label__->HorizontalAlignment = HorizontalAlignment::Center;
 
 			panel__->Children->Append(label__);


### PR DESCRIPTION
[TIMOB-23283](https://jira.appcelerator.org/browse/TIMOB-23283)

```javascript
var pb = Ti.UI.createProgressBar({
    min: 0,
    max: 10,
    value: 0,
    color: 'blue',
    backgroundColor: 'green',
    backgroundDisabledColor: 'gray',
    message: 'Downloading 0 of 10',
    width: Ti.UI.FILL
});
var win = Ti.UI.createWindow();
win.add(pb);
win.open();
pb.show();
```