### PR TITLE
[TIMOB-23372] Fix: right margin breaks layout

### DIFF
--- a/Examples/NMocha/src/Assets/ti.ui.layout.test.js
+++ b/Examples/NMocha/src/Assets/ti.ui.layout.test.js
@@ -1179,4 +1179,313 @@ describe("Titanium.UI.Layout", function () {
         win.add(view);
         win.open();
     });
+
+    // TIMOB-23372 #1
+    //
+    // left/right/top/bottom should just work for child view
+    // when both left/right/top/bottom are specified to parent
+    // 
+    it("TIMOB-23372 #1", function (finish) {
+        var a = Ti.UI.createView({
+            backgroundColor: 'orange',
+            top: 10,
+            left: 10,
+            right: 10,
+            bottom: 10,
+        }),
+        b = Ti.UI.createView({
+            backgroundColor: 'yellow',
+            top: 10,
+            left: 10,
+            right: 10,
+            bottom: 10,
+        });
+        var win = createWindow({}, function() {
+            should(a.rect.x).eql(10);
+            should(a.rect.y).eql(10);
+            should(b.rect.x).eql(10);
+            should(b.rect.y).eql(10);
+            should(b.rect.width).eql(a.rect.width - 20);
+            should(b.rect.height).eql(a.rect.height - 20);
+            finish();
+        });
+        a.add(b);
+        win.add(a);
+        win.open();
+    });
+
+    // TIMOB-23372 #2
+    //
+    // left & right should just work for child view (vertical)
+    // when both left & right are specified to parent
+    // 
+    it("TIMOB-23372 #2", function (finish) {
+        var view = Ti.UI.createView({
+            backgroundColor: 'orange',
+            layout: "vertical",
+            top: 10,
+            left: 10,
+            right: 10,
+            height: Ti.UI.SIZE,
+            width: Ti.UI.SIZE,
+        }),
+        label = Ti.UI.createLabel({
+            left: 10,
+            right: 10,
+            color: "green",
+            backgroundColor: 'yellow',
+            text: "this is test text"
+        });
+        var win = createWindow({}, function() {
+            should(view.rect.x).eql(10);
+            should(view.rect.y).eql(10);
+            should(label.rect.x).eql(10);
+            should(label.rect.y).eql(0);
+            should(label.rect.width).eql(view.rect.width - 20);
+            finish();
+        });
+        view.add(label);
+        win.add(view);
+        win.open();
+    });
+
+    // TIMOB-23372 #3
+    //
+    // left & right should just work for child view (composite)
+    // when both left & right are specified to parent
+    // 
+    it("TIMOB-23372 #3", function (finish) {
+        var view = Ti.UI.createView({
+            backgroundColor: 'yellow',
+            layout: "composite",
+            top: 10,
+            left: 10,
+            right: 10,
+            height: Ti.UI.SIZE,
+            width: Ti.UI.SIZE
+        }),
+        label = Ti.UI.createLabel({
+            left: 10,
+            right: 10,
+            color: "blue",
+            text: "this is test text"
+        });
+        view.add(label);
+        var win = createWindow({}, function () {
+            should(view.rect.x).eql(10);
+            should(view.rect.y).eql(10);
+            should(label.rect.x).eql(10);
+            should(label.rect.y).eql(0);
+            should(label.rect.width).eql(view.rect.width - 20);
+            finish();
+        });
+        win.add(view);
+        win.open();
+    });
+
+    // TIMOB-23372 #4
+    //
+    // left & right should just work for child view (horizontal)
+    // when both left & right are specified to parent
+    // 
+    it("TIMOB-23372 #4", function (finish) {
+        var view = Ti.UI.createView({
+            backgroundColor: 'yellow',
+            layout: "horizontal",
+            top: 10,
+            left: 10,
+            right: 10,
+            height: Ti.UI.SIZE,
+            width: Ti.UI.SIZE
+        }),
+        label = Ti.UI.createLabel({
+            left: 10,
+            right: 10,
+            color: "blue",
+            text: "this is test text"
+        });
+        view.add(label);
+        var win = createWindow({}, function() {
+            should(view.rect.x).eql(10);
+            should(view.rect.y).eql(10);
+            should(label.rect.x).eql(10);
+            should(label.rect.y).eql(0);
+            should(label.rect.width).eql(view.rect.width - 20);
+            finish();
+        });
+        win.add(view);
+        win.open();
+    });
+
+    // TIMOB-23372 #5
+    //
+    // left & right should just work for label (horizontal)
+    // even when parent view doesn't have right value.
+    // parent view should fit the size of the child, not Window
+    // 
+    it("TIMOB-23372 #5", function (finish) {
+        var view = Ti.UI.createView({
+            backgroundColor: 'orange',
+            layout: "horizontal",
+            top: 10,
+            left: 10,
+            height: Ti.UI.SIZE,
+            width: Ti.UI.SIZE,
+        }),
+        label = Ti.UI.createLabel({
+            left: 10,
+            right: 10,
+            color: "green",
+            backgroundColor: 'yellow',
+            text: "this is test text"
+        });
+        var win = createWindow({}, function() {
+            should(view.rect.x).eql(10);
+            should(view.rect.y).eql(10);
+            should(label.rect.x).eql(10);
+            should(label.rect.y).eql(0);
+            should(label.rect.width).eql(view.rect.width - 20);
+            should(view.rect.width).not.eql(win.rect.width - 20);
+            finish();
+        });
+        view.add(label);
+        win.add(view);
+        win.open();
+    });
+
+    // TIMOB-23372 #6
+    //
+    // left & right should just work for label (vertical)
+    // even when parent view doesn't have right value.
+    // parent view should fit the size of the child, not Window
+    // 
+    it("TIMOB-23372 #6", function (finish) {
+        var view = Ti.UI.createView({
+            backgroundColor: 'orange',
+            layout: "vertical",
+            top: 10,
+            left: 10,
+            height: Ti.UI.SIZE,
+            width: Ti.UI.SIZE,
+        }),
+        label = Ti.UI.createLabel({
+            left: 10,
+            right: 10,
+            color: "green",
+            backgroundColor: 'yellow',
+            text: "this is test text"
+        });
+        var win = createWindow({}, function() {
+            should(view.rect.x).eql(10);
+            should(view.rect.y).eql(10);
+            should(label.rect.x).eql(10);
+            should(label.rect.y).eql(0);
+            should(label.rect.width).eql(view.rect.width - 20);
+            should(view.rect.width).not.eql(win.rect.width - 20);
+            finish();
+        });
+        view.add(label);
+        win.add(view);
+        win.open();
+    });
+
+    // TIMOB-23372 #7
+    //
+    // left & right should just work for label (composite)
+    // even when parent view doesn't have right value.
+    // parent view should fit the size of the child, not Window
+    // 
+    it("TIMOB-23372 #7", function (finish) {
+        var view = Ti.UI.createView({
+            backgroundColor: 'orange',
+            layout: "composite",
+            top: 10,
+            left: 10,
+            height: Ti.UI.SIZE,
+            width: Ti.UI.SIZE,
+        }),
+        label = Ti.UI.createLabel({
+            left: 10,
+            right: 10,
+            color: "green",
+            backgroundColor: 'yellow',
+            text: "this is test text"
+        });
+        var win = createWindow({}, function() {
+            should(view.rect.x).eql(10);
+            should(view.rect.y).eql(10);
+            should(label.rect.x).eql(10);
+            should(label.rect.y).eql(0);
+            should(label.rect.width).eql(view.rect.width - 20);
+            should(view.rect.width).not.eql(win.rect.width - 20);
+            finish();
+        });
+        view.add(label);
+        win.add(view);
+        win.open();
+    });
+
+    // TIMOB-23372 #8
+    //
+    // left & right should just work for child view when parent is Window (composite)
+    // 
+    it("TIMOB-23372 #8", function (finish) {
+        var label = Ti.UI.createLabel({
+            left: 10,
+            right: 10,
+            backgroundColor:'yellow',
+            color: "green",
+            text: "this is test text"
+        });
+        var win = createWindow({layout:'composite'}, function() {
+            should(label.rect.x).eql(10);
+            should(label.rect.width).eql(win.rect.width - 20);
+            finish();
+        });
+        win.add(label);
+        win.open();
+    });
+
+    // TIMOB-23372 #9
+    //
+    // left & right should just work for child view when parent is Window (horizontal)
+    // 
+    it("TIMOB-23372 #9", function (finish) {
+        var label = Ti.UI.createLabel({
+            left: 10,
+            right: 10,
+            backgroundColor:'yellow',
+            color: "green",
+            text: "this is test text"
+        });
+        var win = createWindow({layout:'horizontal'}, function() {
+            should(label.rect.x).eql(10);
+            should(label.rect.width).eql(win.rect.width - 20);
+            finish();
+        });
+        win.add(label);
+        win.open();
+    });
+
+    // TIMOB-23372 #10
+    //
+    // left & right should just work for child view when parent is Window (vertical)
+    // 
+    it("TIMOB-23372 #10", function (finish) {
+        var label = Ti.UI.createLabel({
+            left: 10,
+            right: 10,
+            backgroundColor:'yellow',
+            color: "green",
+            text: "this is test text"
+        });
+        var win = createWindow({layout:'vertical'}, function() {
+            should(label.rect.x).eql(10);
+            should(label.rect.width).eql(win.rect.width - 20);
+            finish();
+        });
+        win.add(label);
+        win.open();
+    });
+
 });

