### PR TITLE
Force "en" instead of "en-US" for the default language

### DIFF
--- a/cli/commands/_build/generate.js
+++ b/cli/commands/_build/generate.js
@@ -27,6 +27,7 @@ function mixin(WindowsBuilder) {
 	WindowsBuilder.prototype.generateCapabilityList = generateCapabilityList;
 	WindowsBuilder.prototype.generateAppxManifestForPlatform = generateAppxManifestForPlatform;
 	WindowsBuilder.prototype.generateAppxManifest = generateAppxManifest;
+	WindowsBuilder.prototype.addI18nVSResources = addI18nVSResources;
 }
 
 /**
@@ -92,6 +93,26 @@ function generateI18N(next) {
 
 	next();
 };
+
+/**
+ * Updates the Visual Studio project to add the generated Resources.resw file
+ *
+ * @param {Function} next - A function to call after resources have been generated.
+ */
+function addI18nVSResources(next) {
+	var cmakeProjectName = this.sanitizeProjectName(this.cli.tiapp.name),
+		vcxproj = path.resolve(this.cmakeTargetDir, cmakeProjectName + '.vcxproj');
+
+	var modified = fs.readFileSync(vcxproj, 'utf8');
+	fs.existsSync(vcxproj) && fs.renameSync(vcxproj, vcxproj + '.bak');
+
+	// DefaultLanguage (forcing to "en" for now)
+	modified = modified.replace(/<DefaultLanguage>[a-zA-Z]{2}(-[a-zA-Z]{2})*<\/DefaultLanguage>/, '<DefaultLanguage>en</DefaultLanguage>');
+
+	fs.writeFileSync(vcxproj, modified);
+
+	next();
+}
 
 /**
  * Generates the native type wrappers and adds them to the Visual Studio project.

--- a/cli/commands/_build/run.js
+++ b/cli/commands/_build/run.js
@@ -53,6 +53,7 @@ function run(logger, config, cli, finished) {
 		'generateAppxManifest',
 		'generateCmakeList',
 		'runCmake',
+		'addI18nVSResources',
 		'compileApp',
 		'writeBuildManifest',
 		'copyResultsToProject',


### PR DESCRIPTION
Force "en" instead of "en-US" for the default language.

```
> appc ti build -p windows --build-only
[WARN]  MakePRI : warning 0xdef00522: no resources found for default language(s): 'en-US'.
Change the default language or qualify resources with the default language.
http://go.microsoft.com/fwlink/?LinkId=231899
```

Introduced by #737.

