### PR TITLE
[TIMOB-23225] Fix: wrong size for child view with Ti.UI.SIZE

### DIFF
--- a/Examples/NMocha/src/Assets/ti.ui.layout.test.js
+++ b/Examples/NMocha/src/Assets/ti.ui.layout.test.js
@@ -1520,4 +1520,41 @@ describe('Titanium.UI.Layout', function () {
 		win.add(label);
 		win.open();
 	});
+
+    // TIMOB-23225
+	it('TIMOB-23225', function (finish) {
+	    var parent = Ti.UI.createView({
+	        height: Ti.UI.SIZE,
+	        width: Ti.UI.SIZE,
+	        backgroundColor: 'orange'
+	    });
+
+	    var v1 = Ti.UI.createView({
+	        height: 100, width: Ti.UI.FILL,
+	        backgroundColor: 'gray',
+	    });
+	    var v2 = Ti.UI.createImageView({
+	        height: 50, width: 50,
+	        top: 0, right: 0,
+	        backgroundColor: 'red',
+	    });
+	    var win = createWindow({}, finish);
+	    win.addEventListener('open', function () {
+	        setTimeout(function () {
+	            should(v1.rect.x).eql(0);
+	            should(v1.rect.y).eql(0);
+	            should(v1.rect.width).eql(parent.rect.width);
+	            should(v1.rect.height).eql(parent.rect.height);
+	            should(v2.rect.x).eql(parent.rect.width - v2.rect.width);
+	            should(v2.rect.y).eql(0);
+	            should(v2.rect.width).eql(50);
+	            should(v2.rect.width).eql(50);
+	            finish();
+	        }, 2000);
+	    });
+	    parent.add(v1);
+	    parent.add(v2);
+	    win.add(parent);
+	    win.open();
+	});
 });

--- a/Source/LayoutEngine/src/Composite.cpp
+++ b/Source/LayoutEngine/src/Composite.cpp
@@ -112,7 +112,7 @@ namespace Titanium
 				child = deferredLeftCalculations[i];
 				leftLayoutCoefficients = (*child).layoutCoefficients.left;
 				sandboxWidthLayoutCoefficients = (*child).layoutCoefficients.sandboxWidth;
-				(*child).measuredLeft = measuredLeft = leftLayoutCoefficients.x1 * computedSize.width + leftLayoutCoefficients.x2 * measuredWidth + leftLayoutCoefficients.x3;
+				(*child).measuredLeft = measuredLeft = leftLayoutCoefficients.x1 * computedSize.width + leftLayoutCoefficients.x2 * (*child).measuredWidth + leftLayoutCoefficients.x3;
 				(*child).measuredSandboxWidth = measuredSandboxWidth = sandboxWidthLayoutCoefficients.x1 * height + sandboxWidthLayoutCoefficients.x2 + (*child).measuredWidth + measuredLeft;
 
 				// Update the size of the component
@@ -124,7 +124,7 @@ namespace Titanium
 				child = deferredTopCalculations[i];
 				topLayoutCoefficients = (*child).layoutCoefficients.top;
 				sandboxHeightLayoutCoefficients = (*child).layoutCoefficients.sandboxHeight;
-				(*child).measuredTop = measuredTop = topLayoutCoefficients.x1 * computedSize.height + topLayoutCoefficients.x2 * measuredHeight + topLayoutCoefficients.x3;
+				(*child).measuredTop = measuredTop = topLayoutCoefficients.x1 * computedSize.height + topLayoutCoefficients.x2 * (*child).measuredHeight + topLayoutCoefficients.x3;
 				(*child).measuredSandboxHeight = measuredSandboxHeight = sandboxHeightLayoutCoefficients.x1 * height + sandboxHeightLayoutCoefficients.x2 + (*child).measuredHeight + measuredTop;
 
 				// Update the size of the component


### PR DESCRIPTION
[TIMOB-23225](https://jira.appcelerator.org/browse/TIMOB-23225)

```javascript
var win = Ti.UI.createWindow({ backgroundColor: 'green' });

var view = Ti.UI.createView({
    height: Ti.UI.SIZE,
    width: Ti.UI.SIZE,
    backgroundColor: 'orange'
});

var img1 = Ti.UI.createView({
    height: 100, width: Ti.UI.FILL,
    backgroundColor:'gray'
});
var img2 = Ti.UI.createView({
    height: 50, width: 50,
    top: 0, right: 0,
    backgroundColor: 'red'
});

view.add(img1);
view.add(img2);
win.add(view);

win.open();
```

![timob-23225](https://cloud.githubusercontent.com/assets/1661068/15853797/8f1bdc96-2ce1-11e6-9627-6e99aaca5e2a.png)
