### PR TITLE
[5_3_X][TIMOB-23374] Windows: Label backgroundColor cut through border with radius

### DIFF
--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -643,6 +643,8 @@ namespace TitaniumWindows
 		{
 			if (underlying_control__) {
 				underlying_control__->Background = brush;
+			} else if (border__) {
+				border__->Background = brush;
 			} else if (is_panel__) {
 				dynamic_cast<Panel^>(component__)->Background = brush;
 			} else if (is_control__) {


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-23374

This simply applies background brushes (color/image/gradient) to the wrapping Border object when we have a non-null border__ (and don't have an underlying_control__).

I have no idea the ordering of when this should apply: I stuck it before the is_panel and is_control checks, but honestly I don't know under what circumstance we should move the background to the wrapping border and when we shouldn't.

When merged, this needs to be cherry-picked to master.