### PR TITLE
[TIMOB-23392] Analytics: Timestamp for Windows payloads are inconsistent with other platforms

### DIFF
--- a/Source/TitaniumKit/src/analytics.js
+++ b/Source/TitaniumKit/src/analytics.js
@@ -53,6 +53,16 @@ Analytics.prototype.saveEventQueue = function saveEventQueue() {
 };
 
 /**
+ * Converts an ISO Date string to the format required by our analytics server.
+ * (Basically replace the trailing 'Z' with +0000)
+ * @param  {String} dateString Date.prototype.toISOString()
+ * @return {String}            [description]
+ */
+function toAnalyticsDate(dateString) {
+	return dateString.replace('Z', '+0000');
+}
+
+/**
  * Creates an event and adds it to the event queue
  * @param {String} eventType - event type (e.g: 'app.feature')
  * @param {Object} data - JSON event data
@@ -62,7 +72,7 @@ Analytics.prototype.createEvent = function createEvent(eventType, data) {
 	var event = {
 		id: Ti.Platform.createUUID() + ':' + Ti.Platform.id,
 		sid: this.sessionId,
-		ts: new Date().toISOString(),
+		ts: toAnalyticsDate(new Date().toISOString()),
 		event: eventType,
 		seq: this.sequence++,
 		mid: Ti.Platform.id,


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-23392

Basically it boils down to us using the ISO string format and the other platforms using a "+0000" timezone offset instead of "Z" at the end. So I generate our ISO string and replace "Z" with "+0000".