### PR TITLE
[TIMOB-23639] Fix Ti.UI.TableView.deleteSection()

### DIFF
--- a/Source/UI/src/TableView.cpp
+++ b/Source/UI/src/TableView.cpp
@@ -246,8 +246,7 @@ namespace TitaniumWindows
 
 			unregisterSectionLayoutNode(section);
 
-			const auto views = static_cast<Vector<UIElement^>^>(collectionViewItems__->GetAt(sectionIndex));
-			views->Clear();
+			collectionViewItems__->RemoveAt(sectionIndex);
 
 			bindCollectionViewSource();
 


### PR DESCRIPTION
- ``deleteSection`` should remove the section instead of removing the section rows

###### TEST CASE
```Javascript
var win = Ti.UI.createWindow(),
    sections = [],
    table = Ti.UI.createTableView(),
    createSection = function (title) {
        return section = Ti.UI.createTableViewSection({headerTitle: title});
    }

for (var i = 0; i < 3; i++) {
    sections[i] = createSection('Section #' + i);
}
table.data = sections;
table.deleteSection(1);
table.updateSection(1, createSection('Section #1'));

win.add(table);
win.open();
```
```
Section #0
Section #1
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23639)