--- a/Source/LayoutEngine/src/Composite.cpp
+++ b/Source/LayoutEngine/src/Composite.cpp
@@ -190,17 +190,32 @@ namespace Titanium
 			double x3 = 0;
 
 			if (widthType == Size) {
-				x1 = x2 = NAN;
+				if (leftType != None && rightType != None) {
+					x1 = 1;
+					if (leftType == Percent) {
+						x1 -= leftValue;
+					} else if (leftType == Fixed) {
+						x2 -= leftValue;
+					}
+					if (rightType == Percent) {
+						x1 -= rightValue;
+					} else if (rightType == Fixed) {
+						x2 -= rightValue;
+					}
+				} else {
+					x1 = x2 = NAN;
+				}
 			} else if (widthType == Fill) {
 				x1 = 1;
 				if (leftType == Percent) {
 					x1 -= leftValue;
 				} else if (leftType == Fixed) {
-					x2 = -leftValue;
-				} else if (rightType == Percent) {
+					x2 -= leftValue;
+				}
+				if (rightType == Percent) {
 					x1 -= rightValue;
 				} else if (rightType == Fixed) {
-					x2 = -rightValue;
+					x2 -= rightValue;
 				}
 			} else if (widthType == Percent) {
 				x1 = widthValue;
@@ -258,11 +273,12 @@ namespace Titanium
 				if (topType == Percent) {
 					x1 -= topValue;
 				} else if (topType == Fixed) {
-					x2 = -topValue;
-				} else if (bottomType == Percent) {
+					x2 -= topValue;
+				}
+				if (bottomType == Percent) {
 					x1 -= bottomValue;
 				} else if (bottomType == Fixed) {
-					x2 = -bottomValue;
+					x2 -= bottomValue;
 				}
 			} else if (heightType == Percent) {
 				x1 = heightValue;

--- a/Source/LayoutEngine/src/Vertical.cpp
+++ b/Source/LayoutEngine/src/Vertical.cpp
@@ -163,17 +163,32 @@ namespace Titanium
 
 			// Width rule evaluation
 			if (widthType == Size) {
-				x1 = x2 = NAN;
+				if (leftType != None && rightType != None) {
+					x1 = 1;
+					if (leftType == Percent) {
+						x1 -= leftValue;
+					} else if (leftType == Fixed) {
+						x2 -= leftValue;
+					}
+					if (rightType == Percent) {
+						x1 -= rightValue;
+					} else if (rightType == Fixed) {
+						x2 -= rightValue;
+					}
+				} else {
+					x1 = x2 = NAN;
+				}
 			} else if (widthType == Fill) {
 				x1 = 1;
 				if (leftType == Percent) {
 					x1 -= leftValue;
 				} else if (leftType == Fixed) {
-					x2 = -leftValue;
-				} else if (rightType == Percent) {
+					x2 -= leftValue;
+				}
+				if (rightType == Percent) {
 					x1 -= rightValue;
 				} else if (rightType == Fixed) {
-					x2 = -rightValue;
+					x2 -= rightValue;
 				}
 			} else if (widthType == Percent) {
 				x1 = widthValue;
@@ -232,10 +247,10 @@ namespace Titanium
 				x1 = x2 = x3 = NAN;
 			} else if (heightType == Fill) {
 				x2 = 1;
-				topType == Percent&&(x1 = -topValue);
-				topType == Fixed&&(x3 = -topValue);
-				bottomType == Percent&&(x1 = -bottomValue);
-				bottomType == Fixed&&(x3 = -bottomValue);
+				topType == Percent&&(x1 -= topValue);
+				topType == Fixed&&(x3 -= topValue);
+				bottomType == Percent&&(x1 -= bottomValue);
+				bottomType == Fixed&&(x3 -= bottomValue);
 			} else if (heightType == Percent) {
 				x1 = heightValue;
 			} else if (heightType == Fixed) {

--- a/Source/UI/include/TitaniumWindows/UI/Label.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/Label.hpp
@@ -57,8 +57,6 @@ namespace TitaniumWindows
 		private:
 			Windows::UI::Xaml::Controls::Grid^ parent__;
 			Windows::UI::Xaml::Controls::TextBlock^ label__;
-			Windows::Foundation::EventRegistrationToken label_sizechanged_event__;
-			bool sizeChanged__{ false };
 		};
 	} // namespace UI
 } // namespace TitaniumWindows

