### PR TITLE
PoC: [TIMOB-23439] Unified way to catch exception

### DIFF
--- a/Source/Titanium/include/TitaniumWindows/TitaniumWindows.hpp
+++ b/Source/Titanium/include/TitaniumWindows/TitaniumWindows.hpp
@@ -28,6 +28,7 @@ namespace TitaniumWindows
 		virtual ~Application();
 
 		virtual void OnLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs^ args) override;
+		void OnUnhandledException(Object^ sender, Windows::UI::Xaml::UnhandledExceptionEventArgs^ arg);
 		void OnSuspending(Object^ sender, Windows::ApplicationModel::SuspendingEventArgs^ e);
 		void OnResuming(Object ^sender, Object ^args);
 

--- a/Source/Titanium/include/TitaniumWindows/TitaniumWindows.hpp
+++ b/Source/Titanium/include/TitaniumWindows/TitaniumWindows.hpp
@@ -28,7 +28,6 @@ namespace TitaniumWindows
 		virtual ~Application();
 
 		virtual void OnLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs^ args) override;
-		void OnUnhandledException(Object^ sender, Windows::UI::Xaml::UnhandledExceptionEventArgs^ arg);
 		void OnSuspending(Object^ sender, Windows::ApplicationModel::SuspendingEventArgs^ e);
 		void OnResuming(Object ^sender, Object ^args);
 
@@ -47,6 +46,7 @@ namespace TitaniumWindows
 #endif
 
 	private:
+		void OnUnhandledException(Object^ sender, Windows::UI::Xaml::UnhandledExceptionEventArgs^ arg);
 
 #if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP)
 		// This code is for Windows phone apps only.

--- a/Source/TitaniumKit/include/Titanium/Module.hpp
+++ b/Source/TitaniumKit/include/Titanium/Module.hpp
@@ -133,8 +133,6 @@ namespace Titanium
 		virtual void fireEvent(const std::string& name) TITANIUM_NOEXCEPT final;
 		virtual void fireEvent(const std::string& name, const JSObject& event) TITANIUM_NOEXCEPT final;
 
-		virtual void showRedScreenOfDeath(const std::string& message) TITANIUM_NOEXCEPT final;
-
 		Module(const JSContext&, const std::string& apiName = "Titanium.Proxy") TITANIUM_NOEXCEPT;
 		virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;
 
@@ -149,6 +147,7 @@ namespace Titanium
 		// TODO: The following functions can automatically be generated from
 		// the YAML API docs.
 		static void JSExportInitialize();
+		static void ShowRedScreenOfDeath(const JSContext& js_context, const std::string& message) TITANIUM_NOEXCEPT;
 
 		TITANIUM_PROPERTY_DEF(bubbleParent);
 		TITANIUM_PROPERTY_READONLY_DEF(apiName);

--- a/Source/TitaniumKit/include/Titanium/detail/TiImpl.hpp
+++ b/Source/TitaniumKit/include/Titanium/detail/TiImpl.hpp
@@ -435,4 +435,14 @@ TITANIUM_PROPERTY_SETTER(MODULE, NAME) { \
 	return false; \
 }
 
+#define TITANIUM_EXCEPTION_CATCH_START try
+#define TITANIUM_EXCEPTION_CATCH_END \
+catch (const HAL::detail::js_runtime_error& ex) { \
+    std::ostringstream os; \
+    os << "Runtime Error: " << ex.js_message(); \
+    Titanium::Module::ShowRedScreenOfDeath(get_context(), os.str()); \
+} catch (...) { \
+    Titanium::Module::ShowRedScreenOfDeath(get_context(), "Unknown Exception"); \
+}
+
 #endif  // _TITANIUM_DETAIL_TIIMPL_HPP_

--- a/Source/TitaniumKit/src/GlobalObject.cpp
+++ b/Source/TitaniumKit/src/GlobalObject.cpp
@@ -9,6 +9,7 @@
 #include "Titanium/GlobalObject.hpp"
 #include "Titanium/detail/TiUtil.hpp"
 #include "Titanium/detail/TiImpl.hpp"
+#include "Titanium/Module.hpp"
 #include <sstream>
 #include <functional>
 #include <boost/algorithm/string/predicate.hpp>
@@ -382,7 +383,7 @@ namespace Titanium
 
 	void GlobalObject::InvokeCallback(const unsigned& timerId) TITANIUM_NOEXCEPT
 	{
-		try {
+		TITANIUM_EXCEPTION_CATCH_START{
 			const std::string timerId_str = "callback_" + std::to_string(timerId);
 			TITANIUM_ASSERT(callback_map__.HasProperty(timerId_str));
 			JSValue callback_property = callback_map__.GetProperty(timerId_str);
@@ -390,17 +391,7 @@ namespace Titanium
 			JSObject callback = static_cast<JSObject>(callback_property);
 			TITANIUM_ASSERT(callback.IsFunction());
 			callback(get_context().get_global_object());
-		} catch (const HAL::detail::js_runtime_error& ex) {
-			std::ostringstream os;
-			os << "Runtime Error: " << ex.js_message();
-
-			const auto ctx = get_context();
-			const auto what = ctx.CreateString(os.str());
-			const auto rsod = ctx.get_global_object().GetProperty("Titanium_RedScreenOfDeath");
-			auto rsod_func = static_cast<JSObject>(rsod);
-			const std::vector<JSValue> args = { what };
-			rsod_func(args, rsod_func);
-		}
+		} TITANIUM_EXCEPTION_CATCH_END
 	}
 
 	void GlobalObject::StartTimer(Callback_t&& callback, const unsigned& timerId, const std::chrono::milliseconds& delay) TITANIUM_NOEXCEPT

