### PR TITLE
[TIMOB-23411] Catch InvalidArgumentException in requiredModuleExists()

### DIFF
--- a/Source/Global/src/GlobalObject.cpp
+++ b/Source/Global/src/GlobalObject.cpp
@@ -91,6 +91,8 @@ namespace TitaniumWindows
 			try {
 				task.get();
 				exists = true;
+			} catch (Platform::InvalidArgumentException^ ex) {
+				exists = false;
 			} catch (Platform::COMException^ ex) {
 				exists = false;
 			}


### PR DESCRIPTION
- Catch an uncaught ``InvalidArgumentException`` in ``requiredModuleExists()``
- This can happen when the ``StorageFile`` path is invalid
- An attempt to fix [TIMOB-23411](https://jira.appcelerator.org/browse/TIMOB-23411)