### PR TITLE
[TIMOB-23563] Suppress 'possible EventEmitter memory leak detected'

### DIFF
--- a/cli/commands/_buildModule.js
+++ b/cli/commands/_buildModule.js
@@ -27,6 +27,7 @@ var archiver = require('archiver'),
 	types = defaultTypes.slice(0),
 	typesMin = ['phone', 'store', 'win10'],
 	configuration = 'Release',
+	EventEmitter = require('events').EventEmitter,
 	vs_architectures = {ARM:'ARM', x86:'Win32'}; // x86 -> Win32 mapping
 
 function WindowsModuleBuilder() {
@@ -287,6 +288,10 @@ function walkdir(dirpath, base, callback) {
 }
 
 WindowsModuleBuilder.prototype.packageZip = function packageZip(next) {
+
+	// Suppress warnings from Stream
+	EventEmitter.defaultMaxListeners = 100;
+
 	var buildDir = path.join(this.projectDir, 'build'),
 		moduleDir = path.join(buildDir, this.manifest.moduleid, this.manifest.version),
 		projectname = this.manifest.moduleIdAsIdentifier,


### PR DESCRIPTION
[TIMOB-23563](https://jira.appcelerator.org/browse/TIMOB-23563)

Suppress `possible EventEmitter memory leak detected` warnings from on packaging module by using [EventEmitter.defaultMaxListeners](https://nodejs.org/api/events.html#events_eventemitter_defaultmaxlisteners). I assume this is safe because these warnings are from Node.js Streams and they properly removes listeners on finish.