--- a/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
@@ -432,6 +432,15 @@ namespace TitaniumWindows
 				underlying_control__ = control;
 			}
 
+			//
+			// Check if this component uses its own width
+			//
+			virtual bool shouldUseOwnWidth() const TITANIUM_NOEXCEPT;
+
+			//
+			// Check if this component uses its own height
+			//
+			virtual bool shouldUseOwnHeight() const TITANIUM_NOEXCEPT;
 
 			virtual Titanium::LayoutEngine::Node* getLayoutNode() const TITANIUM_NOEXCEPT
 			{
@@ -441,6 +450,11 @@ namespace TitaniumWindows
 			virtual bool isLoaded() const TITANIUM_NOEXCEPT
 			{
 				return is_loaded__;
+			}
+
+			virtual void useOwnSize() TITANIUM_NOEXCEPT
+			{
+				use_own_size__ = true;
 			}
 
 			virtual void requestLayout(const bool& fire_event = false);
@@ -513,6 +527,7 @@ namespace TitaniumWindows
 			bool is_scrollview__ { false };
 			bool is_button__{ false };
 			bool is_loaded__{false};
+			bool use_own_size__ { false };
 
 			Titanium::LayoutEngine::Rect oldRect__;
 

--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -1312,10 +1312,33 @@ namespace TitaniumWindows
 			}
 		}
 
