### PR TITLE
[TIMOB-23422] Try and fix HTTPClient post with Blob and string data

### DIFF
--- a/Examples/NMocha/src/Assets/ti.network.httpclient.test.js
+++ b/Examples/NMocha/src/Assets/ti.network.httpclient.test.js
@@ -7,13 +7,22 @@
 var should = require('./should');
 
 describe("Titanium.Network.HTTPClient", function () {
+    it("apiName", function (finish) {
+        var xhr = Ti.Network.createHTTPClient();
+        // See https://jira.appcelerator.org/browse/TIMOB-23346
+        if (Ti.Platform.osname === 'windowsstore' || Ti.Platform.osname === 'windowsphone') {
+            should(xhr.apiName).be.eql("Titanium.Network.HTTPClient");
+        } else {
+            should(xhr.apiName).be.eql("Ti.Network.HTTPClient");
+        }
+        finish();
+    });
+
     (Ti.Platform.osname === 'windowsstore' ? it.skip : it)("responseXML", function (finish) {
         this.timeout(6e4);
 
         var xhr = Ti.Network.createHTTPClient();
         xhr.setTimeout(6e4);
-
-        should(xhr.apiName).be.eql("Titanium.Network.HTTPClient");
 
         xhr.onload = function (e) {
             should(xhr.responseXML === null).be.false;
@@ -82,7 +91,7 @@ describe("Titanium.Network.HTTPClient", function () {
         xhr.send("TIMOB-23127");
     });
 
-	it("TIMOB-23214", function (finish) {
+    it("TIMOB-23214", function (finish) {
         this.timeout(6e4);
 
         var xhr = Ti.Network.createHTTPClient();
@@ -366,5 +375,57 @@ describe("Titanium.Network.HTTPClient", function () {
             password: "sanford1000",
             message: "check me out"
         });
+    });
+
+    it("POST mulitpart/form-data containing Ti.Blob", function (finish) {
+        this.timeout(6e4);
+
+        var xhr = Ti.Network.createHTTPClient(),
+            imageFile = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, 'Logo.png'),
+            newId = new Date().getTime(),
+            newName = 'HEY_YOU_GUYS_WAIT_FOR_ME-' + newId,
+            form,
+            blob = imageFile.read(imageFile);
+
+        xhr.setTimeout(6e4);
+
+        xhr.onload = function (e) {
+            should(function () {
+                //should(e.code).eql(200);// because our API is insane, this always returns 0
+                should(xhr.status).eql(200);
+
+                var result = JSON.parse(xhr.responseText);
+                // check sent headers
+                should(result).have.property('headers');
+                should(result.headers).have.property('Content-Type');
+                should(result.headers['Content-Type']).startWith('multipart/form-data');
+
+                // check name got added
+                should(result).have.property('form');
+                should(result.form).have.property('name');
+                should(result.form.name).eql(newName);
+
+                // check blob data
+                should(result).have.property('files');
+                should(result.files).have.property('attachment');
+                should(result.files.attachment).startWith('data:');
+                // may be application/octet-stream (curl), image/png (Android)
+                // TODO Can we parse this data and make sure it's an actual match against the logo file? curl and Android matched...
+                should(result.files.attachment).endWith(';base64,iVBORw0KGgoAAAANSUhEUgAAAJYAAACWCAYAAAA8AXHiAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAsNJREFUeNrs3b1NI0EYgGG8InQZlEFCdl1AfhGRayCiABKugMvJaIECKMP53hgZ6QJujXwzuzvf97zSyoEt2Z55NLO2/LMZx/FCqt1gCASWwBJYElgCS2BJYAksgSWBJbAElgSWwBJYElgCS2BJYAksgSWBJbAElgSWwBJYElgCS2BJYAksgSWBJbAUusuOHuur6froxoolW6GUdSv8qn057jebzXukSRnH8apcPJZja8VapsPAPx4nAiqwqqxU4XBFQdUzrPtouCZQPYA1U8dzqjC4plCV5/oCFlxQRTh57x1XVFQRXhV2iysyqhCwesQVHVUYWD3hyoAqFKwecGVBFQ7WmnGV+95mQRUS1hpxZUMVFtaacP2F6ioLqtCw1oArK6rwsJbElRlVClhL4MqOKg2sOXFNoPqVBVUqWHPgmkD1Uu77OdNYp/vMeytcJ1A9ZBvnlF+mqI0LKrCq44IKrOq4oAKrOi6owKqOCyqwquOCCqzquKACqwmucuygAqsFrmuowGqBCyqwquF6+8fVv40QWGdVTtZ3X2x/n4X6lRuw5kX1Y+ImW7jAqoEq1A+RgLUiVOWc6w0usGqj2p94KwIusM5DdeKtCLjAOh8VXGA1QwUXWM1QwQVWM1RwgdUMFVxgfaK6q40KruSwyuQeQN22QAVXUlhHVLuWqOBKBmtOVHAlgbUEKriCw1oSVXZcQzJU+zlRZcY1QAUXWP+PatF/Ys2Ea4AKLrA6R5UJ1wAVXGAFQZUB1wAVXGAFQxUZ1wDV+nGBNV8/I6H6Bi6wZmobDdUJXN11GWAuDsieyvZ4ISuWwJLO2NJtIbJiCSyBJYElsASWBJbAElgSWAJLYElgCSyBJYElsASWBJbAElgSWAJLYElgCSyBJYElsASWBJbAElgSWAJLYElgCSyBJYElsASWBJbAElgSWFqyPwIMAMpfdKkmd/FSAAAAAElFTkSuQmCC');
+            }).not.throw();
+            finish();
+        };
+        xhr.onerror = function (e) {
+            finish(new Error(e.error || this.responseText));
+        };
+
+        xhr.open('POST', 'http://www.httpbin.org/post');
+
+        form = {
+            name: newName,
+            attachment: blob
+        };
+
+        xhr.send(form);
     });
 });

--- a/Examples/NMocha/src/Assets/ti.network.httpclient.test.js
+++ b/Examples/NMocha/src/Assets/ti.network.httpclient.test.js
@@ -377,7 +377,7 @@ describe("Titanium.Network.HTTPClient", function () {
         });
     });
 
-    it("POST mulitpart/form-data containing Ti.Blob", function (finish) {
+    it("POST multipart/form-data containing Ti.Blob", function (finish) {
         this.timeout(6e4);
 
         var xhr = Ti.Network.createHTTPClient(),
@@ -390,29 +390,25 @@ describe("Titanium.Network.HTTPClient", function () {
         xhr.setTimeout(6e4);
 
         xhr.onload = function (e) {
-            should(function () {
-                //should(e.code).eql(200);// because our API is insane, this always returns 0
-                should(xhr.status).eql(200);
+            //should(e.code).eql(200);// because our API is insane, this always returns 0
+            should(xhr.status).eql(200);
+            var result = JSON.parse(xhr.responseText);
+            // check sent headers
+            should(result).have.property('headers');
+            should(result.headers).have.property('Content-Type');
+            should(result.headers['Content-Type']).startWith('multipart/form-data');
 
-                var result = JSON.parse(xhr.responseText);
-                // check sent headers
-                should(result).have.property('headers');
-                should(result.headers).have.property('Content-Type');
-                should(result.headers['Content-Type']).startWith('multipart/form-data');
+            // check name got added
+            should(result).have.property('form');
+            should(result.form).have.property('name');
+            should(result.form.name).eql(newName);
 
-                // check name got added
-                should(result).have.property('form');
-                should(result.form).have.property('name');
-                should(result.form.name).eql(newName);
+            // check blob data
+            should(result).have.property('files');
+            should(result.files).have.property('attachment');
+            // image/png (Android), image/png (Windows). Ideally this would match the mimetype/contenttype of the file (which it does for Android/Windows). Let's hope it does on iOS?
+            should(result.files.attachment).eql('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJYAAACWCAYAAAA8AXHiAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAsNJREFUeNrs3b1NI0EYgGG8InQZlEFCdl1AfhGRayCiABKugMvJaIECKMP53hgZ6QJujXwzuzvf97zSyoEt2Z55NLO2/LMZx/FCqt1gCASWwBJYElgCS2BJYAksgSWBJbAElgSWwBJYElgCS2BJYAksgSWBJbAElgSWwBJYElgCS2BJYAksgSWBJbAUusuOHuur6froxoolW6GUdSv8qn057jebzXukSRnH8apcPJZja8VapsPAPx4nAiqwqqxU4XBFQdUzrPtouCZQPYA1U8dzqjC4plCV5/oCFlxQRTh57x1XVFQRXhV2iysyqhCwesQVHVUYWD3hyoAqFKwecGVBFQ7WmnGV+95mQRUS1hpxZUMVFtaacP2F6ioLqtCw1oArK6rwsJbElRlVClhL4MqOKg2sOXFNoPqVBVUqWHPgmkD1Uu77OdNYp/vMeytcJ1A9ZBvnlF+mqI0LKrCq44IKrOq4oAKrOi6owKqOCyqwquOCCqzquKACqwmucuygAqsFrmuowGqBCyqwquF6+8fVv40QWGdVTtZ3X2x/n4X6lRuw5kX1Y+ImW7jAqoEq1A+RgLUiVOWc6w0usGqj2p94KwIusM5DdeKtCLjAOh8VXGA1QwUXWM1QwQVWM1RwgdUMFVxgfaK6q40KruSwyuQeQN22QAVXUlhHVLuWqOBKBmtOVHAlgbUEKriCw1oSVXZcQzJU+zlRZcY1QAUXWP+PatF/Ys2Ea4AKLrA6R5UJ1wAVXGAFQZUB1wAVXGAFQxUZ1wDV+nGBNV8/I6H6Bi6wZmobDdUJXN11GWAuDsieyvZ4ISuWwJLO2NJtIbJiCSyBJYElsASWBJbAElgSWAJLYElgCSyBJYElsASWBJbAElgSWAJLYElgCSyBJYElsASWBJbAElgSWAJLYElgCSyBJYElsASWBJbAElgSWFqyPwIMAMpfdKkmd/FSAAAAAElFTkSuQmCC');
 
-                // check blob data
-                should(result).have.property('files');
-                should(result.files).have.property('attachment');
-                should(result.files.attachment).startWith('data:');
-                // may be application/octet-stream (curl), image/png (Android)
-                // TODO Can we parse this data and make sure it's an actual match against the logo file? curl and Android matched...
-                should(result.files.attachment).endWith(';base64,iVBORw0KGgoAAAANSUhEUgAAAJYAAACWCAYAAAA8AXHiAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAsNJREFUeNrs3b1NI0EYgGG8InQZlEFCdl1AfhGRayCiABKugMvJaIECKMP53hgZ6QJujXwzuzvf97zSyoEt2Z55NLO2/LMZx/FCqt1gCASWwBJYElgCS2BJYAksgSWBJbAElgSWwBJYElgCS2BJYAksgSWBJbAElgSWwBJYElgCS2BJYAksgSWBJbAUusuOHuur6froxoolW6GUdSv8qn057jebzXukSRnH8apcPJZja8VapsPAPx4nAiqwqqxU4XBFQdUzrPtouCZQPYA1U8dzqjC4plCV5/oCFlxQRTh57x1XVFQRXhV2iysyqhCwesQVHVUYWD3hyoAqFKwecGVBFQ7WmnGV+95mQRUS1hpxZUMVFtaacP2F6ioLqtCw1oArK6rwsJbElRlVClhL4MqOKg2sOXFNoPqVBVUqWHPgmkD1Uu77OdNYp/vMeytcJ1A9ZBvnlF+mqI0LKrCq44IKrOq4oAKrOi6owKqOCyqwquOCCqzquKACqwmucuygAqsFrmuowGqBCyqwquF6+8fVv40QWGdVTtZ3X2x/n4X6lRuw5kX1Y+ImW7jAqoEq1A+RgLUiVOWc6w0usGqj2p94KwIusM5DdeKtCLjAOh8VXGA1QwUXWM1QwQVWM1RwgdUMFVxgfaK6q40KruSwyuQeQN22QAVXUlhHVLuWqOBKBmtOVHAlgbUEKriCw1oSVXZcQzJU+zlRZcY1QAUXWP+PatF/Ys2Ea4AKLrA6R5UJ1wAVXGAFQZUB1wAVXGAFQxUZ1wDV+nGBNV8/I6H6Bi6wZmobDdUJXN11GWAuDsieyvZ4ISuWwJLO2NJtIbJiCSyBJYElsASWBJbAElgSWAJLYElgCSyBJYElsASWBJbAElgSWAJLYElgCSyBJYElsASWBJbAElgSWAJLYElgCSyBJYElsASWBJbAElgSWFqyPwIMAMpfdKkmd/FSAAAAAElFTkSuQmCC');
-            }).not.throw();
             finish();
         };
         xhr.onerror = function (e) {

--- a/Examples/NMocha/src/Assets/ti.network.test.js
+++ b/Examples/NMocha/src/Assets/ti.network.test.js
@@ -1,6 +1,6 @@
 /*
  * Appcelerator Titanium Mobile
- * Copyright (c) 2011-2015 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2011-2016 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
@@ -9,7 +9,12 @@ var should = require('./should');
 describe("Titanium.Network", function () {
 
     it("apiName", function (finish) {
-        should(Ti.Network.apiName).be.eql("Titanium.Network")
+        // See https://jira.appcelerator.org/browse/TIMOB-23346
+        if (Ti.Platform.osname === 'windowsstore' || Ti.Platform.osname === 'windowsphone') {
+            should(Ti.Network.apiName).be.eql("Titanium.Network");
+        } else {
+            should(Ti.Network.apiName).be.eql("Ti.Network");
+        }
         finish();
     });
 

--- a/Source/Network/include/TitaniumWindows/Network/HTTPClient.hpp
+++ b/Source/Network/include/TitaniumWindows/Network/HTTPClient.hpp
@@ -52,7 +52,7 @@ namespace TitaniumWindows
 			virtual std::string getResponseHeader(const std::string& name) TITANIUM_NOEXCEPT override final;
 			virtual void open(const std::string& method, const std::string& url) TITANIUM_NOEXCEPT override final;
 			virtual void send() TITANIUM_NOEXCEPT override final;
-			virtual void send(const std::map<std::string, std::vector<std::uint8_t>>& postDataPairs, const bool& useMultipartForm) TITANIUM_NOEXCEPT override final;
+			virtual void send(const std::map<std::string, JSValue>& postDataPairs, const bool& useMultipartForm) TITANIUM_NOEXCEPT override final;
 			virtual void send(const std::string& postDataStr) TITANIUM_NOEXCEPT override final;
 			virtual void setRequestHeader(const std::string& name, const std::string& value) TITANIUM_NOEXCEPT override final;
 			// properties
@@ -101,7 +101,7 @@ namespace TitaniumWindows
 
 			void startDispatcherTimer();
 			task<Windows::Storage::Streams::IBuffer^> HTTPClient::HTTPResultAsync(Windows::Storage::Streams::IInputStream^ stream, concurrency::cancellation_token token);
-			Windows::Storage::Streams::Buffer^ charVecToBuffer(std::vector<std::uint8_t> char_vector);
+			Windows::Storage::Streams::IBuffer^ charVecToBuffer(std::vector<std::uint8_t> char_vector);
 
 			void SerializeHeaders(Windows::Web::Http::HttpResponseMessage^ response);
 			void SerializeHeaderCollection(Windows::Foundation::Collections::IIterable<Windows::Foundation::Collections::IKeyValuePair<::Platform::String^, ::Platform::String^>^>^ headers);

--- a/Source/Network/src/HTTPClient.cpp
+++ b/Source/Network/src/HTTPClient.cpp
@@ -117,32 +117,39 @@ namespace TitaniumWindows
 			send(postData);
 		}
 
-		void HTTPClient::send(const std::map<std::string, std::vector<std::uint8_t>>& postDataPairs, const bool& useMultipartForm) TITANIUM_NOEXCEPT
+		void HTTPClient::send(const std::map<std::string, JSValue>& postDataPairs, const bool& useMultipartForm) TITANIUM_NOEXCEPT
 		{
 			if (method__ == Titanium::Network::RequestMethod::Get) {
 				TITANIUM_MODULE_LOG_WARN("HTTPClient::send: Data found during a GET request. Method will be changed to POST.");
 				method__ = Titanium::Network::RequestMethod::Post;
 			}
 
+
 			Windows::Web::Http::IHttpContent^ postData;
 			if (useMultipartForm) {
 				postData = ref new Windows::Web::Http::HttpMultipartFormDataContent();
 
 				for (auto pair : postDataPairs) {
-					Platform::String ^ name = TitaniumWindows::Utility::ConvertString(pair.first);
-					static_cast<Windows::Web::Http::HttpMultipartFormDataContent^>(postData)->Add(ref new Windows::Web::Http::HttpBufferContent(charVecToBuffer(pair.second)), name);
+					Platform::String^ name = TitaniumWindows::Utility::ConvertUTF8String(pair.first);
+					const auto value = pair.second;
+					if (value.IsObject()) {
+						auto blob_ptr = static_cast<JSObject>(value).GetPrivate<Titanium::Blob>();
+						if (blob_ptr != nullptr) {
+							static_cast<Windows::Web::Http::HttpMultipartFormDataContent^>(postData)->Add(ref new Windows::Web::Http::HttpBufferContent(charVecToBuffer(blob_ptr->getData())), name);
+							continue;
+						}
+					}
+
+					// Assume string
+					std::string str = static_cast<std::string>(value);
+					Platform::String^ converted = TitaniumWindows::Utility::ConvertUTF8String(str);
+					static_cast<Windows::Web::Http::HttpMultipartFormDataContent^>(postData)->Add(ref new Windows::Web::Http::HttpStringContent(converted), name);
 				}
 			} else {
 				auto keyValues = ref new Platform::Collections::Map<Platform::String^, Platform::String^>();
 				for (auto pair : postDataPairs) {
-					Platform::String ^ name = TitaniumWindows::Utility::ConvertString(pair.first);
-
-					std::stringstream ws_stream;
-					for (auto c : pair.second) {
-						ws_stream << c;
-					}
-
-					Platform::String ^ value = TitaniumWindows::Utility::ConvertString(ws_stream.str());
+					Platform::String^ name = TitaniumWindows::Utility::ConvertUTF8String(pair.first);
+					Platform::String^ value = TitaniumWindows::Utility::ConvertUTF8String(static_cast<std::string>(pair.second));
 					keyValues->Insert(name, value);
 				}
 
@@ -371,26 +378,13 @@ namespace TitaniumWindows
 			}
 		}
 
-		Windows::Storage::Streams::Buffer^ HTTPClient::charVecToBuffer(std::vector<std::uint8_t> char_vector)
+		Windows::Storage::Streams::IBuffer^ HTTPClient::charVecToBuffer(std::vector<std::uint8_t> char_vector)
 		{
+			using namespace Windows::Storage;
 			int size = char_vector.size();
-
-			Windows::Storage::Streams::Buffer^ buffer = ref new Windows::Storage::Streams::Buffer(size);
-			buffer->Length = size;
-
-			Microsoft::WRL::ComPtr<Windows::Storage::Streams::IBufferByteAccess> bufferByteAccess;
-			HRESULT hr = reinterpret_cast<IUnknown*>(buffer)->QueryInterface(IID_PPV_ARGS(&bufferByteAccess));
-			if (FAILED(hr)) {
-				throw ref new Platform::Exception(hr);
-			}
-
-			std::uint8_t* data = (std::uint8_t*)&char_vector[0];
-			hr = bufferByteAccess->Buffer(&data);
-			if (FAILED(hr)) {
-				throw ref new Platform::Exception(hr);
-			}
-
-			return buffer;
+			const auto writer = ref new Streams::DataWriter(ref new Streams::InMemoryRandomAccessStream());
+			writer->WriteBytes(::Platform::ArrayReference<std::uint8_t>(&char_vector[0], size));
+			return writer->DetachBuffer();
 		}
 
 		void HTTPClient::SerializeHeaders(Windows::Web::Http::HttpResponseMessage^ response)

--- a/Source/TitaniumKit/include/Titanium/Network/HTTPClient.hpp
+++ b/Source/TitaniumKit/include/Titanium/Network/HTTPClient.hpp
@@ -237,7 +237,7 @@ namespace Titanium
 			  @abstract send
 			  @discussion Do an HTTP POST or PUT request with data URL encoded or contained in multipart form.
 			*/
-			virtual void send(const std::map<std::string, std::vector<std::uint8_t>>& postDataPairs, const bool& useMultipartForm) TITANIUM_NOEXCEPT;
+			virtual void send(const std::map<std::string, JSValue>& postDataPairs, const bool& useMultipartForm) TITANIUM_NOEXCEPT;
 
 			/*!
 			  @method

--- a/Source/TitaniumKit/src/Network/HTTPClient.cpp
+++ b/Source/TitaniumKit/src/Network/HTTPClient.cpp
@@ -94,7 +94,7 @@ namespace Titanium
 			TITANIUM_LOG_WARN("HTTPClient::send: unimplemented");
 		}
 
-		void HTTPClient::send(const std::map<std::string, std::vector<std::uint8_t>>& postDataPairs, const bool& useMultipartForm) TITANIUM_NOEXCEPT
+		void HTTPClient::send(const std::map<std::string, JSValue>& postDataPairs, const bool& useMultipartForm) TITANIUM_NOEXCEPT
 		{
 			TITANIUM_LOG_WARN("HTTPClient::send<data>: unimplemented");
 		}
@@ -293,24 +293,15 @@ namespace Titanium
 					send(postDataString);
 				} else {
 					bool useMultipartForm = false;
-					std::map<std::string, std::vector<std::uint8_t>> map;
+					std::map<std::string, JSValue> map;
 					JSObject sendArgs = static_cast<JSObject>(arguments.at(0));
 					for (const auto& property_name : static_cast<std::vector<JSString>>(sendArgs.GetPropertyNames())) {
 						TITANIUM_ASSERT(sendArgs.GetProperty(property_name).IsObject() || sendArgs.GetProperty(property_name).IsString());
 						JSValue prop = sendArgs.GetProperty(property_name);
 						if (prop.IsObject()) {
 							useMultipartForm = true;
-							auto blob_ptr = static_cast<JSObject>(prop).GetPrivate<Titanium::Blob>();
-							if (blob_ptr != nullptr) {
-								map.insert(std::make_pair(property_name, blob_ptr->getData()));
-							} else {
-								std::string str = static_cast<std::string>(prop);
-								map.insert(std::make_pair(property_name, std::vector<std::uint8_t>(str.begin(), str.end())));
-							}
-						} else {
-							std::string str = static_cast<std::string>(prop);
-							map.insert(std::make_pair(property_name, std::vector<std::uint8_t>(str.begin(), str.end())));
 						}
+						map.insert(std::make_pair(property_name, prop));
 					}
 					send(map, useMultipartForm);
 				}


### PR DESCRIPTION
**JIRA**: https://jira.appcelerator.org/browse/TIMOB-23422

Looks like we're mangling the post data we send as multi-part form data. I'm not sure we can properly convert everything to `std::vector<std::uint8_t>` like we currently do. So this PR goes back to keep the values as JSValue and letting the Windows implementation look for Blobs and when found basically just copy their data as a buffer passthrough, otherwise cast to std::string and convert to Platform::String as normal string content.

I created a new requestbin used below, and tested with the following code. I still need to hit it with iOS/Android to compare the exact data from the PNG file matches, but the request looks closer. (Note that Android actually writes a blob as a file to disk and then uses Apache's FileBody to attach it - whereas we pass the bytes in a buffer without re-writing to disk).

http://requestb.in/1j1lh941?inspect

```javascript
var url = 'http://requestb.in/1j1lh941';
//use favorite inspector here...

function go() {
    var imageFile = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, "Logo.png");
    var newId = new Date().getTime();
    var newName = 'HEY_YOU_GUYS_WAIT_FOR_ME-' + newId;
    var client = Ti.Network.createHTTPClient({
        onload: function (e) {
            alert('success');
        },
        onerror: function (err) {
            alert('error');
        }
    });

    client.open("POST", url);

    var f = {
        name: newName,
        attachment: imageFile.read(imageFile)
    };

    client.send(f);
      
}


Titanium.UI.setBackgroundColor('#fff');

var win = Titanium.UI.createWindow({
    title: 'win',
    backgroundColor: '#fff'
});

var label = Ti.UI.createLabel({
    color: 'blue',
    text: 'Send it!',
    width: 300, height: 200
});

label.addEventListener('click', function (e) {
    go();
});

win.add(label);

win.open();
```