### PR TITLE
[TIMOB-23398] Analytics: SDK version format on Windows phone should match other platforms

### DIFF
--- a/Source/TitaniumKit/src/analytics.js
+++ b/Source/TitaniumKit/src/analytics.js
@@ -74,6 +74,16 @@ Analytics.prototype.createEvent = function createEvent(eventType, data) {
 	this.lastEvent = event;
 };
 
+function trimVersionQualifier(version) {
+	var parts = [];
+	// keep first three segments of the version number.
+	if (version && version.indexOf('.') != -1) {
+		parts = version.split('.');
+		return parts.slice(0, 3).join('.');
+	}
+	return version;
+}
+
 /**
  * Creates a 'ti.enroll' event and adds it to the event queue
  * @private
@@ -93,7 +103,7 @@ Analytics.prototype.createEnrollEvent = function createAppEnrollEvent() {
 		nettype: Ti.Network.networkTypeName,
 		app_version: Ti.App.version,
 		osver: Ti.Platform.version,
-		sdkver: Ti.version
+		sdkver: "ti." + trimVersionQualifier(Ti.version)
 	});
 };
 
@@ -116,7 +126,7 @@ Analytics.prototype.createForegroundEvent = function foregroundEvent() {
 		nettype: Ti.Network.networkTypeName,
 		app_version: Ti.App.version,
 		osver: Ti.Platform.version,
-		sdkver: Ti.version
+		sdkver: "ti." + trimVersionQualifier(Ti.version)
 	});
 };
 


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-23398

We need to prefix sdkver value with "ti." and trim the version down to the first three segments (drop the timestamp qualifier).