### PR TITLE
[TIMOB-23305] Ti.UI.Label width is not updated when setting new text

### DIFF
--- a/Examples/NMocha/src/Assets/ti.ui.layout.test.js
+++ b/Examples/NMocha/src/Assets/ti.ui.layout.test.js
@@ -1488,4 +1488,33 @@ describe("Titanium.UI.Layout", function () {
         win.open();
     });
 
+    // TIMOB-23305
+    //
+    // Label width should be updated when setting new text
+    it("TIMOB-23305", function (finish) {
+        var label = Ti.UI.createLabel({
+            text: 'Lorem ipsum dolor sit amet',
+            backgroundColor: 'orange',
+        });
+        var savedRect = {};
+        var win = createWindow({}, function () {
+                should(label.rect.width).not.eql(0);
+                should(label.rect.height).not.eql(0);
+                should(label.rect.width).greaterThan(savedRect.width);
+                if (Ti.Platform.osname === 'windowsphone') {
+                    should(label.rect.height).greaterThan(savedRect.height);
+                }
+                finish();
+        });
+        label.addEventListener('postlayout', function () {
+            if (didPostlayout) return;
+            didPostlayout = true;
+            savedRect = label.rect;
+            should(label.rect.width).not.eql(0);
+            should(label.rect.height).not.eql(0);
+            label.text = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut mollis rutrum dignissim.';
+        });
+        win.add(label);
+        win.open();
+    });
 });

--- a/Source/TitaniumKit/include/Titanium/Module.hpp
+++ b/Source/TitaniumKit/include/Titanium/Module.hpp
@@ -221,6 +221,7 @@ namespace Titanium
 
 #pragma warning(push)
 #pragma warning(disable : 4251)
+		bool propertiesSet__{ false };
 		bool bubbleParent__ { true };
 		std::string apiName__;
 		std::shared_ptr<Titanium::UI::Window> lifecycleContainerWindow__;

--- a/Source/TitaniumKit/src/Module.cpp
+++ b/Source/TitaniumKit/src/Module.cpp
@@ -121,8 +121,10 @@ namespace Titanium
 				this_object.SetProperty(property_name, props.GetProperty(property_name));
 			}
 		}
+
 		const auto module = this_object.GetPrivate<Titanium::Module>();
 		if (module) {
+			module->propertiesSet__ = true;
 			module->afterPropertiesSet();
 		}
 	}

--- a/Source/UI/include/TitaniumWindows/UI/ImageView.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/ImageView.hpp
@@ -109,7 +109,6 @@ namespace TitaniumWindows
 			Windows::UI::Xaml::Controls::Border^ border__{ nullptr };
 			Windows::UI::Xaml::Controls::Image^ image__{ nullptr };
 			Windows::UI::Xaml::Media::Animation::Storyboard^ storyboard__;
-			bool propertiesSet__{ false };
 			bool sizeChanged__{ true };
 
 #pragma warning(pop)

--- a/Source/UI/include/TitaniumWindows/UI/Label.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/Label.hpp
@@ -46,6 +46,7 @@ namespace TitaniumWindows
 
 			virtual void set_color(const std::string& color) TITANIUM_NOEXCEPT override final;
 			virtual void set_text(const std::string& text) TITANIUM_NOEXCEPT override final;
+			virtual void set_text(const std::string& text, const bool resize) TITANIUM_NOEXCEPT;
 			virtual void set_textAlign(const Titanium::UI::TEXT_ALIGNMENT& textAlign) TITANIUM_NOEXCEPT override final;
 			virtual void set_verticalAlign(const Titanium::UI::TEXT_VERTICAL_ALIGNMENT& verticalAlign) TITANIUM_NOEXCEPT override final;
 			virtual void set_wordWrap(const bool& wordWrap) TITANIUM_NOEXCEPT override final;
@@ -55,6 +56,9 @@ namespace TitaniumWindows
 			static const std::uint32_t DefaultFontSize = 20;
 
 		private:
