### PR TITLE
On Hold - [TIMOB-23405] Translate 8.1 client version

### DIFF
--- a/Source/Ti/src/Platform.cpp
+++ b/Source/Ti/src/Platform.cpp
@@ -16,6 +16,7 @@
 #include <collection.h>
 #include <regex>
 #include <concrt.h>
+#include <boost/algorithm/string.hpp>
 
 namespace TitaniumWindows
 {
@@ -328,7 +329,7 @@ namespace TitaniumWindows
 		requestedProperties->Append("{A8B865DD-2E3D-4094-AD97-E593A70C75D6},3"); // version
 		requestedProperties->Append("{A45C254E-DF1C-4EFD-8020-67D146A850E0},10"); // device
 
-		std::string os_version = "6.3.9600"; // Win 8.1 base value
+		std::string os_version = "8.1"; // Win 8.1 base value
 		concurrency::event event;
 		concurrency::create_task(PnpObject::FindAllAsync(PnpObjectType::Device, requestedProperties)).then([&event, &os_version](concurrency::task<PnpObjectCollection^> t) {
 			try {
@@ -338,7 +339,10 @@ namespace TitaniumWindows
 					auto deviceClass = object->Properties->Lookup("{A45C254E-DF1C-4EFD-8020-67D146A850E0},10")->ToString();
 					if (deviceClass == "{4d36e966-e325-11ce-bfc1-08002be10318}") {
 						auto version = object->Properties->Lookup("{A8B865DD-2E3D-4094-AD97-E593A70C75D6},3")->ToString();
-						os_version = Utility::ConvertUTF8String(version);
+						const auto version_str = Utility::ConvertUTF8String(version);
+						if (!boost::starts_with(version_str, "6.3")) {
+							os_version = version_str;
+						}
 						found = true;
 						break;
 					}


### PR DESCRIPTION
- Translate Windows 8.1 client version `6.3.-` into `8.1`
###### NOTES
- Do we want to append the build number to the end? e.g `8.1.9600`
- If we don't then we should remove the build number from Windows 10 `10.0.10586.0`
###### TEST CASE

``` Javascript
Ti.API.info(Ti.Platform.version);
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23405)
