### PR TITLE
[TIMOB-23363] Windows: textAlign property of Button does not work in 8.1 or 10

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/Button.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/Button.hpp
@@ -39,7 +39,6 @@ namespace TitaniumWindows
 		class TITANIUMWINDOWS_UI_EXPORT Button final : public Titanium::UI::Button, public JSExport<Button>
 		{
 		public:
-			TITANIUM_FUNCTION_UNIMPLEMENTED(textAlign);
 			TITANIUM_PROPERTY_UNIMPLEMENTED(borderRadius);
 
 			Button(const JSContext&) TITANIUM_NOEXCEPT;
@@ -53,7 +52,7 @@ namespace TitaniumWindows
 #endif
 
 			static void JSExportInitialize();
-			
+
 			virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;
 
 			virtual void set_color(const std::string& color) TITANIUM_NOEXCEPT override final;

--- a/Source/UI/src/Button.cpp
+++ b/Source/UI/src/Button.cpp
@@ -91,14 +91,13 @@ namespace TitaniumWindows
 		{
 			Titanium::UI::Button::set_textAlign(textAlign);
 
-			TITANIUM_LOG_WARN("Button.textAlign is not implemented yet");
-			//if (textAlign == Titanium::UI::TEXT_ALIGNMENT::CENTER) {
-			//	button__->TextAlignment = TextAlignment::Center;
-			//} else if (textAlign == Titanium::UI::TEXT_ALIGNMENT::LEFT) {
-			//	button__->TextAlignment = TextAlignment::Left;
-			//} else if (textAlign == Titanium::UI::TEXT_ALIGNMENT::RIGHT) {
-			//	button__->TextAlignment = TextAlignment::Right;
-			//}
+			if (textAlign == Titanium::UI::TEXT_ALIGNMENT::CENTER) {
+				button__->HorizontalContentAlignment = HorizontalAlignment::Center;
+			} else if (textAlign == Titanium::UI::TEXT_ALIGNMENT::LEFT) {
+				button__->HorizontalContentAlignment = HorizontalAlignment::Left;
+			} else if (textAlign == Titanium::UI::TEXT_ALIGNMENT::RIGHT) {
+				button__->HorizontalContentAlignment = HorizontalAlignment::Right;
+			}
 			// TODO Windows supports JUSTIFY!
 		}
 
@@ -112,11 +111,11 @@ namespace TitaniumWindows
 		{
 			Titanium::UI::Button::set_verticalAlign(verticalAlign);
 			if (verticalAlign == Titanium::UI::TEXT_VERTICAL_ALIGNMENT::BOTTOM) {
-				button__ ->VerticalAlignment = VerticalAlignment::Bottom;
+				button__ ->VerticalContentAlignment = VerticalAlignment::Bottom;
 			} else if (verticalAlign == Titanium::UI::TEXT_VERTICAL_ALIGNMENT::CENTER) {
-				button__->VerticalAlignment = VerticalAlignment::Center;
+				button__->VerticalContentAlignment = VerticalAlignment::Center;
 			} else if (verticalAlign == Titanium::UI::TEXT_VERTICAL_ALIGNMENT::TOP) {
-				button__->VerticalAlignment = VerticalAlignment::Top;
+				button__->VerticalContentAlignment = VerticalAlignment::Top;
 			}
 			// TODO Windows supports stretch!
 		}


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-23363

Note that this also fixes an incorrect implementation of verticalAlign property.

For certain controls, like Button, they are subclasses of ContentControl - meaning they have a Content property which can typically take a simple String or an actual complex UI as the value. For these controls, to be able to manage their content they have special properties:
- HorizontalContentAlignment
- VerticalContentAlignment

We just need to use those to set textAlign/verticalAlign on the internal text.