### PR TITLE
Attempt to improve "require" performance

### DIFF
--- a/Source/TitaniumKit/include/Titanium/GlobalObject.hpp
+++ b/Source/TitaniumKit/include/Titanium/GlobalObject.hpp
@@ -261,6 +261,7 @@ namespace Titanium
 #pragma warning(push)
 #pragma warning(disable : 4251)
 		static const std::string COMMONJS_SEPARATOR__;
+		static std::uint32_t require_nested_count__;
 #pragma warning(pop)
 
 		virtual std::string requestResolveModule(const JSObject& parent, const std::string& moduleId, const std::string& dirname = COMMONJS_SEPARATOR__) TITANIUM_NOEXCEPT;
@@ -317,6 +318,7 @@ namespace Titanium
 // need to be exported from a DLL.
 #pragma warning(push)
 #pragma warning(disable : 4251)
+		std::unordered_map<std::string, std::string> module_path_cache__;
 		std::unordered_map<std::string, JSValue> module_cache__;
 		std::string currentDir__;
 		std::unordered_map<unsigned, std::shared_ptr<Timer>> timer_map__;


### PR DESCRIPTION
Attempt to improve "require" performance & log.

- Cache require path search results
- Log nested require count for debug

The final resolved path for`GlobalObject::requestResolveModule` was not cached. It improves performance of `require` significantly when it is called multiple times (e.g. in the loop) with same name like below.

```javascript
for (var i = 0; i < 100; i++) {
    var b = require('some_other_module');
}
```

I also add nested require count for debugging purpose. It is handy to check how deep `require` call is nested.

```
[DEBUG] - require(./app) from /
[DEBUG] -- require(./ti.require.test) from /
[DEBUG] --- require(./sub) from /with_index_js
```