### PR TITLE
[TIMOB-23329] Fix Titanium.UI.TableView.borderRadius property

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/TableView.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/TableView.hpp
@@ -39,9 +39,6 @@ namespace TitaniumWindows
 			TITANIUM_PROPERTY_UNIMPLEMENTED(minRowHeight);
 			TITANIUM_PROPERTY_UNIMPLEMENTED(rowHeight);
 			TITANIUM_PROPERTY_UNIMPLEMENTED(separatorColor);
-			TITANIUM_PROPERTY_UNIMPLEMENTED(borderColor);
-			TITANIUM_PROPERTY_UNIMPLEMENTED(borderWidth);
-			TITANIUM_PROPERTY_UNIMPLEMENTED(borderRadius);
 
 			TableView(const JSContext&) TITANIUM_NOEXCEPT;
 			virtual ~TableView()                  = default;
@@ -96,6 +93,7 @@ namespace TitaniumWindows
 			void setTableHeader();
 			void setTableFooter();
 
+			Windows::UI::Xaml::Controls::Grid^ parent__;
 			Windows::UI::Xaml::Controls::ListView^ tableview__;
 			Windows::UI::Xaml::Data::CollectionViewSource^ collectionViewSource__;
 			Windows::Foundation::Collections::IObservableVector<::Platform::Object^>^ collectionViewItems__;

--- a/Source/UI/src/TableView.cpp
+++ b/Source/UI/src/TableView.cpp
@@ -54,6 +54,7 @@ namespace TitaniumWindows
 		{
 			Titanium::UI::TableView::postCallAsConstructor(js_context, arguments);
 
+			parent__ = ref new Controls::Grid();
 			tableview__ = ref new Controls::ListView();
 			collectionViewItems__ = ref new Vector<Platform::Object^>();
 
@@ -62,11 +63,15 @@ namespace TitaniumWindows
 			tableview__->IsItemClickEnabled = true;
 			tableview__->SelectionMode = Controls::ListViewSelectionMode::None;
 
+			parent__->Children->Append(tableview__);
+			parent__->SetColumn(tableview__, 0);
+			parent__->SetRow(tableview__, 0);
+
 			Titanium::UI::TableView::setLayoutDelegate<WindowsViewLayoutDelegate>();
 			layoutDelegate__->set_defaultWidth(Titanium::UI::LAYOUT::FILL);
 			layoutDelegate__->set_defaultHeight(Titanium::UI::LAYOUT::FILL);
 
-			getViewLayoutDelegate<WindowsViewLayoutDelegate>()->setComponent(tableview__);
+			getViewLayoutDelegate<WindowsViewLayoutDelegate>()->setComponent(parent__);
 		}
 
 		void TableView::JSExportInitialize() 


### PR DESCRIPTION
- Add a ``parent__`` for ``tableview__`` allowing ``borderRadius`` to work correctly

###### TEST CASE
```Javascript
var win = Ti.UI.createWindow({backgroundColor: 'red'}),
    tableView = Ti.UI.createTableView({
        backgroundColor: 'orange',
        borderWidth: 5,
        borderColor: 'yellow',
        borderRadius: 5,
        data: [{title: 'Apples'}, {title: 'Bananas'}, {title: 'Carrots'}, {title: 'Potatoes'}]
    });
win.add(tableView);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23329)