### PR TITLE
[TIMOB-23352] ScrollView click should have actual view as source

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/ScrollView.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/ScrollView.hpp
@@ -24,7 +24,7 @@ namespace TitaniumWindows
 		class TITANIUMWINDOWS_UI_EXPORT ScrollViewLayoutDelegate : public WindowsViewLayoutDelegate
 		{
 		public:
-			ScrollViewLayoutDelegate(ScrollView*, const std::shared_ptr<WindowsViewLayoutDelegate>&) TITANIUM_NOEXCEPT;
+			ScrollViewLayoutDelegate(ScrollView*, const JSObject&) TITANIUM_NOEXCEPT;
 			virtual ~ScrollViewLayoutDelegate() = default;
 
 			virtual void add(const std::shared_ptr<Titanium::UI::View>& view) TITANIUM_NOEXCEPT override;
@@ -37,8 +37,10 @@ namespace TitaniumWindows
 		protected:
 #pragma warning(push)
 #pragma warning(disable : 4251)
+			static JSFunction CreateClickCallback(const JSObject& contentView) TITANIUM_NOEXCEPT;
 			ScrollView* scrollview__;
-			std::shared_ptr<WindowsViewLayoutDelegate> contentView__;
+			JSObject contentView__;
+			JSFunction clickCallback__;
 #pragma warning(pop)
 		};
 
@@ -105,6 +107,7 @@ namespace TitaniumWindows
 			Windows::UI::Xaml::Controls::ScrollViewer^ scroll_viewer__;
 			JSObject contentView__;
 
+			Windows::Foundation::EventRegistrationToken click_event__;
 			Windows::Foundation::EventRegistrationToken dragend_event__;
 			Windows::Foundation::EventRegistrationToken dragstart_event__;
 			Windows::Foundation::EventRegistrationToken scale_event__;


### PR DESCRIPTION
[TIMOB-23352](https://jira.appcelerator.org/browse/TIMOB-23352)

```javascript
var win = Ti.UI.createWindow();

var scrollView = Ti.UI.createScrollView({
    backgroundColor: 'green'
});

scrollView.addEventListener('click', function (e) {
   alert('e.source.apiName: ' + e.source.apiName + (e.source.id ? "\ne.source.id: " + e.source.id : ""));
});

scrollView.add(Ti.UI.createView({
    width: 100,
    height: 100,
    backgroundGradient: {
        type: 'linear',
        startPoint: { x: '0%', y: '50%' },
        endPoint: { x: '100%', y: '50%' },
        colors: [{ color: 'red', offset: 0.0 }, { color: 'blue', offset: 0.25 }, { color: 'red', offset: 1.0 }],
    },
    id: 'my_scrollview_content'
}));

win.add(scrollView);
win.open();
```