### PR TITLE
[TIMOB-23427] Default camera control for Windows 10 apps

### DIFF
--- a/Source/Media/include/TitaniumWindows/Media.hpp
+++ b/Source/Media/include/TitaniumWindows/Media.hpp
@@ -176,6 +176,11 @@ namespace TitaniumWindows
 		void takeScreenshotDone(JSObject callback, const std::string& file = "", const bool& hasError = true);
 		void clearScreenshotResources();
 		void takeScreenshotToFile(JSObject callback);
+
+#if !defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
+		void showDefaultCamera(const Titanium::Media::CameraOptionsType& options) TITANIUM_NOEXCEPT;
+#endif
+
 #if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 		void updatePreviewOrientation();
 #endif


### PR DESCRIPTION
[TIMOB-23427](https://jira.appcelerator.org/browse/TIMOB-23427)

Show default camera UI when no `overlay` is specified. Note that _default camera UI won't be available for Windows Phone 8.1_.

```javascript
var win = Ti.UI.createWindow({ backgroundColor: 'green', layout: 'vertical' }),
    openButton = Ti.UI.createButton({ title: 'OPEN CAMERA', backgroundColor: 'blue' }),
    imageView = Ti.UI.createImageView({ width: Ti.UI.FILL, height: '80%' });

openButton.addEventListener('click', function () {
    Ti.Media.showCamera({
        mediaTypes: [Ti.Media.MEDIA_TYPE_PHOTO],
        success: function (e) {
            Ti.API.info('showCamera() success');
            imageView.image = e.media;
        },
        error: function (e) {
            alert('showCamera() error: ' + JSON.stringify(e));
        }
    });
});

win.add(openButton);
win.add(imageView);
win.open();
```

Default camera UI for Windows 10 Mobile (See [Windows Camera](https://www.microsoft.com/en-us/store/apps/windows-camera/9wzdncrfjbbg))
![windowscamera](https://cloud.githubusercontent.com/assets/1661068/16229767/2ee521ca-37f9-11e6-82d4-54acfbd825f6.png)