--- a/Source/TitaniumKit/src/Module.cpp
+++ b/Source/TitaniumKit/src/Module.cpp
@@ -132,13 +132,17 @@ namespace Titanium
 		TITANIUM_LOG_DEBUG(apiName__, " afterPropertiesSet for ", this);
 	}
 
-	void Module::showRedScreenOfDeath(const std::string& message) TITANIUM_NOEXCEPT {
-		const auto ctx = get_context();
-		const auto what = ctx.CreateString(message);
-		const auto rsod = ctx.get_global_object().GetProperty("Titanium_RedScreenOfDeath");
-		auto rsod_func = static_cast<JSObject>(rsod);
-		const std::vector<JSValue> args = { what };
-		rsod_func(args, rsod_func);
+	void Module::ShowRedScreenOfDeath(const JSContext& ctx, const std::string& message) TITANIUM_NOEXCEPT
+	{
+		try {
+			const auto what = ctx.CreateString(message);
+			const auto rsod = ctx.get_global_object().GetProperty("Titanium_RedScreenOfDeath");
+			auto rsod_func = static_cast<JSObject>(rsod);
+			const std::vector<JSValue> args = { what };
+			rsod_func(args, rsod_func);
+		} catch (...) {
+			// Just to make sure we don't throw another exception :(
+		}
 	}
 
 	void Module::fireEvent(const std::string& name) TITANIUM_NOEXCEPT
@@ -171,7 +175,7 @@ namespace Titanium
 		}
 		event_copy.SetProperty("type", event.get_context().CreateString(name));
 
-		try {
+		TITANIUM_EXCEPTION_CATCH_START {
 			for (size_t i = 0; i < event_listener_count; ++i) {
 				JSObject callback_payload = event_listener_list.at(i);
 
@@ -198,12 +202,7 @@ namespace Titanium
 				//
 				callback({ static_cast<JSValue>(event_copy), callback }, this_object);
 			}
-		} catch (const HAL::detail::js_runtime_error& ex) {
-			std::ostringstream os;
-			os << "Runtime Error during " << name << " event: " << ex.js_message();
-
-			showRedScreenOfDeath(os.str());
-		}
+		} TITANIUM_EXCEPTION_CATCH_END
 	}
 
 	void Module::enableEvent(const std::string& event_name) TITANIUM_NOEXCEPT

--- a/Source/Utility/CMakeLists.txt
+++ b/Source/Utility/CMakeLists.txt
@@ -47,6 +47,7 @@ set(SOURCE_Utility
   include/TitaniumWindows/Utility.hpp
   src/Utility.cpp
   include/TitaniumWindows/WindowsMacros.hpp
+  include/TitaniumWindows/WindowsTiImpl.hpp
   src/TitaniumEntryPoint.cpp
   include/TitaniumWindows/LogForwarder.hpp
   src/LogForwarder.cpp

--- a/Source/Utility/include/TitaniumWindows/WindowsTiImpl.hpp
+++ b/Source/Utility/include/TitaniumWindows/WindowsTiImpl.hpp
@@ -1,0 +1,22 @@
+/**
+ * Windows specific macros for implementation
+ *
+ * Copyright (c) 2016 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License.
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#ifndef _TITANIUMWINDOWS_WINDOWSTIIMPL_HPP_
+#define _TITANIUMWINDOWS_WINDOWSTIIMPL_HPP_
+
+#include "Titanium/detail/TiImpl.hpp"
+#include "TitaniumWindows/Utility.hpp"
+
+#define TITANIUMWINDOWS_EXCEPTION_CATCH_END \
+catch (::Platform::COMException^ ex) { \
+    std::ostringstream os; \
+    os << "Runtime Error: " << TitaniumWindows::Utility::ConvertString(ex->Message); \
+    Titanium::Module::ShowRedScreenOfDeath(get_context(), os.str()); \
+} TITANIUM_EXCEPTION_CATCH_END
+
+#endif  // _TITANIUMWINDOWS_WINDOWSTIIMPL_HPP_


### PR DESCRIPTION
*PROOF OF CONCEPT*

[TIMOB-23439](https://jira.appcelerator.org/browse/TIMOB-23439)

Introduce new unified way to catch exception inspired by #715 

* `TITANIUM_EXCEPTION_CATCH_START` indicates you starts to catch the exception 
* `TITANIUM_EXCEPTION_CATCH_END` indicates you catches the exception and show "red screen of death". Used in TitaniumKit.
* `TITANIUMWINDOWS_EXCEPTION_CATCH_START` is Windows-specific version of `TITANIUM_EXCEPTION_CATCH_END`. It catches `Platform::COMException` and show "red screen of death" with exception detail. 

```c++
TITANIUM_EXCEPTION_CATCH_START {
    throw ref new Platform::COMException(0, "TEST EXCEPTION");
}  TITANIUMWINDOWS_EXCEPTION_CATCH_END
```

In asyc functions, you need to use `concurrency::task` along with `concurrency::task::get()` to catch exception, because `get()` gives a chances to catch exception like below.

```c++
concurrency::create_task(Geolocator::RequestAccessAsync()).then([this](concurrency::task<GeolocationAccessStatus> task) {
	TITANIUM_EXCEPTION_CATCH_START {
		const auto status = task.get(); // this could throw new exception
		//
		// do something useful with the status then...
		//
	}  TITANIUMWINDOWS_EXCEPTION_CATCH_END
});
```

For more details [Geolocation.cpp](https://github.com/infosia/titanium_mobile_windows/blob/41c13085c7c7fd3b8a4f988ccf6cb0d872736284/Source/Sensors/src/Geolocation.cpp) would be a good example to see how to migrate existing codes.