### PR TITLE
[TIMOB-23512] [TIMOB-23543] Relative require() from sub-directory fails

### DIFF
--- a/Examples/NG/CMakeLists.txt
+++ b/Examples/NG/CMakeLists.txt
@@ -150,6 +150,12 @@ source_group("Strings\\en" FILES "src/Assets/Strings/en/Resources.resw")
 set(SOURCE_Strings_es "src/Assets/Strings/es/Resources.resw")
 source_group("Strings\\es" FILES "src/Assets/Strings/es/Resources.resw")
 
+file(GLOB_RECURSE COMMONJS_LEGACY_PACKAGE_DIRECTORY "modules/commonjs/commonjs.legacy.package/1.0.0/*.*")
+set(SOURCE_commonjs_legacy_package ${COMMONJS_LEGACY_PACKAGE_DIRECTORY})
+source_group("node_modules/commonjs.legacy.package" FILES ${COMMONJS_LEGACY_PACKAGE_DIRECTORY})
+set_property(SOURCE ${SOURCE_commonjs_legacy_package} PROPERTY VS_DEPLOYMENT_LOCATION "node_modules\\commonjs.legacy.package")
+set_property(SOURCE ${SOURCE_commonjs_legacy_package} PROPERTY VS_DEPLOYMENT_CONTENT 1)
+
 file(GLOB_RECURSE WITH_INDEX_JS_DIRECTORY "src/Assets/with_index_js/*.*")
 set(SOURCE_with_index_js ${WITH_INDEX_JS_DIRECTORY})
 source_group("with_index_js" FILES ${WITH_INDEX_JS_DIRECTORY})
@@ -164,6 +170,7 @@ add_executable(${EXE_NAME} WIN32
   ${SOURCE_Strings_en}
   ${SOURCE_Strings_es}
   ${SOURCE_with_index_js}
+  ${SOURCE_commonjs_legacy_package}
 )
 
 set_target_properties(${EXE_NAME} PROPERTIES VS_WINRT_COMPONENT TRUE)

--- a/Examples/NG/CMakeLists.txt
+++ b/Examples/NG/CMakeLists.txt
@@ -128,6 +128,7 @@ set(SOURCE_Assets
   src/Assets/cricket.wav
   src/Assets/WebViewIndexPage.htm
   src/Assets/WebViewNextPage.htm
+  src/Assets/require_test.js
   )
 
 set_property(SOURCE ${SOURCE_Assets} PROPERTY VS_DEPLOYMENT_CONTENT 1)
@@ -149,6 +150,12 @@ source_group("Strings\\en" FILES "src/Assets/Strings/en/Resources.resw")
 set(SOURCE_Strings_es "src/Assets/Strings/es/Resources.resw")
 source_group("Strings\\es" FILES "src/Assets/Strings/es/Resources.resw")
 
+file(GLOB_RECURSE WITH_INDEX_JS_DIRECTORY "src/Assets/with_index_js/*.*")
+set(SOURCE_with_index_js ${WITH_INDEX_JS_DIRECTORY})
+source_group("with_index_js" FILES ${WITH_INDEX_JS_DIRECTORY})
+set_property(SOURCE ${SOURCE_with_index_js} PROPERTY VS_DEPLOYMENT_LOCATION "with_index_js")
+set_property(SOURCE ${SOURCE_with_index_js} PROPERTY VS_DEPLOYMENT_CONTENT 1)
+
 add_executable(${EXE_NAME} WIN32
   src/main.cpp
   include/OutputDebugStringBuf.hpp
@@ -156,6 +163,7 @@ add_executable(${EXE_NAME} WIN32
   ${SOURCE_fonts}
   ${SOURCE_Strings_en}
   ${SOURCE_Strings_es}
+  ${SOURCE_with_index_js}
 )
 
 set_target_properties(${EXE_NAME} PROPERTIES VS_WINRT_COMPONENT TRUE)

--- a/Examples/NG/modules/commonjs/commonjs.legacy.package/1.0.0/commonjs.legacy.package.js
+++ b/Examples/NG/modules/commonjs/commonjs.legacy.package/1.0.0/commonjs.legacy.package.js
@@ -1,0 +1,3 @@
+module.exports = {
+	name: 'commonjs.legacy.package/commonjs.legacy.package.js'
+};

--- a/Examples/NG/modules/commonjs/commonjs.legacy.package/1.0.0/index.js
+++ b/Examples/NG/modules/commonjs/commonjs.legacy.package/1.0.0/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+	name: 'commonjs.legacy.package/index.js'
+};

