### PR TITLE
[TIMOB-23209] Improve handling of view animations on multiple presses

### DIFF
--- a/Source/TitaniumKit/include/Titanium/UI/Animation.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/Animation.hpp
@@ -305,7 +305,6 @@ namespace Titanium
 				std::string backgroundColor__;
 				boost::optional<std::string> bottom__;
 				boost::optional<Point> center__;
-				Point center__;
 				std::string color__;
 				ANIMATION_CURVE curve__;
 				std::chrono::milliseconds delay__;

--- a/Source/TitaniumKit/include/Titanium/UI/Animation.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/Animation.hpp
@@ -67,7 +67,7 @@ namespace Titanium
 			  @abstract center
 			  @discussion Value of the `center` property at the end of the animation.
 			*/
-			TITANIUM_PROPERTY_IMPL_DEF(Point, center);
+			TITANIUM_PROPERTY_IMPL_DEF(boost::optional<Point>, center);
 
 			/*!
 			  @property
@@ -188,6 +188,14 @@ namespace Titanium
 			*/
 			TITANIUM_PROPERTY_IMPL_DEF(boost::optional<uint32_t>, zIndex);
 
+			/*
+			 * Check if there are layout changes (position or size)
+			 */
+			bool hasLayoutTransform()
+			{
+				return get_transform() || get_top() || get_bottom() || get_left() || get_right() || get_center() || get_width() || get_height();
+			}
+
 			Animation(const JSContext&) TITANIUM_NOEXCEPT;
 			virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;
 
@@ -296,7 +304,7 @@ namespace Titanium
 				bool autoreverse__;
 				std::string backgroundColor__;
 				boost::optional<double> bottom__;
-				Point center__;
+				boost::optional<Point> center__;
 				std::string color__;
 				ANIMATION_CURVE curve__;
 				std::chrono::milliseconds delay__;

--- a/Source/TitaniumKit/src/UI/Animation.cpp
+++ b/Source/TitaniumKit/src/UI/Animation.cpp
@@ -47,7 +47,7 @@ namespace Titanium
 
 		TITANIUM_PROPERTY_READWRITE(Animation, boost::optional<double>, bottom)
 
-		TITANIUM_PROPERTY_READWRITE(Animation, Point, center)
+		TITANIUM_PROPERTY_READWRITE(Animation, boost::optional<Point>, center)
 
 		TITANIUM_PROPERTY_READWRITE(Animation, std::string, color)
 
@@ -210,7 +210,11 @@ namespace Titanium
 
 		TITANIUM_PROPERTY_GETTER(Animation, center)
 		{
-			return Point_to_js(get_context(), get_center());
+			const auto center = get_center();
+			if (center) {
+				return Point_to_js(get_context(), *center);
+			}
+			return get_context().CreateUndefined();
 		}
 
 		TITANIUM_PROPERTY_SETTER(Animation, center)

--- a/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
@@ -528,6 +528,7 @@ namespace TitaniumWindows
 			bool is_button__{ false };
 			bool is_loaded__{false};
 			bool use_own_size__ { false };
+			bool is_transforming_layout__ { false }; // true when animate() is transforming layout
 
 			Titanium::LayoutEngine::Rect oldRect__;
 

--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -473,8 +473,6 @@ namespace TitaniumWindows
 						value *= layout_node__->parent->element.measuredHeight;
 					}
 
-					// TODO Bottom
-					// Because we're animating a transform, the value behaves like setting By, not To. So we need to calculate the difference and set our target To to that value
 					const auto current_top = Controls::Canvas::GetTop(component);
 					const auto diff = value - current_top;
 
@@ -487,11 +485,35 @@ namespace TitaniumWindows
 					storyboard->Children->Append(top_anim);
 				}
 
