### PR TITLE
generate capabilities only when none are defined in the tiapp.xml

### DIFF
--- a/cli/commands/_build/generate.js
+++ b/cli/commands/_build/generate.js
@@ -406,8 +406,9 @@ function generateAppxManifestForPlatform(target, properties) {
 			}
 		});
 		properties.Capabilities = capabilities.concat(deviceCapabilities);
+	} else {
+		this.generateCapabilityList(target, properties);
 	}
-	this.generateCapabilityList(target, properties);
 
 	properties.Prerequisites = properties.Prerequisites || [];
 	properties.Resources = properties.Resources || [];


### PR DESCRIPTION
Follow up on https://github.com/appcelerator/titanium_mobile_windows/pull/761#discussion_r69987108

Basically revert https://github.com/appcelerator/titanium_mobile_windows/pull/771/commits/c963430484aca4fa5e36ebcd1c2f3262cded8e5c to recover CI build asap.