### PR TITLE
[TIMOB-23350] Default ScrollView width and height to Ti.UI.FILL

### DIFF
--- a/Source/UI/src/ScrollView.cpp
+++ b/Source/UI/src/ScrollView.cpp
@@ -72,8 +72,8 @@ namespace TitaniumWindows
 
 			contentView__.SetProperty("top", get_context().CreateNumber(0));
 			contentView__.SetProperty("left", get_context().CreateNumber(0));
-			contentView__.SetProperty("width", get_context().CreateString(Titanium::UI::Constants::to_string(Titanium::UI::LAYOUT::SIZE)));
-			contentView__.SetProperty("height", get_context().CreateString(Titanium::UI::Constants::to_string(Titanium::UI::LAYOUT::SIZE)));
+			contentView__.SetProperty("width", get_context().CreateString(Titanium::UI::Constants::to_string(Titanium::UI::LAYOUT::FILL)));
+			contentView__.SetProperty("height", get_context().CreateString(Titanium::UI::Constants::to_string(Titanium::UI::LAYOUT::FILL)));
 
 			auto content = contentView__.GetPrivate<TitaniumWindows::UI::View>();
 			scroll_viewer__->Content = content->getComponent();


### PR DESCRIPTION
- Default ``Titanium.UI.ScrollView`` ``width height`` to ``Titanium.UI.FILL``

###### TEST CASE
```Javascript
var win = Ti.UI.createWindow(),
    scrollView = Ti.UI.createScrollView({
        layout: "vertical",
        backgroundColor: 'red'
    }),
    view = Ti.UI.createView({
        backgroundColor: 'orange',
        top: 10,
        left: 10,
        height: Ti.UI.SIZE,
        width: Ti.UI.SIZE
    }),
    label = Ti.UI.createLabel({
        left: 10,
        right: 10,
        color: "green",
        backgroundColor: 'yellow',
        text: "this is test text"
    });
view.add(label);
scrollView.add(view);
win.add(scrollView);
win.open();
```

###### EXPECTED
![](https://jira.appcelerator.org/secure/attachment/59418/expected.jpg)

[JIRA Ticket](TIMOB-23350)