+				const auto bottom = animation->get_bottom();
+				if (bottom) {
+					setLayoutProperty(Titanium::LayoutEngine::ValueName::Bottom, *bottom, properties);
+					const auto type = properties->bottom.valueType;
+					auto value = properties->bottom.value;
+
+					if (type == Titanium::LayoutEngine::ValueType::Percent) {
+						value *= layout_node__->parent->element.measuredHeight;
+					}
+
+					const auto current_top = Controls::Canvas::GetTop(component);
+					const auto parent_height = layout_node__->parent->element.measuredHeight;
+					const auto current_height = layout_node__->element.measuredHeight;
+					const auto diff = (parent_height - current_height - value) - current_top;
+
+					const auto bottom_anim = ref new Media::Animation::DoubleAnimation();
+					bottom_anim->To = diff;
+					bottom_anim->EasingFunction = ease;
+					bottom_anim->Duration = duration;
+					storyboard->SetTargetProperty(bottom_anim, "(UIElement.RenderTransform).(TransformGroup.Children)[2].(TranslateTransform.TranslateY)");
+					storyboard->SetTarget(bottom_anim, component);
+					storyboard->Children->Append(bottom_anim);
+				}
+
 				// TODO if they specify top AND bottom and DON'T specify height, we should translate top, and treat bottom - top as height.
 				// If they specify bottom AND height, BUT NOT top; we should translate bottom and scale height?
 				// If they specify just bottom, no top or height, just translate bottom?
 
-				const auto left = animation->get_left(); // TODO Right
+				const auto left = animation->get_left();
 				if (left) {
 					setLayoutProperty(Titanium::LayoutEngine::ValueName::Left, *left, properties);
 					const auto type = properties->left.valueType;
@@ -501,7 +523,6 @@ namespace TitaniumWindows
 						value *= layout_node__->parent->element.measuredWidth;
 					}
 
-					// TODO If "right", we need to calculate the current position of "right", take the diff and then do a transform By, not To
 					const auto current_left = Controls::Canvas::GetLeft(component);
 					const auto diff = value - current_left;
 
@@ -514,6 +535,72 @@ namespace TitaniumWindows
 					storyboard->Children->Append(left_anim);
 				}
 
+				const auto right = animation->get_right();
+				if (right) {
+					setLayoutProperty(Titanium::LayoutEngine::ValueName::Right, *right, properties);
+					const auto type = properties->right.valueType;
+					auto value = properties->right.value;
+
+					if (type == Titanium::LayoutEngine::ValueType::Percent) {
+						value *= layout_node__->parent->element.measuredWidth;
+					}
+
+					const auto current_left = Controls::Canvas::GetLeft(component);
+					const auto parent_width = layout_node__->parent->element.measuredWidth;
+					const auto current_width = layout_node__->element.measuredWidth;
+					const auto diff = (parent_width - current_width - value) - current_left;
+
+					const auto right_anim = ref new Media::Animation::DoubleAnimation();
+					right_anim->To = diff;
+					right_anim->EasingFunction = ease;
+					right_anim->Duration = duration;
+					storyboard->SetTargetProperty(right_anim, "(UIElement.RenderTransform).(TransformGroup.Children)[2].(TranslateTransform.TranslateX)");
+					storyboard->SetTarget(right_anim, component);
+					storyboard->Children->Append(right_anim);
+				}
+
+				const auto center = animation->get_center();
+				if (center) {
+					// x-axis
+					auto x_value = center->x;
+					if (!center->x_percent.empty()) {
+						setLayoutProperty(Titanium::LayoutEngine::ValueName::Left, center->x_percent, properties);
+						x_value = properties->left.value;
+						const auto x_type = properties->left.valueType;
+						if (x_type == Titanium::LayoutEngine::ValueType::Percent) {
+							x_value *= layout_node__->parent->element.measuredWidth;
+						}
+					}
+					const auto current_left = Controls::Canvas::GetLeft(component);
+					const auto x_diff = x_value - current_left;
+					const auto x_anim = ref new Media::Animation::DoubleAnimation();
+					x_anim->To = x_diff;
+					x_anim->EasingFunction = ease;
+					x_anim->Duration = duration;
+					storyboard->SetTargetProperty(x_anim, "(UIElement.RenderTransform).(TransformGroup.Children)[2].(TranslateTransform.TranslateX)");
+					storyboard->SetTarget(x_anim, component);
+					storyboard->Children->Append(x_anim);
+
+					//y-axis
+					auto y_value = center->y;
+					if (!center->y_percent.empty()) {
+						setLayoutProperty(Titanium::LayoutEngine::ValueName::Right, center->y_percent, properties);
+						y_value = properties->right.value;
+						const auto y_type = properties->right.valueType;
+						if (y_type == Titanium::LayoutEngine::ValueType::Percent) {
+							y_value *= layout_node__->parent->element.measuredHeight;
+						}
+					}
+					const auto current_top = Controls::Canvas::GetTop(component);
+					const auto y_diff = y_value - current_top;
+					const auto y_anim = ref new Media::Animation::DoubleAnimation();
+					y_anim->To = y_diff;
+					y_anim->EasingFunction = ease;
+					y_anim->Duration = duration;
+					storyboard->SetTargetProperty(y_anim, "(UIElement.RenderTransform).(TransformGroup.Children)[2].(TranslateTransform.TranslateY)");
+					storyboard->SetTarget(y_anim, component);
+					storyboard->Children->Append(y_anim);
+				}
 
 				// For width and height, we have to calculate the scale to use to achieve desired height/width, since animating the Height or Width properties are ppor performance-wise and best avoided.
 				const auto height = animation->get_height();
