### PR TITLE
[TIMOB-23503] Fix: WebView local script doesn't work for hyperlink

### DIFF
--- a/Examples/NG/CMakeLists.txt
+++ b/Examples/NG/CMakeLists.txt
@@ -127,6 +127,9 @@ set(SOURCE_Assets
   src/Assets/Square44x44Logo.png
   src/Assets/cricket.wav
   src/Assets/Resources.resw
+  src/Assets/WebViewIndexPage.htm
+  src/Assets/WebViewNextPage.htm
+  src/Assets/Resources.resw
   )
 
 set_property(SOURCE ${SOURCE_Assets} PROPERTY VS_DEPLOYMENT_CONTENT 1)

--- a/Examples/NG/src/Assets/WebViewIndexPage.htm
+++ b/Examples/NG/src/Assets/WebViewIndexPage.htm
@@ -1,0 +1,14 @@
+<html>
+<head>
+    <script>
+        Ti.App.addEventListener("app:fromTitanium", function(e) {
+            Ti.API.info(e.message);
+        });
+    </script>
+</head>
+<body>
+    <h2><a href="http://www.google.com/">Google.com</a></h2>
+    <h2><a href="ms-appx-web:///WebViewNextPage.htm">Follow this link and see if script works</a></h2>
+    <button onclick="Ti.App.fireEvent('app:fromWebView', { message: 'event fired from WebView, handled in Titanium' });">fromWebView</button>
+</body>
+</html>

--- a/Examples/NG/src/Assets/WebViewNextPage.htm
+++ b/Examples/NG/src/Assets/WebViewNextPage.htm
@@ -1,0 +1,13 @@
+<html>
+<head>
+    <script>
+        Ti.App.addEventListener("app:fromTitanium", function(e) {
+            Ti.API.info(e.message);
+        });
+    </script>
+</head>
+<body>
+    <h2>ms-appx-web:///NextPage.htm</h2>
+    <button onclick="Ti.App.fireEvent('app:fromWebView', { message: 'event fired from WebView, handled in Titanium' });">fromWebView</button>
+</body>
+</html>

--- a/Source/UI/include/TitaniumWindows/UI/WebView.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/WebView.hpp
@@ -68,6 +68,9 @@ namespace TitaniumWindows
 			virtual void reload() TITANIUM_NOEXCEPT override;
 			virtual void stopLoading(const bool& hardStop) TITANIUM_NOEXCEPT override;
 
+			bool isLocalUri(Windows::Foundation::Uri^ uri) const TITANIUM_NOEXCEPT;
+
+			bool localscript_navigating__{ false };
 			bool error_event_enabled__ { false };
 			bool load_event_enabled__  { false };
 			bool beforeload_event_enabled__  { false };


### PR DESCRIPTION
[TIMOB-23503](https://jira.appcelerator.org/browse/TIMOB-23503)

Resources/app.js

```javascript
var win = Ti.UI.createWindow();
var view = Ti.UI.createView({backgroundColor:'blue'});
var webview = Ti.UI.createWebView({
    url: 'WebViewTestPage.htm',
    height: '80%',
    width: Ti.UI.FILL,
    bottom: 0
});
var button = Ti.UI.createButton({
    title: 'fromTitanium',
    height: '10%',
    width: Ti.UI.FILL,
    top: 0, left: 0
});
button.addEventListener('click', function (e) {
    Ti.App.fireEvent('app:fromTitanium', { message: 'event fired from Titanium, handled in WebView' });
});
Ti.App.addEventListener('app:fromWebView', function (e) {
    alert(e.message);
});

view.add(webview);
view.add(button);
win.add(view);
win.open();
```

Resources/WebViewTestPage.htm
```html
<html>
<head>
    <script>
        Ti.App.addEventListener("app:fromTitanium", function(e) {
            Ti.API.info(e.message);
        });
    </script>
</head>
<body>
    <h2><a href="ms-appx-web:///NextPage.htm">Follow this link and see if script works</a></h2>
    <button onclick="Ti.App.fireEvent('app:fromWebView', { message: 'event fired from WebView, handled in Titanium' });">fromWebView</button>
</body>
</html>
```

Resources/NextPage.htm
```html
<html>
<head>
    <script>
        Ti.App.addEventListener("app:fromTitanium", function(e) {
            Ti.API.info(e.message);
        });
    </script>
</head>
<body>
    <h2>NextPage.htm</h2>
    <button onclick="Ti.App.fireEvent('app:fromWebView', { message: 'event fired from WebView, handled in Titanium' });">fromWebView</button>
</body>
</html>
```