### PR TITLE
[TIMOB-23343] Fix: Map annotations do not handle click events

### DIFF
--- a/Source/Map/include/TitaniumWindows/Map/View.hpp
+++ b/Source/Map/include/TitaniumWindows/Map/View.hpp
@@ -22,6 +22,8 @@ namespace TitaniumWindows
 
 		using Annotation_shared_ptr_t = std::shared_ptr<Titanium::Map::Annotation>;
 
+		class Annotation;
+
 		/*!
 		  @class View
 		  @ingroup Titanium.Map.View
@@ -52,6 +54,14 @@ namespace TitaniumWindows
 
 			static void JSExportInitialize();
 
+#pragma warning(push)
+#pragma warning(disable : 4251)
+			// Save current View in static variable, assuming we use only one MapControl at once.
+			// Assuming it's right since that's the precondition we use static MapControl::SetLocation in Annotaiton.
+			static std::shared_ptr<View> CurrentView__;
+			static void HandleMapClick(const JSContext& js_context, const std::shared_ptr<View>& view, const double& latitude, const double& longitude, const std::shared_ptr<Annotation>& annotation) TITANIUM_NOEXCEPT;
+#pragma warning(pop)
+
 			virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;
 
 			// properties
@@ -67,9 +77,14 @@ namespace TitaniumWindows
 			virtual void removeAnnotation(const Annotation_shared_ptr_t& annotation) TITANIUM_NOEXCEPT;
 			virtual void zoom(const uint32_t& zoom) TITANIUM_NOEXCEPT override final;
 
+#if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
+			virtual void enableEvent(const std::string& event_name) TITANIUM_NOEXCEPT override;
+			virtual void disableEvent(const std::string& event_name) TITANIUM_NOEXCEPT override;
+#endif
 		private:
 
 #if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
+			Windows::Foundation::EventRegistrationToken click_event__;
 			Windows::UI::Xaml::Controls::Maps::MapControl^ mapview__ = { nullptr };
 #endif
 		};

--- a/Source/Map/src/Annotation.cpp
+++ b/Source/Map/src/Annotation.cpp
@@ -11,6 +11,7 @@
 #include "Titanium/detail/TiLogger.hpp"
 #include "Titanium/detail/TiImpl.hpp"
 #include "TitaniumWindows/WindowsMacros.hpp"
+#include "TitaniumWindows/Map/View.hpp"
 
 #if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 using namespace Windows::UI::Xaml::Controls::Maps;
@@ -85,6 +86,16 @@ namespace TitaniumWindows
 			TITANIUM_LOG_DEBUG("Annotation::ctor Initialize");
 #if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			mapicon__ = ref new Windows::UI::Xaml::Controls::Grid();
+
+			mapicon__->Tapped += ref new Windows::UI::Xaml::Input::TappedEventHandler(
+				[this](Platform::Object^ sender, Windows::UI::Xaml::Input::TappedRoutedEventArgs^ e) {
+				TitaniumWindows::Map::View::HandleMapClick(
+					get_context(), 
+					TitaniumWindows::Map::View::CurrentView__,
+					get_latitude(),
+					get_longitude(),
+					get_object().GetPrivate<TitaniumWindows::Map::Annotation>());
+			});
 
 			// Draw pin
 			pin__ = ref new Windows::UI::Xaml::Shapes::Line();

--- a/Source/TitaniumKit/src/Map/Annotation.cpp
+++ b/Source/TitaniumKit/src/Map/Annotation.cpp
@@ -283,7 +283,11 @@ namespace Titanium
 
 		TITANIUM_PROPERTY_GETTER(Annotation, customView)
 		{
-			return get_customView()->get_object();
+			const auto view = get_customView();
+			if (view) {
+				return view->get_object();
+			}
+			return get_context().CreateNull();
 		}
 
 		TITANIUM_PROPERTY_SETTER(Annotation, customView)
@@ -343,7 +347,11 @@ namespace Titanium
 
 		TITANIUM_PROPERTY_GETTER(Annotation, leftView)
 		{
-			return get_leftView()->get_object();
+			const auto view = get_leftView();
+			if (view) {
+				return view->get_object();
+			}
+			return get_context().CreateNull();
 		}
 
 		TITANIUM_PROPERTY_SETTER(Annotation, leftView)
@@ -391,7 +399,11 @@ namespace Titanium
 
 		TITANIUM_PROPERTY_GETTER(Annotation, rightView)
 		{
-			return get_rightView()->get_object();
+			const auto view = get_rightView();
+			if (view) {
+				return view->get_object();
+			}
+			return get_context().CreateNull();
 		}
 
 		TITANIUM_PROPERTY_SETTER(Annotation, rightView)

--- a/Source/TitaniumKit/src/Map/View.cpp
+++ b/Source/TitaniumKit/src/Map/View.cpp
@@ -520,7 +520,11 @@ namespace Titanium
 
 		TITANIUM_PROPERTY_GETTER(View, camera)
 		{
-			return get_camera()->get_object();
+			const auto camera = get_camera();
+			if (camera) {
+				return camera->get_object();
+			}
+			return get_context().CreateNull();
 		}
 
 		TITANIUM_PROPERTY_SETTER(View, camera)


### PR DESCRIPTION
[TIMOB-23343](https://jira.appcelerator.org/browse/TIMOB-23343)

Supported properties:

- latitude
- longitude
- map
- clicksource (`pin` when annotation is clicked,`null` otherwise)
- annotation (only when annotation is clicked)
- title (only when annotation is clicked)
- subtitle (only when annotation is clicked)
- type, source

```javascript
var win = Titanium.UI.createWindow();

var mountainView = Titanium.Map.createAnnotation({
    latitude: 37.390749,
    longitude: -122.081651,
    title: "Previous Appcelerator HQ",
    subtitle: 'Mountain View, CA',
    pincolor: Titanium.Map.ANNOTATION_RED,
    myid: 1 // Custom property to uniquely identify this annotation.
});

var mapview = Titanium.Map.createView({
    mapType: Titanium.Map.STANDARD_TYPE,
    region: {
        latitude: 37.390749, longitude: -122.081651,
        latitudeDelta: 0.01, longitudeDelta: 0.01
    },
    annotations: [mountainView]
});

win.add(mapview);

mapview.addEventListener('click', function (evt) {
    if (evt.annotation) {
        Ti.API.info("Annotation " + evt.title + " clicked, id: " + evt.annotation.myid);
    }
    Ti.API.info(evt.longitude + " : " + evt.latitude);
});
win.open();
```