### PR TITLE
Remove missing asset from NG example

### DIFF
--- a/Examples/NG/CMakeLists.txt
+++ b/Examples/NG/CMakeLists.txt
@@ -128,7 +128,6 @@ set(SOURCE_Assets
   src/Assets/cricket.wav
   src/Assets/WebViewIndexPage.htm
   src/Assets/WebViewNextPage.htm
-  src/Assets/Resources.resw
   )
 
 set_property(SOURCE ${SOURCE_Assets} PROPERTY VS_DEPLOYMENT_CONTENT 1)


### PR DESCRIPTION
Remove wrong cmake link from ` Examples/NG/CMakeLists.txt `, seems like merged incorrectly in previous commit.