### PR TITLE
[TIMOB-23641] Fix Ti.UI.ListSection.insertItemsAt()

### DIFF
--- a/Source/TitaniumKit/src/UI/ListSection.cpp
+++ b/Source/TitaniumKit/src/UI/ListSection.cpp
@@ -126,7 +126,7 @@ namespace Titanium
 		void ListSection::insertItemsAt(const std::uint32_t& index, const std::vector<ListDataItem>& dataItems, const std::shared_ptr<ListViewAnimationProperties>& animation) TITANIUM_NOEXCEPT
 		{
 			items__.insert(items__.begin() + index, dataItems.begin(), dataItems.end());
-			fireListSectionEvent("append", index, static_cast<std::uint32_t>(dataItems.size()));
+			fireListSectionEvent("insert", index, static_cast<std::uint32_t>(dataItems.size()));
 		}
 
 		void ListSection::replaceItemsAt(const std::uint32_t& index, const std::uint32_t& count, const std::vector<ListDataItem>& dataItems, const std::shared_ptr<ListViewAnimationProperties>& animation) TITANIUM_NOEXCEPT

--- a/Source/UI/src/ListView.cpp
+++ b/Source/UI/src/ListView.cpp
@@ -272,6 +272,12 @@ namespace TitaniumWindows
 				} else {
 					views->Clear();
 				}
+			} else if (name == "insert") {
+				for (std::uint32_t i = itemIndex; i < itemIndex + itemCount; i++) {
+					const auto view = createSectionItemViewAt<TitaniumWindows::UI::View>(sectionIndex, i);
+					insertListViewItemForSection(view, views, i);
+					section->setViewForSectionItem(i, view);
+				}
 			}
 			Titanium::UI::ListView::fireListSectionEvent(name, section, itemIndex, itemCount, affectedRows);
 		}


### PR DESCRIPTION
- Fix ``Titanium.UI.ListSection.insertItemsAt()`` to ``insert`` and not ``append`` items

###### TEST CASE
```Javascript
var win = Ti.UI.createWindow({backgroundColor: 'orange'}),
    list = Ti.UI.createListView(),
    items = [];

for (var i = 1; i < 3; i++) {
    items.push({properties: {title: 'Item #'+i}});
}
list.sections = [Ti.UI.createListSection({ items: items })];
list.sections[0].insertItemsAt(0, [{properties: {title: 'Item #0'}}]);

win.add(list);
win.open();
```
```
Item #0
Item #1
Item #2
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23641)