--- a/Examples/NG/modules/commonjs/commonjs.legacy.package/1.0.0/index.json
+++ b/Examples/NG/modules/commonjs/commonjs.legacy.package/1.0.0/index.json
@@ -1,0 +1,3 @@
+{
+	"name": "commonjs.legacy.package/index.json"
+}

--- a/Examples/NG/modules/commonjs/commonjs.legacy.package/1.0.0/main.js
+++ b/Examples/NG/modules/commonjs/commonjs.legacy.package/1.0.0/main.js
@@ -1,0 +1,3 @@
+module.exports = {
+	name: 'commonjs.legacy.package/main.js'
+};

--- a/Examples/NG/modules/commonjs/commonjs.legacy.package/1.0.0/manifest
+++ b/Examples/NG/modules/commonjs/commonjs.legacy.package/1.0.0/manifest
@@ -1,0 +1,17 @@
+#
+# this is your module manifest and used by Titanium
+# during compilation, packaging, distribution, etc.
+#
+version: 1.0.0
+description: testing
+author: Chris Williams
+license: Appcelerator Commercial License
+copyright: Copyright (c) 2016 by Appcelerator,  Inc.
+
+
+# these should not be edited
+name: commonjs.legacy.package
+moduleid: commonjs.legacy.package
+guid: 1056b5d2-2bb5-4339-b930-297637aeec4e
+platform: commonjs
+minsdk: 5.4.0

--- a/Examples/NG/modules/commonjs/commonjs.legacy.package/1.0.0/package.json
+++ b/Examples/NG/modules/commonjs/commonjs.legacy.package/1.0.0/package.json
@@ -1,0 +1,2 @@
+{ "name" : "commonjs.legacy.package",
+  "main" : "./main.js" }

--- a/Examples/NG/src/Assets/require_test.js
+++ b/Examples/NG/src/Assets/require_test.js
@@ -1,0 +1,3 @@
+module.exports = {
+	name: 'index.js'
+};

--- a/Examples/NG/src/Assets/with_index_js/index.js
+++ b/Examples/NG/src/Assets/with_index_js/index.js
@@ -1,0 +1,6 @@
+var sub = require('./sub');
+Ti.API.info('sub.name: ' + sub.name);
+
+module.exports = {
+	name: 'index.js'
+};

--- a/Examples/NG/src/Assets/with_index_js/index.json
+++ b/Examples/NG/src/Assets/with_index_js/index.json
@@ -1,0 +1,3 @@
+{
+	"name": "index.json"
+}

--- a/Examples/NG/src/Assets/with_index_js/sub.js
+++ b/Examples/NG/src/Assets/with_index_js/sub.js
@@ -1,0 +1,3 @@
+module.exports = {
+    name: 'sub.js'
+};

--- a/Examples/NMocha/src/Assets/ti.require.test.js
+++ b/Examples/NMocha/src/Assets/ti.require.test.js
@@ -122,7 +122,7 @@ describe('requireJS', function () {
 		var object = require('ti.require.test_test');
 		should(object).be.an.Object;
 		should(object.filename).be.a.String;
-		should(object.filename).be.eql('ti.require.test_test');
+		should(object.filename).be.eql('/ti.require.test_test.js');
 		finish();
 	});
 
