### PR TITLE
[TIMOB-23607] Fix Ti.UI.animate() for right and bottom properties

### DIFF
--- a/Examples/NMocha/src/Assets/ti.ui.view.test.js
+++ b/Examples/NMocha/src/Assets/ti.ui.view.test.js
@@ -285,6 +285,73 @@ describe('Titanium.UI.View', function () {
 	});
 
 	// FIXME: Windows 10 Store app fails for this...need to figure out why.
+	it('animate (right)', function (finish) {
+		this.timeout(1e4);
+		var win = Ti.UI.createWindow(),
+		    parent = Ti.UI.createView({backgroundColor: 'red', width: 100, height: 100}),
+		    view = Ti.UI.createView({
+		        backgroundColor: 'orange',
+		        top: 0,
+		        left: 0,
+		        height: '10',
+		        width: '10'
+		    }),
+            animation = Ti.UI.createAnimation({
+		        right: '10',
+		        duration: 1000
+            });
+
+		animation.addEventListener('complete', function () {
+		    setTimeout(function () {
+				should(view.rect.x).be.eql(80);
+				should(view.rect.y).be.eql(0);
+				should(view.left).be.eql(0);
+				should(view.top).be.eql(0);
+				win.close();
+				finish();
+			}, 500);
+		});
+
+		parent.add(view);
+		view.animate(animation);
+		win.add(parent);
+		win.open();
+	});
+
+	// FIXME: Windows 10 Store app fails for this...need to figure out why.
+	it('animate (bottom)', function (finish) {
+		this.timeout(1e4);
+		var win = Ti.UI.createWindow(),
+		    parent = Ti.UI.createView({backgroundColor: 'red', width: 100, height: 100}),
+		    view = Ti.UI.createView({
+		        backgroundColor: 'orange',
+		        top: 0,
+		        left: 0,
+		        height: '10',
+		        width: '10'
+		    });
+		    animation = Ti.UI.createAnimation({
+		        bottom: '10',
+		        duration: 1000
+		    });
+		animation.addEventListener('complete', function () {
+		    setTimeout(function () {
+		        should(view.rect.x).be.eql(0);
+		        should(view.rect.y).be.eql(80);
+		        should(view.left).be.eql(0);
+		        should(view.top).be.eql(0);
+		        win.close();
+		        finish();
+	        }, 500);
+        });
+
+		parent.add(view);
+		view.animate(animation);
+		win.add(parent);
+		win.open();
+	});
+
+	// FIXME: Windows 10 Store app fails for this...need to figure out why.
 	((utilities.isWindows10() && utilities.isWindowsDesktop()) ? it.skip : it)('TIMOB-20598', function (finish) {
 		var win = Ti.UI.createWindow(),
 			view = Ti.UI.createView({

--- a/Source/LayoutEngine/src/ParseProperty.cpp
+++ b/Source/LayoutEngine/src/ParseProperty.cpp
@@ -22,6 +22,8 @@ namespace Titanium
 				return Size;
 			} else if (value == "UI.FILL") {
 				return Fill;
+			} else if (value == "NONE") {
+				return None;
 			} else if (value.find("%") != std::string::npos) {
 				return Percent;
 			} else {

--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -732,20 +732,20 @@ namespace TitaniumWindows
 				// Make sure to update the position of the view because StoryBoard doesn't change actual position of it.
 				//
 				const auto top = animation->get_top();
+				const auto bottom = animation->get_bottom();
 				if (top) {
 					setLayoutProperty(Titanium::LayoutEngine::ValueName::Top, *top);
-				}
-				const auto bottom = animation->get_bottom();
-				if (bottom) {
+				} else if (bottom) {
+					setLayoutProperty(Titanium::LayoutEngine::ValueName::Top, "NONE");
 					setLayoutProperty(Titanium::LayoutEngine::ValueName::Bottom, *bottom);
 				}
 
 				const auto left = animation->get_left();
+				const auto right = animation->get_right();
 				if (left) {
 					setLayoutProperty(Titanium::LayoutEngine::ValueName::Left, *left);
-				}
-				const auto right = animation->get_right();
-				if (right) {
+				} else if (right) {
+					setLayoutProperty(Titanium::LayoutEngine::ValueName::Left, "NONE");
 					setLayoutProperty(Titanium::LayoutEngine::ValueName::Right, *right);
 				}
 


### PR DESCRIPTION
- Fix ``Titanium.UI.animate()`` where ``right`` and ``bottom`` properties would not be retained after the animation

###### TEST CASE
```Javascript
var win = Ti.UI.createWindow({ backgroundColor: 'red' }),
    view = Ti.UI.createView({
        backgroundColor: 'orange',
        top: 0,
        left: 0,
        height: '100',
        width: '100'
    });

view.addEventListener('click', function () {
    view.animate(Ti.UI.createAnimation({
        right: '50%',
        bottom: '50%',
        duration: 2000
    }));
});

win.add(view);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23607)