### PR TITLE
[5_3_X] [TIMOB-23461] Fix: Ti.UI.View ignores click event

### DIFF
--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -643,7 +643,7 @@ namespace TitaniumWindows
 		{
 			if (underlying_control__) {
 				underlying_control__->Background = brush;
-			} else if (border__) {
+			} else if (is_grid__ && border__) {
 				border__->Background = brush;
 			} else if (is_panel__) {
 				dynamic_cast<Panel^>(component__)->Background = brush;


### PR DESCRIPTION
[5_3_X] [TIMOB-23461](https://jira.appcelerator.org/browse/TIMOB-23461)

Fix: `Ti.UI.View` ignores `click` event. This issue has been introduced by [TIMOB-23374](https://jira.appcelerator.org/browse/TIMOB-23374).

*Test code*

```javascript
﻿var window = Ti.UI.createWindow({ backgroundColor: 'green' });
var view = Ti.UI.createView({
    borderRadius: 5,
    borderColor: 'orange',
    borderWidth: 10,
    backgroundColor: 'blue',
    width: '90%',
    height: '90%',
});
var label = Ti.UI.createLabel({
    text: "ABC",
    color: "#C41230",
    borderRadius: 30,
    borderWidth: 2,
    borderColor: "#C41230",
    backgroundColor: "#F2D0D6",
    textAlign: "center",
    width: 100, height: 50
});
view.add(label);

label.addEventListener('click', function () {
    Ti.API.info('Label clicked');
});

view.addEventListener('click', function () {
    Ti.API.info('View clicked');
});
window.addEventListener('click', function () {
    Ti.API.info('Window clicked');
});
window.add(view);
window.open();
```

*Expected*

* Clicking blue `View` should print

```
[INFO] View clicked
[INFO] Window clicked
```

* Clicking pink oval `Label` should print

```
[INFO] Label clicked
[INFO] View clicked
[INFO] Window clicked
```
