### PR TITLE
[5_4_X] [TIMOB-23125] Fix: Getting photo from photo gallery fails

### DIFF
--- a/Source/Media/src/Media.cpp
+++ b/Source/Media/src/Media.cpp
@@ -271,13 +271,13 @@ namespace TitaniumWindows
 		}
 
 		if (files.size() > 0) {
-			const auto blob = TitaniumWindows::Utility::GetTiBlobForFile(get_context(), files.at(0));
-			if (blob.IsObject()) {
+			const auto filename = files.at(0);
+			if (!filename.empty()) {
 				Titanium::Media::CameraMediaItemType item;
 				item.code = 0;
 				item.success = true;
 				item.mediaType = Titanium::Media::MediaType::Photo;
-				item.media = static_cast<JSObject>(blob).GetPrivate<Titanium::Blob>();
+				item.media_filename = filename;
 				openPhotoGalleryOptionsState__.callbacks.onsuccess(item);
 			} else {
 				Titanium::ErrorResponse error;
@@ -537,12 +537,7 @@ namespace TitaniumWindows
 				Titanium::Media::CameraMediaItemType item;
 				item.mediaType = Titanium::Media::MediaType::Photo;
 				if (file != nullptr) {
-					const auto blob = TitaniumWindows::Utility::GetTiBlobForFile(get_context(), TitaniumWindows::Utility::ConvertString(file->Path));
-					if (blob.IsObject()) {
-						item.media = static_cast<JSObject>(blob).GetPrivate<Titanium::Blob>();
-					} else {
-						item.error = "Failed to create media object from file";
-					}
+					item.media_filename = TitaniumWindows::Utility::ConvertString(file->Path);
 				} else {
 					item.error = "Failed to take picture";
 				}

--- a/Source/TitaniumKit/include/Titanium/Media/CameraMediaItemType.hpp
+++ b/Source/TitaniumKit/include/Titanium/Media/CameraMediaItemType.hpp
@@ -32,7 +32,6 @@ namespace Titanium
 			std::int32_t code { 0 };
 			Titanium::UI::Dimension cropRect;
 			std::string error;
-			std::shared_ptr<Titanium::Blob> media;
 			MediaType mediaType;
 			bool success { true };
 

--- a/Source/TitaniumKit/src/Media/CameraMediaItemType.cpp
+++ b/Source/TitaniumKit/src/Media/CameraMediaItemType.cpp
@@ -32,9 +32,6 @@ namespace Titanium
 			object.SetProperty("code", js_context.CreateNumber(config.code));
 			object.SetProperty("cropRect", Titanium::UI::Dimension_to_js(js_context, config.cropRect));
 			object.SetProperty("error", js_context.CreateString(config.error));
-			if (config.media != nullptr) {
-				object.SetProperty("media", config.media->get_object());
-			}
 			if (!config.media_filename.empty()) {
 				object.SetProperty("_media_filename", js_context.CreateString(config.media_filename));
 			}


### PR DESCRIPTION
[TIMOB-23125](https://jira.appcelerator.org/browse/TIMOB-23125)

```javascript
var window = Ti.UI.createWindow({
    exitOnClose: true,
});
var viewParent = Ti.UI.createView({
    width: '60%',
    height: '41%',
    top: '1%'
});

var imageTaken = Ti.UI.createImageView({
    width: Ti.UI.FILL,
    height: Ti.UI.FILL,
});

var cameraImage = Ti.UI.createButton({
    title: "Choose Photos",
    bottom: '0%',
    height: '20%',
    font: {
        fontSize: 15,
        fontWeight: "bold"
    },
    width: Ti.UI.FILL,
});

viewParent.add(imageTaken);
viewParent.add(cameraImage);
window.add(viewParent);

cameraImage.addEventListener('click', function (e) {

    Ti.Media.openPhotoGallery({
        autoHide: true,
        mediaTypes: [Ti.Media.MEDIA_TYPE_PHOTO],
        success: function (e) {
            if (e.mediaType === Ti.Media.MEDIA_TYPE_PHOTO) {
                imageTaken.image = e.media;
            }
        },
        cancel: function () {
        },
        error: function (err) {
            Ti.API.error(err);
        }
    });

});
window.open();
```