+			// Measure desired size based on current text.
+			void measureDesiredSize() TITANIUM_NOEXCEPT;
+
 			Windows::UI::Xaml::Controls::Grid^ parent__;
 			Windows::UI::Xaml::Controls::TextBlock^ label__;
 		};

--- a/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
@@ -482,7 +482,7 @@ namespace TitaniumWindows
 
 #pragma warning(push)
 #pragma warning(disable : 4251)
-			std::function<JSObject(const JSContext&, const JSObject&)> native_wrapper_hook__;
+			std::function<JSObject(const JSContext&, const JSObject&)> native_wrapper_hook__ { nullptr };
 			std::vector<std::string> filtered_events__;
 #pragma warning(pop)
 

--- a/Source/UI/src/ImageView.cpp
+++ b/Source/UI/src/ImageView.cpp
@@ -127,9 +127,6 @@ namespace TitaniumWindows
 		void ImageView::afterPropertiesSet() TITANIUM_NOEXCEPT
 		{
 			Titanium::UI::ImageView::afterPropertiesSet();
-
-			// Make sure to call set_image after all properties are set
-			propertiesSet__ = true;
 			
 			// Initialize image
 			if (!get_image().empty()) {

--- a/Source/UI/src/Label.cpp
+++ b/Source/UI/src/Label.cpp
@@ -89,10 +89,34 @@ namespace TitaniumWindows
 
 		void Label::set_text(const std::string& text) TITANIUM_NOEXCEPT
 		{
+			set_text(text, true);
+		}
+
+		void Label::set_text(const std::string& text, const bool resize) TITANIUM_NOEXCEPT
+		{
 			Titanium::UI::Label::set_text(text);
 			const auto new_text = TitaniumWindows::Utility::ConvertUTF8String(text);
-			if (label__->Text != new_text) {
-				label__->Text = new_text;
+
+			label__->Text = new_text;
+
+			if (propertiesSet__) {
+				measureDesiredSize();
+			}
+		}
+
+		void Label::measureDesiredSize() TITANIUM_NOEXCEPT
+		{
+			// TIMOB-23305: Measure desired size for this text and resize parent container accordingly.
+			Windows::Foundation::Size desiredSize{ static_cast<float>(label__->MaxWidth), static_cast<float>(label__->MaxHeight) };
+			label__->Measure(desiredSize);
+
+			const auto layout = getViewLayoutDelegate<WindowsViewLayoutDelegate>();
+
+			if (layout->get_width().empty() || layout->get_right().empty()) {
+				parent__->Width = label__->DesiredSize.Width;
+			}
+			if (layout->get_height().empty() || layout->get_bottom().empty()) {
+				parent__->Height = label__->DesiredSize.Height;
 			}
 		}
 


### PR DESCRIPTION
[TIMOB-23305](https://jira.appcelerator.org/browse/TIMOB-23305)

Attempt to update width when setting new text. Currently it's blocked because Xaml `TextBlock` does not shrink its size with shorter text.

* `TextBlock` does not change its size when `TextWrapping` is `Wrap`.
* `TextBlock` expands its size when `TextWrapping` is `NoWrap`.
* `TextBlock` does not shrink its size in every cases of text wrapping.
* ~~We might need to find a way to calculate its size for the given text and font manually.~~ <- `Measure()` works good for it

```javascript
var win = Ti.UI.createWindow({
    backgroundColor: 'green',
    layout: 'vertical'
});

var update = true;

var topView = Ti.UI.createView({ backgroundColor: 'blue', width: Ti.UI.FILL, height: '10%' });
var button = Ti.UI.createButton({ title: 'Change Text' });
topView.add(button);

var label = Ti.UI.createLabel({
    text: update ? 'Lorem ipsum' : 'Lorem ipsum dolor sit amet.',
    backgroundColor: 'orange'
});

button.addEventListener('click', function () {
    label.text = update ? 'Lorem ipsum dolor sit amet.' : 'Lorem ipsum';
    update = !update;
});

var bottomView = Ti.UI.createView({backgroundColor:'blue', width:Ti.UI.FILL, height: '10%'});

win.add(topView);
win.add(label);
win.add(bottomView);

win.open();
```