@@ -138,6 +138,15 @@ describe('requireJS', function () {
 		should(with_index_js).have.property('name');
 		should(with_index_js.name).be.eql('index.js');
 		finish();
+	});
+    
+    // TIMOB-23512
+	it('relative require() from sub directory', function (finish) {
+	    var with_index_js = require('./with_index_js/sub1');
+	    should(with_index_js).have.property('name');
+	    should(with_index_js.name).be.eql('sub1.js');
+	    should(with_index_js.sub).be.eql('sub2.js');
+	    finish();
 	});
 
 	it('falls back to index.json when requiring directory with no package.json or index.js', function (finish) {

--- a/Examples/NMocha/src/Assets/with_index_js/sub1.js
+++ b/Examples/NMocha/src/Assets/with_index_js/sub1.js
@@ -1,0 +1,6 @@
+var sub2 = require('./sub2')
+
+module.exports = {
+    name: 'sub1.js',
+    sub: sub2.name
+};

--- a/Examples/NMocha/src/Assets/with_index_js/sub2.js
+++ b/Examples/NMocha/src/Assets/with_index_js/sub2.js
@@ -1,0 +1,3 @@
+module.exports = {
+    name: 'sub2.js'
+};

--- a/Source/TitaniumKit/src/GlobalObject.cpp
+++ b/Source/TitaniumKit/src/GlobalObject.cpp
@@ -266,7 +266,19 @@ namespace Titanium
 			return requireNativeModule(js_context, moduleId);
 		}
 
-		auto module_path = requestResolveModule(parent, moduleId);
+		std::string dirname = COMMONJS_SEPARATOR__;
+		if (parent.HasProperty("__filename")) {
+			const auto filename_obj = parent.GetProperty("__filename");
+			if (filename_obj.IsString()) {
+				const auto filename = static_cast<std::string>(filename_obj);
+				const auto pos = filename.find_last_of(COMMONJS_SEPARATOR__);
+				if (pos != std::string::npos) {
+					dirname = filename.substr(0, pos);
+				}
+			}
+		}
+
+		auto module_path = requestResolveModule(parent, moduleId, dirname);
 		if (module_path.empty()) {
 			// Fall back to assuming equivalent of "/" + moduleId?
 			module_path = requestResolveModule(parent, "/" + moduleId);
@@ -296,8 +308,8 @@ namespace Titanium
 				if (moduleId == "/app") {
 					result = js_context.JSEvaluateScript(module_js, js_context.get_global_object());
 				} else {
-					const std::string require_module_js = "(function(global) { var exports={},__OXP=exports,module={'exports':exports},__filename='"
-						+ moduleId + "';" + module_js + R"JS(
+					const std::string require_module_js = "(function(global) { var exports={},__OXP=exports,module={'exports':exports};this.__filename='/"
+						+ module_path + "';" + module_js + R"JS(
 						if(module.exports !== __OXP){
 							return module.exports;
 						} else {

--- a/Source/TitaniumKit/src/GlobalObject.cpp
+++ b/Source/TitaniumKit/src/GlobalObject.cpp
@@ -267,8 +267,8 @@ namespace Titanium
 		}
 
 		std::string dirname = COMMONJS_SEPARATOR__;
-		if (parent.HasProperty("__filename")) {
-			const auto filename_obj = parent.GetProperty("__filename");
+		if (parent.HasProperty("__TI_REQUIRED__")) {
+			const auto filename_obj = parent.GetProperty("__TI_REQUIRED__");
 			if (filename_obj.IsString()) {
 				const auto filename = static_cast<std::string>(filename_obj);
 				const auto pos = filename.find_last_of(COMMONJS_SEPARATOR__);
@@ -308,8 +308,9 @@ namespace Titanium
 				if (moduleId == "/app") {
 					result = js_context.JSEvaluateScript(module_js, js_context.get_global_object());
 				} else {
-					const std::string require_module_js = "(function(global) { var exports={},__OXP=exports,module={'exports':exports};this.__filename='/"
-						+ module_path + "';" + module_js + R"JS(
+					const std::string require_module_js = "(function(global) { var exports={},__OXP=exports,module={'exports':exports},__filename='/"
+						+ module_path + "';this.__TI_REQUIRED__ = __filename;" + module_js + R"JS(
+						delete this.__TI_REQUIRED__; // only available while evaluating current module
 						if(module.exports !== __OXP){
 							return module.exports;
 						} else {

--- a/Source/TitaniumKit/test/GlobalObjectTests.cpp
+++ b/Source/TitaniumKit/test/GlobalObjectTests.cpp
@@ -389,7 +389,7 @@ TEST_F(GlobalObjectTests, requireNestedModule)
 	)js";
 
 	std::string module_js = R"js(
-		var hello = require('hello');
+		var hello = require('./hello');
 		module.exports = hello;
 	)js";
 


### PR DESCRIPTION
[TIMOB-23512](https://jira.appcelerator.org/browse/TIMOB-23512) and [TIMOB-23543](https://jira.appcelerator.org/browse/TIMOB-23543)

### app.js
```javascript
var test = require('subdir/index');
should(test.filename).eql('/subdir/index.js');
should(test.name).eql('index.js');
should(test.sub).eql('sub.js');
```

### subdir/index.js

```javascript
var sub = require('./sub')
module.exports = {
    filename: __filename,
    name: 'index.js',
    sub: sub.name
};
```


### subdir/sub.js

```javascript
module.exports = {
    name: 'sub.js',
};
```

Note: In  order to retrieve current file name from requiring object, I ended up adding new hidden variable `__TI_REQUIRED__` in global object, which is only available while evaluating required module. This is tricky but needed because `JSObject parent` in `GlobalObject::requestResolveModule(parent, moduleId)` is always global object. (See also [Source/TitaniumKit/src/GlobalObject.cpp ](https://github.com/appcelerator/titanium_mobile_windows/pull/750/files#diff-3b6d0c60899ff30352e5cc386b90fa56R270))