### PR TITLE
[TIMOB-23294] Set Ti.UI.PickerRow ViewLayoutDelegate

### DIFF
--- a/Source/UI/src/PickerRow.cpp
+++ b/Source/UI/src/PickerRow.cpp
@@ -36,6 +36,9 @@ namespace TitaniumWindows
 			item__  = ref new ComboBoxItem();
 			label__ = ref new TextBlock();
 			item__->Content = label__;
+
+			Titanium::UI::PickerRow::setLayoutDelegate<WindowsViewLayoutDelegate>();
+			getViewLayoutDelegate<WindowsViewLayoutDelegate>()->setComponent(item__, nullptr, false);
 		}
 
 		void PickerRow::set_color(const std::string& colorName) TITANIUM_NOEXCEPT


### PR DESCRIPTION
- Set the ``WindowsViewLayoutDelegate`` for ``Titanium.UI.PickerRow`` allowing properties such as ``backgroundColor`` to be set

###### TEST CASE
```Javascript
var win = Ti.UI.createWindow(),
    picker = Ti.UI.createPicker({top: 10});

picker.add(Ti.UI.createPickerRow({ title: 'Bananas', backgroundColor: 'yellow'}));
picker.add(Ti.UI.createPickerRow({ title: 'Strawberries', backgroundColor: 'red' }));
picker.add(Ti.UI.createPickerRow({ title: 'Grapes', backgroundColor: 'purple' }));

win.add(picker);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23294)