### PR TITLE
[5_3_X] Fix: Workaround to make corporate app look right

### DIFF
--- a/Source/UI/src/Label.cpp
+++ b/Source/UI/src/Label.cpp
@@ -57,10 +57,10 @@ namespace TitaniumWindows
 					}
 					const auto width = layout->get_width();
 					if (!layout->get_right().empty() && !layout->get_left().empty()) {
-						// FIXME:
+						// FIXME: Workaround to make sure text content is shown.
 						// When both left and right is specified with horizontal layout, LayoutEngine doesn't respect them. (TIMOB-23372)
 						// We would respect text box size in this case to make sure text content is shown at least.
-						layout->set_width(std::to_string(e->NewSize.Width));
+						layout->set_width(std::to_string(e->NewSize.Width + /* some more margin was needed */ std::stod(layout->get_left())));
 					} else if (width.empty() || width == size) {
 						layout->set_width(std::to_string(e->NewSize.Width));
 					}


### PR DESCRIPTION
<img width="250" alt="capture" src="https://cloud.githubusercontent.com/assets/1661068/15281303/e58200e8-1b74-11e6-8a10-04ea3eb42789.PNG">

[TIMOB-23293](https://jira.appcelerator.org/browse/TIMOB-23293)
[TIMOB-23377](https://jira.appcelerator.org/browse/TIMOB-23377)