### PR TITLE
[TIMOB-23399] Implement getter for Ti.Network.networkTypeName

### DIFF
--- a/Examples/NMocha/src/Assets/ti.network.test.js
+++ b/Examples/NMocha/src/Assets/ti.network.test.js
@@ -35,4 +35,23 @@ describe('Titanium.Network', function () {
 		should(Ti.Network.createHTTPClient).be.a.Function;
 		finish();
 	});
+
+	it('networkType', function () {
+	    should(Ti.Network.networkType).not.be.null;
+	    should(Ti.Network.networkType).be.a.Number;
+	});
+
+	it('networkTypeName', function () {
+	    should(Ti.Network.networkTypeName).not.be.null;
+	    should(Ti.Network.networkTypeName).be.a.String;
+	    if (Ti.Network.networkType == Ti.Network.NETWORK_LAN) {
+	        Ti.Network.networkTypeName.should.eql('LAN');
+	    } else if (Ti.Network.networkType == Ti.Network.NETWORK_MOBILE) {
+	        Ti.Network.networkTypeName.should.eql('MOBILE');
+	    } else if (Ti.Network.networkType == Ti.Network.NETWORK_NONE) {
+	        Ti.Network.networkTypeName.should.eql('NONE');
+	    } else if (Ti.Network.networkType == Ti.Network.NETWORK_UNKNOWN) {
+	        Ti.Network.networkTypeName.should.eql('UNKNOWN');
+	    }
+	});
 });

--- a/Source/TitaniumKit/src/NetworkModule.cpp
+++ b/Source/TitaniumKit/src/NetworkModule.cpp
@@ -443,7 +443,6 @@ namespace Titanium
 	TITANIUM_FUNCTION_AS_GETTER(NetworkModule, getHttpURLFormatter, httpURLFormatter)
 	TITANIUM_FUNCTION_AS_SETTER(NetworkModule, setHttpURLFormatter, httpURLFormatter)
 
-	TITANIUM_PROPERTY_GETTER_STRING(NetworkModule, networkTypeName);
 	TITANIUM_PROPERTY_GETTER_BOOL(NetworkModule, online);
 	TITANIUM_PROPERTY_GETTER_STRING(NetworkModule, remoteDeviceUUID);
 	TITANIUM_PROPERTY_GETTER_BOOL(NetworkModule, remoteNotificationsEnabled);
@@ -452,6 +451,12 @@ namespace Titanium
 	TITANIUM_PROPERTY_GETTER(NetworkModule, networkType)
 	{
 		return get_context().CreateNumber(Titanium::Network::Constants::to_underlying_type(get_networkType()));
+	}
+
+	TITANIUM_PROPERTY_GETTER(NetworkModule, networkTypeName)
+	{
+		const auto type = Titanium::Network::Constants::to_string(get_networkType());
+		return get_context().CreateString(type);
 	}
 
 	TITANIUM_PROPERTY_GETTER(NetworkModule, remoteNotificationTypes)


### PR DESCRIPTION
- Implement ``Titanium.Network.networkTypeName`` property getter

###### TEST CASE
```Javascript
Ti.API.info(Ti.Network.networkTypeName);
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23399)