### PR TITLE
[5_3_X][TIMOB-23378] Fix borderRadius clip for Ti.UI.Label

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/Label.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/Label.hpp
@@ -55,7 +55,7 @@ namespace TitaniumWindows
 			static const std::uint32_t DefaultFontSize = 20;
 
 		private:
-			Windows::UI::Xaml::Controls::Grid^ parent__;
+			Windows::UI::Xaml::Controls::Border^ parent__;
 			Windows::UI::Xaml::Controls::TextBlock^ label__;
 			Windows::Foundation::EventRegistrationToken label_sizechanged_event__;
 			bool sizeChanged__{ false };

--- a/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
@@ -509,6 +509,7 @@ namespace TitaniumWindows
 			bool is_control__{false};
 			bool is_scrollview__ { false };
 			bool is_button__{ false };
+			bool is_border__{ false };
 			bool is_loaded__{false};
 
 			Titanium::LayoutEngine::Rect oldRect__;

--- a/Source/UI/src/Label.cpp
+++ b/Source/UI/src/Label.cpp
@@ -41,8 +41,8 @@ namespace TitaniumWindows
 		{
 			Titanium::UI::Label::postCallAsConstructor(js_context, arguments);
 			
-			// Note: TextAlignment and VerticalAlignment does not work without parent Grid container!
-			parent__ = ref new Controls::Grid();
+			// Note: TextAlignment and VerticalAlignment does not work without parent container!
+			parent__ = ref new Windows::UI::Xaml::Controls::Border();
 			label__ = ref new Windows::UI::Xaml::Controls::TextBlock();
 
 			// In case width/height is Ti.UI.SIZE, grid needs to resize when label text is changed
@@ -80,16 +80,14 @@ namespace TitaniumWindows
 				label__->MaxHeight = current->Bounds.Height;
 			}
 
-			parent__->Children->Append(label__);
-			parent__->SetColumn(label__, 0);
-			parent__->SetRow(label__, 0);
+			parent__->Child = label__;
 
 			layoutDelegate__->set_defaultHeight(Titanium::UI::LAYOUT::SIZE);
 			layoutDelegate__->set_defaultWidth(Titanium::UI::LAYOUT::SIZE);
 			layoutDelegate__->set_autoLayoutForHeight(Titanium::UI::LAYOUT::SIZE);
 			layoutDelegate__->set_autoLayoutForWidth(Titanium::UI::LAYOUT::SIZE);
 
-			getViewLayoutDelegate<WindowsViewLayoutDelegate>()->setComponent(parent__);
+			getViewLayoutDelegate<WindowsViewLayoutDelegate>()->setComponent(parent__, nullptr, parent__);
 		}
 
 		void Label::JSExportInitialize()

--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -647,6 +647,8 @@ namespace TitaniumWindows
 				dynamic_cast<Panel^>(component__)->Background = brush;
 			} else if (is_control__) {
 				dynamic_cast<Control^>(component__)->Background = brush;
+			} else if (is_border__) {
+				dynamic_cast<Border^>(component__)->Background = brush;
 			} else {
 				TITANIUM_LOG_WARN("Unable to set background: Unknown component");
 			}
@@ -1148,6 +1150,7 @@ namespace TitaniumWindows
 			is_control__ = dynamic_cast<Controls::Control^>(component__) != nullptr;
 			is_scrollview__ = dynamic_cast<Controls::ScrollViewer^>(component__) != nullptr;
 			is_grid__    = dynamic_cast<Controls::Grid^>(component__) != nullptr;
+			is_border__ = dynamic_cast<Controls::Border^>(component__) != nullptr;
 			is_button__  = dynamic_cast<Controls::Button^>(underlying_control__) != nullptr;
 
 			loaded_event__ = component__->Loaded += ref new RoutedEventHandler([this](Platform::Object^ sender, RoutedEventArgs^ e) {


### PR DESCRIPTION
- Parent the ``Label`` component to a ``Border`` to allow clipping

###### TEST CASE
```Javascript
var win = Ti.UI.createWindow({ backgroundColor: 'white' }),
    label = Ti.UI.createLabel({
        text: "TEST",
        height: 60,
        width: 60,
        color: "#C41230",
        borderRadius: 30,
        borderWidth: 2,
        borderColor: "#C41230",
        backgroundColor: "#F2D0D6",
        textAlign: "center",
        font: {
            fontSize: 20,
        },
        left: "10%"
    });
win.add(label);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23378)