@@ -648,18 +735,26 @@ namespace TitaniumWindows
 				if (top) {
 					setLayoutProperty(Titanium::LayoutEngine::ValueName::Top, *top);
 				}
+				const auto bottom = animation->get_bottom();
+				if (bottom) {
+					setLayoutProperty(Titanium::LayoutEngine::ValueName::Bottom, *bottom);
+				}
+
 				const auto left = animation->get_left();
 				if (left) {
 					setLayoutProperty(Titanium::LayoutEngine::ValueName::Left, *left);
 				}
-
-				const auto width = animation->get_width();
-				if (width) {
-					setLayoutProperty(Titanium::LayoutEngine::ValueName::Width, *width);
+				const auto right = animation->get_right();
+				if (right) {
+					setLayoutProperty(Titanium::LayoutEngine::ValueName::Right, *right);
 				}
-				const auto height = animation->get_height();
-				if (height) {
-					setLayoutProperty(Titanium::LayoutEngine::ValueName::Height, *height);
+
+				const auto center = animation->get_center();
+				if (center) {
+					std::string x = center->x_percent.empty() ? std::to_string(center->x) : center->x_percent;
+					std::string y = center->y_percent.empty() ? std::to_string(center->y) : center->y_percent;
+					setLayoutProperty(Titanium::LayoutEngine::ValueName::Left, x);
+					setLayoutProperty(Titanium::LayoutEngine::ValueName::Top, y);
 				}
 
 				// Make sure to clear the StoryBoard because transform made by StoryBoard remains.


### PR DESCRIPTION
[TIMOB-23209](https://jira.appcelerator.org/browse/TIMOB-23209)
[TIMOB-18750](https://jira.appcelerator.org/browse/TIMOB-18750)

Attempt to gain parity with iOS. Basic idea is to suppress multiple layout changes (size & position) done at a time of animation.

### Steps to reproduce

* Tap red box while box is moving.

### Expected

* The box doesn't reset its position while it's moving. 
* Warning message `[WARN] New layout set while view animating` is shown

```javascript
var win = Ti.UI.createWindow({ backgroundColor: 'green' });
var box = Ti.UI.createView({
    backgroundColor: 'red',
    left: 100,
    height: '100',
    width: '100'
});

var pin1 = Ti.UI.createView({
    backgroundColor: 'blue',
    left: 150,
    height: '140',
    width: '6'
});
var pin2 = Ti.UI.createView({
    backgroundColor: 'blue',
    left: 200,
    height: '140',
    width: '6'
});
var pin3 = Ti.UI.createView({
    backgroundColor: 'blue',
    left: 250,
    height: '140',
    width: '6'
});

win.add(pin1);
win.add(pin2);
win.add(pin3);
win.add(box);

var pos = 150;
box.addEventListener('click', function () {
    var a = Ti.UI.createAnimation({
        left: pos,
        duration: 2000,
    });
    a.addEventListener('complete', function () {
       pos += 50;
    });
    box.animate(a);
});
win.open();
```