### PR TITLE
[TIMOB-23531] Fix: Tab title color is not changed on selection

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/Tab.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/Tab.hpp
@@ -81,7 +81,6 @@ namespace TitaniumWindows
 			std::vector<std::shared_ptr<Window>> window_stack__;
 #if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 			Windows::UI::Xaml::Controls::PivotItem^ pivotItem__;
-			Windows::UI::Xaml::Media::Brush^ defaultForeground__;
 #else
 			Windows::UI::Xaml::Controls::Grid^  grid__;
 #endif


### PR DESCRIPTION
[TIMOB-23531](https://jira.appcelerator.org/browse/TIMOB-23531)

* Try to get "default color" from current theme if no Tab title color is specified.

```javascript
// create tab group
var tabGroup = Titanium.UI.createTabGroup();

//
// create base UI tab and root window
//
var win1 = Titanium.UI.createWindow({
    title: 'Tab 1',
    backgroundColor: '#fff'
});
var tab1 = Titanium.UI.createTab({
    title: 'Tab 1',
    window: win1,
    // titleColor: 'blue',
    // activeColor: 'orange'
});

var label1 = Titanium.UI.createLabel({
    color: '#999',
    text: 'I am Window 1',
    font: { fontSize: 20, fontFamily: 'Helvetica Neue' },
    textAlign: 'center',
    width: 'auto'
});

win1.add(label1);

//
// create controls tab and root window
//
var win2 = Titanium.UI.createWindow({
    title: 'Tab 2',
    backgroundColor: '#fff'
});
var tab2 = Titanium.UI.createTab({
    title: 'Tab 2',
    window: win2,
    // titleColor: 'blue',
    // activeColor: 'orange'
});

var label2 = Titanium.UI.createLabel({
    color: '#999',
    text: 'I am Window 2',
    font: { fontSize: 20, fontFamily: 'Helvetica Neue' },
    textAlign: 'center',
    width: 'auto'
});

win2.add(label2);

//
//  add tabs
//
tabGroup.addTab(tab1);
tabGroup.addTab(tab2);

// open tab group
tabGroup.open();
```