### PR TITLE
[5_4_X] [TIMOB-23560] Fix: Setting images on ImageView will crash the app

### DIFF
--- a/Examples/NMocha/src/Assets/ti.ui.imageview.test.js
+++ b/Examples/NMocha/src/Assets/ti.ui.imageview.test.js
@@ -8,7 +8,7 @@ var should = require('./should'),
 	utilities = require('./utilities/utilities');
 
 describe('Titanium.UI.ImageView', function () {
-	this.timeout(5000);
+	this.timeout(10000);
 
 	it('apiName', function (finish) {
 		should(Ti.UI.ImageView.apiName).be.eql('Ti.UI.ImageView');
@@ -212,7 +212,6 @@ describe('Titanium.UI.ImageView', function () {
 			height: Ti.UI.SIZE
 		});
 		var innerView = Ti.UI.createImageView({
-			image: 'http://api.randomuser.me/portraits/women/0.jpg',
 			width: 100,
 			height: Ti.UI.SIZE,
 			top: 0,
@@ -228,6 +227,7 @@ describe('Titanium.UI.ImageView', function () {
 				finish();
 			}, 1000);
 		});
+		innerView.image = 'http://api.randomuser.me/portraits/women/0.jpg';
 		win.add(view);
 		win.open();
 	});

--- a/Source/TitaniumKit/src/UI/ImageView.cpp
+++ b/Source/TitaniumKit/src/UI/ImageView.cpp
@@ -24,10 +24,11 @@ namespace Titanium
 			  decodeRetries__(5),
 			  defaultImage__(""),
 			  enableZoomControls__(false),
-		      duration__(200),
-		      image__(""),
-		      images__(),
-		      preventDefaultImage__(false)
+			  duration__(200),
+			  image__(""),
+			  images__(),
+			  preventDefaultImage__(false),
+			  reverse__(false)
 		{
 		}
 

--- a/Source/UI/include/TitaniumWindows/UI/ImageView.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/ImageView.hpp
@@ -101,7 +101,6 @@ namespace TitaniumWindows
 
 			bool prepareImageParams();
 			void loadBitmap(std::vector<std::uint8_t>& data, SetBitmapImageCallback_t);
-			void loadBitmap(const std::string& path,         SetBitmapImageCallback_t);
 			void loadBitmaps();
 
 			void set_image(Windows::UI::Xaml::Media::Imaging::BitmapImage^);

--- a/Source/UI/src/ImageView.cpp
+++ b/Source/UI/src/ImageView.cpp
@@ -166,7 +166,7 @@ namespace TitaniumWindows
 			for (size_t i = 0; i < image_count; i++) {
 				size_t index = reverse ? (image_count - 1) - i : i;
 
-				const auto bitmap = bitmaps__->GetAt(i);
+				const auto bitmap = bitmaps__->GetAt(index);
 				auto keyFrame = ref new Windows::UI::Xaml::Media::Animation::DiscreteObjectKeyFrame();
 				Windows::Foundation::TimeSpan key_time;
 				key_time.Duration = timer_interval_ticks.count() * i;


### PR DESCRIPTION
[TIMOB-23560](https://jira.appcelerator.org/browse/TIMOB-23560)

```javascript
var win = Ti.UI.createWindow({backgroundColor:'green'});

var images = [];
for (var i = 0; i < 31; i++) {
    images.push('Roamler_app_loader_' + ( '0' + i ).slice( -2 ) + '.png');
}

var image = Ti.UI.createImageView({
    images: images,
    width: 75,
    height: 75,
    duration: 67
});

win.addEventListener('open', function () {
    image.start();
});

win.add(image);
win.open();
```

Images: [loader.zip](https://jira.appcelerator.org/secure/attachment/59655/loader.zip)
