### PR TITLE
[TIMOB-23653] Retain opacity after animation

### DIFF
--- a/Examples/NMocha/src/Assets/ti.ui.view.test.js
+++ b/Examples/NMocha/src/Assets/ti.ui.view.test.js
@@ -347,6 +347,30 @@ describe('Titanium.UI.View', function () {
 		win.open();
 	});
 
+	it('animate (opacity)', function (finish) {
+		this.timeout(1e4);
+		var win = Ti.UI.createWindow(),
+		    img = Ti.UI.createImageView({
+		    	image: 'Logo.png',
+		    	opacity: 0.5
+		    }),
+		    animation = Ti.UI.createAnimation({
+		        opacity: 1,
+		        duration: 1000
+		    });
+		animation.addEventListener('complete', function () {
+		    setTimeout(function () {
+		        should(img.opacity).be.eql(1);
+		        win.close();
+		        finish();
+	        }, 500);
+        });
+
+		win.add(img);
+		img.animate(animation);
+		win.open();
+	});
+
 	// FIXME: Windows 10 Store app fails for this...need to figure out why.
 	((utilities.isWindows10() && utilities.isWindowsDesktop()) ? it.skip : it)('TIMOB-20598', function (finish) {
 		var win = Ti.UI.createWindow(),

--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -767,6 +767,11 @@ namespace TitaniumWindows
 					setLayoutProperty(Titanium::LayoutEngine::ValueName::Top, y);
 				}
 
+				const auto opacity = animation->get_opacity();
+				if (opacity) {
+					set_opacity(*opacity);
+				}
+
 				// Make sure to clear the StoryBoard because transform made by StoryBoard remains.
 				storyboard->Stop();
 


### PR DESCRIPTION
- Retain ``opacity`` after animation

###### TEST CASE
```Javascript
var win = Ti.UI.createWindow({backgroundColor: 'red'}),
    img = Ti.UI.createImageView({image: 'Logo.png', opacity: 0.1}),
    ani = Ti.UI.createAnimation({opacity: 1, duration: 3000});
win.add(img);
img.animate(ani);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23653)