### PR TITLE
[TIMOB-23307] Localized strings in strings.xml don't handle \n newlines

### DIFF
--- a/Source/TitaniumKit/include/Titanium/Locale.hpp
+++ b/Source/TitaniumKit/include/Titanium/Locale.hpp
@@ -98,6 +98,9 @@ namespace Titanium
 		static void JSExportInitialize();
 		static JSObject GetStaticObject(const JSContext& js_context) TITANIUM_NOEXCEPT;
 
+		// Escape characters with backslash. Based on iOS behavior, not all backslashes are converted.
+		static std::string EscapeJSCharacters(const std::string& content) TITANIUM_NOEXCEPT;
+
 		TITANIUM_PROPERTY_READONLY_DEF(currentCountry);
 		TITANIUM_PROPERTY_READONLY_DEF(currentLanguage);
 		TITANIUM_PROPERTY_READONLY_DEF(currentLocale);


### PR DESCRIPTION
[TIMOB-23307](https://jira.appcelerator.org/browse/TIMOB-23307)

I observed that not all escape characters in localized strings are actually escaped on iOS, and so we try to simulate what iOS does on Windows.

character | actual
------------ | -------------
\r | new line
\n | new line
\f | new line
\t | tab
\\ | \
\" | "
\' | '
\b| ignored
\uxxx (unicode characters) | uxxx

### i18n/en/strings.xml

```xml
<?xml version="1.0" encoding="UTF-8"?>
<resources>
  <string name="phrase">"\t"A l\bon\'g l\"abel w\\ith\r\n a few l\rine bre\faks\n and unicode (UTF8)\n symbols such as\n a white chess piece \u2655\nand the euro symbol \u20ac\nlooks like this!\n</string>
</resources>
```

### app.js
```javascript
var win = Ti.UI.createWindow(),
    view = Ti.UI.createView({
        backgroundColor: 'blue',
        top: 10,
        left: 10,
        height: Ti.UI.SIZE,
        width: Ti.UI.SIZE
    }),
    label = Ti.UI.createLabel({
        left: 10,
        right: 10,
        color: "orange",
        backgroundColor: 'green',
        text: L('phrase')
    });
view.add(label);
win.add(view);
win.open();
```