### PR TITLE
Fix another broken require case where multiple relative requires in same file failed.

### DIFF
--- a/Examples/NMocha/src/Assets/ti.require.test.js
+++ b/Examples/NMocha/src/Assets/ti.require.test.js
@@ -139,14 +139,16 @@ describe('requireJS', function () {
 		should(with_index_js.name).be.eql('index.js');
 		finish();
 	});
-    
-    // TIMOB-23512
+
+	// TIMOB-23512
 	it('relative require() from sub directory', function (finish) {
-	    var with_index_js = require('./with_index_js/sub1');
-	    should(with_index_js).have.property('name');
-	    should(with_index_js.name).be.eql('sub1.js');
-	    should(with_index_js.sub).be.eql('sub2.js');
-	    finish();
+		var with_index_js = require('./with_index_js/sub1');
+		should(with_index_js).have.property('name');
+		should(with_index_js.name).be.eql('sub1.js');
+		should(with_index_js.sub).be.eql('sub2.js');
+		// Was also failing if same file had multiple relative requires
+		should(with_index_js.sub3).be.eql('sub3.js');
+		finish();
 	});
 
 	it('falls back to index.json when requiring directory with no package.json or index.js', function (finish) {

--- a/Examples/NMocha/src/Assets/with_index_js/sub1.js
+++ b/Examples/NMocha/src/Assets/with_index_js/sub1.js
@@ -1,6 +1,8 @@
-var sub2 = require('./sub2')
+var sub2 = require('./sub2'),
+    sub3 = require('./sub3');
 
 module.exports = {
     name: 'sub1.js',
-    sub: sub2.name
+    sub: sub2.name,
+    sub3: sub3.name
 };

--- a/Examples/NMocha/src/Assets/with_index_js/sub3.js
+++ b/Examples/NMocha/src/Assets/with_index_js/sub3.js
@@ -1,0 +1,3 @@
+module.exports = {
+    name: 'sub3.js'
+};

--- a/Source/TitaniumKit/include/Titanium/GlobalObject.hpp
+++ b/Source/TitaniumKit/include/Titanium/GlobalObject.hpp
@@ -318,6 +318,7 @@ namespace Titanium
 #pragma warning(push)
 #pragma warning(disable : 4251)
 		std::unordered_map<std::string, JSValue> module_cache__;
+		std::string currentDir__;
 		std::unordered_map<unsigned, std::shared_ptr<Timer>> timer_map__;
 
 		static std::atomic<unsigned> timer_id_generator__;


### PR DESCRIPTION
Follow-on to #750 

The common mocha suite was still broken because it had two relative requires in the same file. The use of the __TI_REQUIRED__ hack would only work for a single require because the property lived off the global, so after the first require it got removed and we lost state. It needed to be able to be dealt with recursively. I instead move it to a currentDir__ field on GlobalObject in the C++ code, mimicking what we do for iOS.

Note that this is a hack that works for now, but a real proper Node-style require implementation requires more than what we're doing now. They generate a Module object after the path is resolved holding the resolved filename and a pointer to the parent Module. They then generate a require function that is hooked within the context of that module. When they load the module from source, they wrap it in a way that they can pass in more arguments than we currently provide: filename, dirname, parent, the custom require for that context.

Basically it allows them to recursively do requires where you take the parent context to know how to resolve. Their cache also holds module objects and returns back module.exports from require calls (where we just hold the exports object itself in the cache).

We should consider fixing our implementation to be closer to theirs. Instead of doing that magic eval string we do, we need to generate a function we can call with actual args and pass in the various pieces. Our Android implementation follows much closer to theirs.

Most of the magic for Node is here: 
- https://github.com/nodejs/node/blob/master/lib/module.js
- https://github.com/nodejs/node/blob/master/lib/internal/module.js
- https://github.com/nodejs/node/blob/1a21524b6908892e2d0a79cbb4241aee78530c09/lib/internal/bootstrap_node.js

See also: https://nodejs.org/dist/latest-v6.x/docs/api/modules.html#modules_the_module_wrapper
