### PR TITLE
Attempt to fix SDK install location on tests

### DIFF
--- a/Tools/Scripts/build/test.js
+++ b/Tools/Scripts/build/test.js
@@ -94,7 +94,7 @@ function getSDKInstallDir(next) {
 					newpath = path.join(out.defaultInstallLocation, 'mobilesdk', 'win32', selectedSDK);
 				if (fs.existsSync(oldpath)) {
 					fs.renameSync(oldpath, newpath);
-					return next(null, out.sdks[version].path);
+					return next(null, newpath);
 				} else {
 					return next('Failed to get SDK install dir: ' + selectedSDK);
 				}


### PR DESCRIPTION
Attempt to workaround SDK install location issue which fails Jenkins tests.

I recently noticed that recent Ti CLI drops version date string (`.v2016xxx`) from `6.0.0.v2016xxx` on `ti sdk install -b master -d`. I expect that's the reason why Jenkins keeps failing.

```
05:36:13 Titanium SDK 6.0.0.v20160624160033 successfully installed!
05:36:14 C:\Jenkins\workspace\titanium_mobile_windows_10_prs\Tools\Scripts\build\test.js:77
05:36:14        next(null, out['titanium'][selectedSDK]['path']);
```

I don't know why exactly recent Ti CLI drops version dates string now, so this PR may be a temporary workaround. Just wanted to proceed our pending PR so that no one is blocked by that.