### PR TITLE
[TIMOB-23658] Fix Ti.UI.Label.border* properties

### DIFF
--- a/Examples/NMocha/src/Assets/ti.ui.label.test.js
+++ b/Examples/NMocha/src/Assets/ti.ui.label.test.js
@@ -35,21 +35,21 @@ describe('Titanium.UI.Label', function () {
 		finish();
 	});
 
-    it("textid", function (finish) {
-        var label = Ti.UI.createLabel({
-            textid: "this is my key"
-        });
-        should(label.textid).be.a.String;
-        should(label.getTextid).be.a.Function;
-        should(label.textid).eql('this is my key');
-        should(label.getTextid()).eql('this is my key');
-        should(label.text).eql('this is my value');
-        label.textid = 'other text';
-        should(label.textid).eql('other text');
-        should(label.getTextid()).eql('other text');
-        should(label.text).eql('this is my value'); // should retain old value if can't find key
-        finish();
-    });
+	it("textid", function (finish) {
+		var label = Ti.UI.createLabel({
+			textid: "this is my key"
+		});
+		should(label.textid).be.a.String;
+		should(label.getTextid).be.a.Function;
+		should(label.textid).eql('this is my key');
+		should(label.getTextid()).eql('this is my key');
+		should(label.text).eql('this is my value');
+		label.textid = 'other text';
+		should(label.textid).eql('other text');
+		should(label.getTextid()).eql('other text');
+		should(label.text).eql('this is my value'); // should retain old value if can't find key
+		finish();
+	});
 
 	it('textAlign', function (finish) {
 		var label = Ti.UI.createLabel({
@@ -175,4 +175,24 @@ describe('Titanium.UI.Label', function () {
 		win.open();
 	});
 
+	it('border (without width/height)', function (finish) {
+		this.timeout(3000);
+		var win = Ti.UI.createWindow(),
+			label = Ti.UI.createLabel({
+				borderWidth: 5,
+				borderColor: 'yellow',
+				borderRadius: 5,
+				text: 'this is some text'
+			});
+		win.addEventListener('focus', function () {
+			setTimeout(function () {
+				should(label.size.width).be.greaterThan(0);
+				should(label.size.height).be.greaterThan(0);
+				win.close();
+				finish();
+			}, 1000);
+		});
+		win.add(label);
+		win.open();
+	});
 });

--- a/Source/UI/include/TitaniumWindows/UI/Label.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/Label.hpp
@@ -59,7 +59,7 @@ namespace TitaniumWindows
 			// Measure desired size based on current text.
 			void measureDesiredSize() TITANIUM_NOEXCEPT;
 
-			Windows::UI::Xaml::Controls::Grid^ parent__;
+			Windows::UI::Xaml::Controls::Border^ border__;
 			Windows::UI::Xaml::Controls::TextBlock^ label__;
 		};
 	} // namespace UI

--- a/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
@@ -523,6 +523,7 @@ namespace TitaniumWindows
 			bool is_height_size__{false};
 			bool is_panel__{false};
 			bool is_grid__{false};
+			bool is_border__{false};
 			bool is_control__{false};
 			bool is_scrollview__ { false };
 			bool is_button__{ false };

--- a/Source/UI/src/Label.cpp
+++ b/Source/UI/src/Label.cpp
@@ -40,8 +40,8 @@ namespace TitaniumWindows
 		{
 			Titanium::UI::Label::postCallAsConstructor(js_context, arguments);
 			
-			// Note: TextAlignment and VerticalAlignment does not work without parent Grid container!
-			parent__ = ref new Controls::Grid();
+			// Note: TextAlignment and VerticalAlignment does not work without parent container!
+			border__ = ref new Controls::Border();
 			label__ = ref new Windows::UI::Xaml::Controls::TextBlock();
 
 			Titanium::UI::Label::setLayoutDelegate<WindowsViewLayoutDelegate>();
@@ -58,9 +58,7 @@ namespace TitaniumWindows
 				label__->MaxHeight = current->Bounds.Height;
 			}
 
