### PR TITLE
[TIMOB-19351] Support unit values for Ti.UI.createAnimation()

### DIFF
--- a/Source/TitaniumKit/include/Titanium/UI/Animation.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/Animation.hpp
@@ -60,7 +60,7 @@ namespace Titanium
 			  @abstract bottom
 			  @discussion Value of the `bottom` property at the end of the animation.
 			*/
-			TITANIUM_PROPERTY_IMPL_DEF(boost::optional<double>, bottom);
+			TITANIUM_PROPERTY_IMPL_DEF(boost::optional<std::string>, bottom);
 
 			/*!
 			  @property
@@ -102,14 +102,14 @@ namespace Titanium
 			  @abstract height
 			  @discussion Value of the `height` property at the end of the animation.
 			*/
-			TITANIUM_PROPERTY_IMPL_DEF(boost::optional<double>, height);
+			TITANIUM_PROPERTY_IMPL_DEF(boost::optional<std::string>, height);
 
 			/*!
 			  @property
 			  @abstract left
 			  @discussion Value of the `left` property at the end of the animation.
 			*/
-			TITANIUM_PROPERTY_IMPL_DEF(boost::optional<double>, left);
+			TITANIUM_PROPERTY_IMPL_DEF(boost::optional<std::string>, left);
 
 			/*!
 			  @property
@@ -137,14 +137,14 @@ namespace Titanium
 			  @abstract right
 			  @discussion Value of the `right` property at the end of the animation.
 			*/
-			TITANIUM_PROPERTY_IMPL_DEF(boost::optional<double>, right);
+			TITANIUM_PROPERTY_IMPL_DEF(boost::optional<std::string>, right);
 
 			/*!
 			  @property
 			  @abstract top
 			  @discussion Value of the `top` property at the end of the animation.
 			*/
-			TITANIUM_PROPERTY_IMPL_DEF(boost::optional<double>, top);
+			TITANIUM_PROPERTY_IMPL_DEF(boost::optional<std::string>, top);
 
 			/*!
 			  @property
@@ -179,7 +179,7 @@ namespace Titanium
 			  @abstract width
 			  @discussion Value of the `width` property at the end of the animation.
 			*/