+
+		bool WindowsViewLayoutDelegate::shouldUseOwnWidth() const TITANIUM_NOEXCEPT
+		{
+			// Check if parent can't decide its width and this component doesn't have fixed width property & handles its width
+			if (use_own_size__ && layout_node__->parent != nullptr) {
+				return get_width().empty()
+					&& layout_node__->parent->properties.right.valueType == Titanium::LayoutEngine::ValueType::None
+					&& layout_node__->parent->properties.width.valueType == Titanium::LayoutEngine::ValueType::Size;
+			}
+			return false;
+		}
+
+		bool WindowsViewLayoutDelegate::shouldUseOwnHeight() const TITANIUM_NOEXCEPT
+		{
+			// Check if parent can't decide its height and this component doesn't have fixed height property & handles its height
+			if (use_own_size__ && layout_node__->parent != nullptr) {
+				return get_height().empty()
+					&& layout_node__->parent->properties.bottom.valueType == Titanium::LayoutEngine::ValueType::None
+					&& layout_node__->parent->properties.height.valueType == Titanium::LayoutEngine::ValueType::Size;
+			}
+			return false;
+		}
+
 		void WindowsViewLayoutDelegate::onLayoutEngineCallback(Titanium::LayoutEngine::Rect rect, const std::string& name)
 		{
-			auto skipHeight = (is_height_size__ && rect.height == 0);
-			auto skipWidth  = (is_width_size__  && rect.width  == 0);
+			auto skipHeight = shouldUseOwnHeight() || (is_height_size__ && rect.height == 0);
+			auto skipWidth  = shouldUseOwnWidth()  || (is_width_size__  && rect.width  == 0);
 
 			if (rect.width < 0 || rect.height < 0)
 				return;


### PR DESCRIPTION
[TIMOB-23372](https://jira.appcelerator.org/browse/TIMOB-23372)

#690 + unit tests + fixes on Label

- Fix ``right`` and ``bottom`` margins in ``Composite`` ``Horizontal`` and ``Vertical`` of LayoutEngine
- The layout engine did not take into account the ``right`` offset when calculating the new width due to an incorrect ``if`` statement
- If a component is of width ``Ti.UI.SIZE`` and the ``right`` margin is specified, it should calculate the new width taking into account both ``left`` and ``right`` margins
- Made a workaround to match iOS and Android when percentage values of ``left`` and ``right`` are set inside a parent View

###### TEST CASE # 1

![1](https://cloud.githubusercontent.com/assets/1661068/15460300/6525c9c2-20ea-11e6-85bf-d7aa72f24ce8.png)

```javascript
var win = Ti.UI.createWindow({ backgroundColor: 'green' }),
    view = Ti.UI.createView({
        backgroundColor: 'yellow',
        top: 10,
        left: 10,
        right: 10,
        height: Ti.UI.SIZE,
        width: Ti.UI.SIZE,
    }),
    label = Ti.UI.createLabel({
        left: 10,
        right: 10,
        color: "blue",
        backgroundColor: 'orange',
        text: "this is test text"
    });
view.add(label);
win.add(view);
win.open();
```

###### TEST CASE # 2

![2](https://cloud.githubusercontent.com/assets/1661068/15460429/f2aa0bfe-20eb-11e6-997d-6b4f96a043c9.png)

Note: On iOS, view is not scaled correctly due to [TIMOB-23385](https://jira.appcelerator.org/browse/TIMOB-23385).

```javascript
var win = Ti.UI.createWindow({ backgroundColor: 'green' }),
    view = Ti.UI.createView({
        backgroundColor: 'yellow',
        top: 10,
        left: 10,
        height: Ti.UI.SIZE,
        width: Ti.UI.SIZE,
    }),
    label = Ti.UI.createLabel({
        left: 10,
        right: 10,
        color: "blue",
        backgroundColor: 'orange',
        text: "this is test text"
    });
view.add(label);
win.add(view);
win.open();
```