-			parent__->Children->Append(label__);
-			parent__->SetColumn(label__, 0);
-			parent__->SetRow(label__, 0);
+			border__->Child = label__;
 
 			const auto layout = getViewLayoutDelegate<WindowsViewLayoutDelegate>();
 
@@ -71,7 +69,7 @@ namespace TitaniumWindows
 
 			// Label handles its size
 			layout->useOwnSize();
-			layout->setComponent(parent__);
+			layout->setComponent(border__, nullptr, border__);
 		}
 
 		void Label::JSExportInitialize()
@@ -113,10 +111,10 @@ namespace TitaniumWindows
 			const auto layout = getViewLayoutDelegate<WindowsViewLayoutDelegate>();
 
 			if (layout->get_width().empty() || layout->get_right().empty()) {
-				parent__->Width = label__->DesiredSize.Width;
+				border__->Width = label__->DesiredSize.Width;
 			}
 			if (layout->get_height().empty() || layout->get_bottom().empty()) {
-				parent__->Height = label__->DesiredSize.Height;
+				border__->Height = label__->DesiredSize.Height;
 			}
 		}
 

--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -884,7 +884,7 @@ namespace TitaniumWindows
 		{
 			if (underlying_control__) {
 				underlying_control__->Background = brush;
-			} else if (is_grid__ && border__) {
+			} else if ((is_grid__ || is_border__) && border__) {
 				border__->Background = brush;
 			} else if (is_panel__) {
 				dynamic_cast<Panel^>(component__)->Background = brush;
@@ -1391,6 +1391,7 @@ namespace TitaniumWindows
 			is_control__ = dynamic_cast<Controls::Control^>(component__) != nullptr;
 			is_scrollview__ = dynamic_cast<Controls::ScrollViewer^>(component__) != nullptr;
 			is_grid__    = dynamic_cast<Controls::Grid^>(component__) != nullptr;
+			is_border__ = dynamic_cast<Controls::Border^>(component__) != nullptr;
 			is_button__  = dynamic_cast<Controls::Button^>(underlying_control__) != nullptr;
 
 			loaded_event__ = component__->Loaded += ref new RoutedEventHandler([this](Platform::Object^ sender, RoutedEventArgs^ e) {
@@ -1680,13 +1681,13 @@ namespace TitaniumWindows
 		{
 			bool needsLayout = false;
 
-			if (is_width_size__ && (is_grid__ || !is_panel__)) {
+			if (is_width_size__ && (is_grid__ || is_border__ || !is_panel__)) {
 				layout_node__->properties.width.value = rect.width;
 				layout_node__->properties.width.valueType = Titanium::LayoutEngine::Fixed;
 				needsLayout = isLoaded();
 			}
 
-			if (is_height_size__ && (is_grid__ || !is_panel__)) {
+			if (is_height_size__ && (is_grid__ || is_border__ || !is_panel__)) {
 				layout_node__->properties.height.value = rect.height;
 				layout_node__->properties.height.valueType = Titanium::LayoutEngine::Fixed;
 				needsLayout = isLoaded();


### PR DESCRIPTION
- ``Windows::UI::Xaml::Controls::Border^`` can be used as a parent for components, offering border controls over ``Windows::UI::Xaml::Controls::Grid^``
- Use ``Border`` as a parent for ``Label`` allowing ``Titanium.UI.Label.border*`` properties to function correctly

###### TEST CASE
```Javascript
var win = Ti.UI.createWindow({ backgroundColor: 'red' }),
    lbl = Ti.UI.createLabel({
        backgroundColor: 'orange',
        borderWidth: 5,
        borderColor: 'yellow',
        borderRadius: 5,
        text: 'TEST TEXT'
    });
win.add(lbl);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23658)