-			TITANIUM_PROPERTY_IMPL_DEF(boost::optional<double>, width);
+			TITANIUM_PROPERTY_IMPL_DEF(boost::optional<std::string>, width);
 
 			/*!
 			  @property
@@ -295,24 +295,24 @@ namespace Titanium
 				Point anchorPoint__;
 				bool autoreverse__;
 				std::string backgroundColor__;
-				boost::optional<double> bottom__;
+				boost::optional<std::string> bottom__;
 				Point center__;
 				std::string color__;
 				ANIMATION_CURVE curve__;
 				std::chrono::milliseconds delay__;
 				std::chrono::milliseconds duration__;
-				boost::optional<double> height__;
-				boost::optional<double> left__;
+				boost::optional<std::string> height__;
+				boost::optional<std::string> left__;
 				boost::optional<double> opacity__;
 				bool opaque__;
 				uint32_t repeat__;
-				boost::optional<double> right__;
-				boost::optional<double> top__;
+				boost::optional<std::string> right__;
+				boost::optional<std::string> top__;
 				std::shared_ptr<Titanium::UI::TwoDMatrix> transform__;
 				uint32_t transition__;
 				std::shared_ptr<Titanium::UI::View> view__;
 				bool visible__;
-				boost::optional<double> width__;
+				boost::optional<std::string> width__;
 				boost::optional<uint32_t> zIndex__;
 #pragma warning(pop)
 		};

--- a/Source/TitaniumKit/src/UI/Animation.cpp
+++ b/Source/TitaniumKit/src/UI/Animation.cpp
@@ -45,7 +45,7 @@ namespace Titanium
 
 		TITANIUM_PROPERTY_READWRITE(Animation, std::string, backgroundColor)
 
-		TITANIUM_PROPERTY_READWRITE(Animation, boost::optional<double>, bottom)
+		TITANIUM_PROPERTY_READWRITE(Animation, boost::optional<std::string>, bottom)
 
 		TITANIUM_PROPERTY_READWRITE(Animation, Point, center)
 
@@ -57,9 +57,9 @@ namespace Titanium
 
 		TITANIUM_PROPERTY_READWRITE(Animation, std::chrono::milliseconds, duration)
 
-		TITANIUM_PROPERTY_READWRITE(Animation, boost::optional<double>, height)
+		TITANIUM_PROPERTY_READWRITE(Animation, boost::optional<std::string>, height)
 
-		TITANIUM_PROPERTY_READWRITE(Animation, boost::optional<double>, left)
+		TITANIUM_PROPERTY_READWRITE(Animation, boost::optional<std::string>, left)
 
 		TITANIUM_PROPERTY_READWRITE(Animation, boost::optional<double>, opacity)
 
@@ -67,9 +67,9 @@ namespace Titanium
 
 		TITANIUM_PROPERTY_READWRITE(Animation, uint32_t, repeat)
 
-		TITANIUM_PROPERTY_READWRITE(Animation, boost::optional<double>, right)
+		TITANIUM_PROPERTY_READWRITE(Animation, boost::optional<std::string>, right)
 
-		TITANIUM_PROPERTY_READWRITE(Animation, boost::optional<double>, top)
+		TITANIUM_PROPERTY_READWRITE(Animation, boost::optional<std::string>, top)
 
 		TITANIUM_PROPERTY_READWRITE(Animation, std::shared_ptr<TwoDMatrix>, transform)
 
@@ -79,7 +79,7 @@ namespace Titanium
 
 		TITANIUM_PROPERTY_READWRITE(Animation, bool, visible)
 
-		TITANIUM_PROPERTY_READWRITE(Animation, boost::optional<double>, width)
+		TITANIUM_PROPERTY_READWRITE(Animation, boost::optional<std::string>, width)
 
 		TITANIUM_PROPERTY_READWRITE(Animation, boost::optional<uint32_t>, zIndex)
 
@@ -196,15 +196,15 @@ namespace Titanium
 		{
 			auto bottom = get_bottom();
 			if (bottom) {
-				return get_context().CreateNumber(*bottom);
+				return get_context().CreateString(*bottom);
 			}
 			return get_context().CreateUndefined();
 		}
 
 		TITANIUM_PROPERTY_SETTER(Animation, bottom)
 		{
-			TITANIUM_ASSERT(argument.IsNumber());
-			set_bottom(static_cast<double>(argument));
+			TITANIUM_ASSERT(argument.IsString());
+			set_bottom(static_cast<std::string>(argument));
 			return true;
 		}
 
@@ -274,15 +274,15 @@ namespace Titanium
 		{
 			auto height = get_height();
 			if (height) {
-				return get_context().CreateNumber(*height);
+				return get_context().CreateString(*height);
 			}
 			return get_context().CreateUndefined();
 		}
 
 		TITANIUM_PROPERTY_SETTER(Animation, height)
 		{
-			TITANIUM_ASSERT(argument.IsNumber());
-			set_height(static_cast<double>(argument));
+			TITANIUM_ASSERT(argument.IsString());
+			set_height(static_cast<std::string>(argument));
 			return true;
 		}
 
@@ -290,15 +290,15 @@ namespace Titanium
 		{
 			auto left = get_left();
 			if (left) {
-				return get_context().CreateNumber(*left);
+				return get_context().CreateString(*left);
 			}
 			return get_context().CreateUndefined();
 		}
 
 		TITANIUM_PROPERTY_SETTER(Animation, left)
 		{
-			TITANIUM_ASSERT(argument.IsNumber());
-			set_left(static_cast<double>(argument));
+			TITANIUM_ASSERT(argument.IsString());
+			set_left(static_cast<std::string>(argument));
 			return true;
 		}
 
@@ -346,15 +346,15 @@ namespace Titanium
 		{
 			auto right = get_right();
 			if (right) {
-				return get_context().CreateNumber(*right);
+				return get_context().CreateString(*right);
 			}
 			return get_context().CreateUndefined();
 		}
 
 		TITANIUM_PROPERTY_SETTER(Animation, right)
 		{
-			TITANIUM_ASSERT(argument.IsNumber());
-			set_right(static_cast<double>(argument));
+			TITANIUM_ASSERT(argument.IsString());
+			set_right(static_cast<std::string>(argument));
 			return true;
 		}
 
@@ -362,15 +362,15 @@ namespace Titanium
 		{
 			auto top = get_top();
 			if (top) {
-				get_context().CreateNumber(*top);
+				get_context().CreateString(*top);
 			}
 			return get_context().CreateUndefined();
 		}
 
 		TITANIUM_PROPERTY_SETTER(Animation, top)
 		{
-			TITANIUM_ASSERT(argument.IsNumber());
-			set_top(static_cast<double>(argument));
+			TITANIUM_ASSERT(argument.IsString());
+			set_top(static_cast<std::string>(argument));
 			return true;
 		}
 
@@ -428,15 +428,15 @@ namespace Titanium
 		{
 			auto width = get_width();
 			if (width) {
-				return get_context().CreateNumber(*width);
+				return get_context().CreateString(*width);
 			}
 			return get_context().CreateUndefined();
 		}
 
 		TITANIUM_PROPERTY_SETTER(Animation, width)
 		{
-			TITANIUM_ASSERT(argument.IsNumber());
-			set_width(static_cast<double>(argument));
+			TITANIUM_ASSERT(argument.IsString());
+			set_width(static_cast<std::string>(argument));
 			return true;
 		}
 

--- a/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
@@ -404,7 +404,7 @@ namespace TitaniumWindows
 			virtual void onLayoutEngineCallback(Titanium::LayoutEngine::Rect rect, const std::string& name);
 			virtual void updateBackgroundGradient();
 
-			virtual void setLayoutProperty(const Titanium::LayoutEngine::ValueName&, const std::string&);
+			virtual void setLayoutProperty(const Titanium::LayoutEngine::ValueName&, const std::string&, const std::shared_ptr<Titanium::LayoutEngine::LayoutProperties> = nullptr);
 
 			virtual void setComponent(Windows::UI::Xaml::FrameworkElement^ component, Windows::UI::Xaml::Controls::Control^ underlying_control = nullptr, const bool& enableBorder = true);
 			virtual void setComponent(Windows::UI::Xaml::FrameworkElement^ component, Windows::UI::Xaml::Controls::Control^ underlying_control, Windows::UI::Xaml::Controls::Border^ border);
@@ -530,6 +530,13 @@ namespace TitaniumWindows
 			bool use_own_size__ { false };
 
 			Titanium::LayoutEngine::Rect oldRect__;
+
+			struct animate_call__ {
+				std::shared_ptr<Titanium::UI::Animation> animation;
+				JSObject callback;
+				JSObject this_object;
+			};
+			std::vector<animate_call__> animate_queue__;
 
 			Windows::UI::Xaml::Media::ImageBrush^ backgroundImageBrush__{ nullptr };
 			Windows::UI::Xaml::Media::ImageBrush^ backgroundDisabledImageBrush__{ nullptr };


### PR DESCRIPTION
- Add support for ``% cm mm cm em pt pc in px dp dip`` in ``width`` ``height`` ``top`` ``left`` (``bottom`` and ``right`` are not implemented)
- Fixed crash when animating ``width`` or ``height`` from ``0``
- Fixed ``width`` and ``height`` not being retained after animation

###### TEST CASE # 1
``Scale height from 0 to 100%``
```Javascript
var win = Ti.UI.createWindow({backgroundColor: 'black'}),
    view = Ti.UI.createView({backgroundColor: 'red', top: 0, left: 0, width:'10%', height: 0}),
    animation = Ti.UI.createAnimation({height: "100%", curve: Ti.UI.ANIMATION_CURVE_EASE_OUT, duration: 2000});
view.animate(animation);
win.add(view);
win.open();
```

###### TEST CASE # 2
``Scale width from 0 to 100%``
```Javascript
var win = Ti.UI.createWindow({backgroundColor: 'black'}),
    view = Ti.UI.createView({backgroundColor: 'red', top: 0, left: 0, width:'0', height: '10%'}),
    animation = Ti.UI.createAnimation({width: '100%', curve: Ti.UI.ANIMATION_CURVE_EASE_OUT, duration: 2000});
view.animate(animation);
win.add(view);
win.open();
```

###### TEST CASE # 3
``Transform left from 0 to 90%``
```Javascript
var win = Ti.UI.createWindow({backgroundColor: 'black'}),
    view = Ti.UI.createView({backgroundColor: 'red', top: 0, left: 0, width:'10%', height: '10%'}),
    animation = Ti.UI.createAnimation({left: '90%', curve: Ti.UI.ANIMATION_CURVE_EASE_OUT, duration: 2000});
view.animate(animation);
win.add(view);
win.open();
```

###### TEST CASE # 4
``Transform top from 0 to 90%``
```Javascript
var win = Ti.UI.createWindow({backgroundColor: 'black'}),
    view = Ti.UI.createView({backgroundColor: 'red', top: 0, left: 0, width:'10%', height: '10%'}),
    animation = Ti.UI.createAnimation({top: '90%', curve: Ti.UI.ANIMATION_CURVE_EASE_OUT, duration: 2000});
view.animate(animation);
win.add(view);
win.open();
```

[TIMOB-19351](https://jira.appcelerator.org/browse/TIMOB-19351)