### PR TITLE
move Window log to internal

### DIFF
--- a/Source/UI/src/Window.cpp
+++ b/Source/UI/src/Window.cpp
@@ -199,7 +199,7 @@ namespace TitaniumWindows
 					}
 
 					if (!found) {
-						TITANIUM_MODULE_LOG_WARN("Window.close: Window is not opened or already closed");
+						TITANIUM_LOG_WARN("Window.close: Window is not opened or already closed");
 					}
 
 				} else {


### PR DESCRIPTION
Per Fokke at [TIMOB-23366](https://jira.appcelerator.org/browse/TIMOB-23366?focusedCommentId=387171&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-387171)

Move warning message at `Windows.close` to internal. This log should have been kept internal because this does not mean actually a issue.