### PR TITLE
[TIMOB-23655] Implement Ti.Geolocation requestLocationPermissions() and hasLocationPermissions()

### DIFF
--- a/Source/Sensors/include/TitaniumWindows/Geolocation.hpp
+++ b/Source/Sensors/include/TitaniumWindows/Geolocation.hpp
@@ -28,12 +28,10 @@ namespace TitaniumWindows
 
 		TITANIUM_PROPERTY_UNIMPLEMENTED(activityType);
 		TITANIUM_PROPERTY_UNIMPLEMENTED(allowsBackgroundLocationUpdates);
-		TITANIUM_PROPERTY_UNIMPLEMENTED(locationServicesAuthorization);
 		TITANIUM_PROPERTY_UNIMPLEMENTED(pauseLocationUpdateAutomatically);
 		TITANIUM_PROPERTY_UNIMPLEMENTED(purpose);
 		TITANIUM_PROPERTY_UNIMPLEMENTED(showCalibration);
 		TITANIUM_PROPERTY_UNIMPLEMENTED(trackSignificantLocationChange);
-		TITANIUM_FUNCTION_UNIMPLEMENTED(requestLocationPermissions);
 
 		Geolocation(const JSContext&) TITANIUM_NOEXCEPT;
 		virtual ~Geolocation()                  = default;
@@ -53,6 +51,9 @@ namespace TitaniumWindows
 		virtual void getCurrentPosition(JSObject callback) TITANIUM_NOEXCEPT override;
 
 		virtual void enableEvent(const std::string& event_name) TITANIUM_NOEXCEPT override final;
+
+		virtual bool hasLocationPermissions(const Titanium::Geolocation::AUTHORIZATION& authorizationType) TITANIUM_NOEXCEPT override;
+		virtual void requestLocationPermissions(const Titanium::Geolocation::AUTHORIZATION& authorizationType, JSObject callback) TITANIUM_NOEXCEPT override;
 
 	protected:
 		void ensureLoadGeolocator();

--- a/Source/Sensors/src/Geolocation.cpp
+++ b/Source/Sensors/src/Geolocation.cpp
@@ -64,6 +64,56 @@ namespace TitaniumWindows
 		}
 	}
 
+	bool Geolocation::hasLocationPermissions(const Titanium::Geolocation::AUTHORIZATION& authorizationType) TITANIUM_NOEXCEPT
+	{
+		// authorizationType is ignored, like on Android and <iOS8
+		return locationServicesAuthorization__ == Titanium::Geolocation::AUTHORIZATION::AUTHORIZED;
+	}
+
+	void Geolocation::requestLocationPermissions(const Titanium::Geolocation::AUTHORIZATION& authorizationType, JSObject callback) TITANIUM_NOEXCEPT
+	{
+		const auto ctx = get_context();
+		JSObject response = ctx.CreateObject();
+#if defined(IS_WINDOWS_10)
+		TitaniumWindows::Utility::RunOnUIThread([this, &ctx, &response, callback]() {
+			concurrency::create_task(Geolocator::RequestAccessAsync()).then([this, &ctx, &response, callback](concurrency::task<GeolocationAccessStatus> task) {
+				try {
+					const auto status = task.get();
+					if (status == GeolocationAccessStatus::Denied) {
+						locationServicesAuthorization__ = Titanium::Geolocation::AUTHORIZATION::DENIED;
+						response.SetProperty("code", ctx.CreateNumber(-1));
+						response.SetProperty("error", ctx.CreateString("location DeviceCapability not set in tiapp.xml"));
+						response.SetProperty("success", ctx.CreateBoolean(false));
+					} else if (status == GeolocationAccessStatus::Allowed) {
+						locationServicesAuthorization__ = Titanium::Geolocation::AUTHORIZATION::AUTHORIZED;
+						response.SetProperty("code", ctx.CreateNumber(0));
+						response.SetProperty("error", ctx.CreateString());
+						response.SetProperty("success", ctx.CreateBoolean(true));
+					}
+				} catch (::Platform::Exception^ e) {
+					response.SetProperty("code", ctx.CreateNumber(e->HResult));
+					response.SetProperty("error", ctx.CreateString(TitaniumWindows::Utility::ConvertString(e->Message)));
+					response.SetProperty("success", ctx.CreateBoolean(false));
+				}
+			});
+		});
+#else
+		locationServicesAuthorization__ = get_locationServicesEnabled() ? Titanium::Geolocation::AUTHORIZATION::AUTHORIZED : Titanium::Geolocation::AUTHORIZATION::DENIED;
+		if (locationServicesAuthorization__ == Titanium::Geolocation::AUTHORIZATION::AUTHORIZED) {
+			response.SetProperty("code", ctx.CreateNumber(0));
+			response.SetProperty("error", ctx.CreateString());
+			response.SetProperty("success", ctx.CreateBoolean(true));
+		} else {
+			response.SetProperty("code", ctx.CreateNumber(-1));
+			response.SetProperty("error", ctx.CreateString("location DeviceCapability not set in tiapp.xml"));
+			response.SetProperty("success", ctx.CreateBoolean(false));
+		}
+#endif
+		auto cb = static_cast<JSObject>(callback);
+		TITANIUM_ASSERT(cb.IsFunction());
+		cb({ response }, get_object());
+	}
+
 	void Geolocation::enableEvent(const std::string& event_name) TITANIUM_NOEXCEPT
 	{
 		Titanium::GeolocationModule::enableEvent(event_name);

--- a/Source/TitaniumKit/include/Titanium/GeolocationModule.hpp
+++ b/Source/TitaniumKit/include/Titanium/GeolocationModule.hpp
@@ -185,6 +185,20 @@ namespace Titanium
 		*/
 		virtual void reverseGeocoder(const double& latitude, const double& longitude, JSObject callback) TITANIUM_NOEXCEPT;
 
+		/*!
+		  @method
+		  @abstract hasLocationPermissions
+		  @discussion Returns true if the app has location access.
+		*/
+		virtual bool hasLocationPermissions(const Geolocation::AUTHORIZATION& authorizationType) TITANIUM_NOEXCEPT;
+
+		/*!
+		  @method
+		  @abstract requestLocationPermissions
+		  @discussion Requests for location access.
+		*/
+		virtual void requestLocationPermissions(const Geolocation::AUTHORIZATION& authorizationType, JSObject callback) TITANIUM_NOEXCEPT;
+
 		GeolocationModule(const JSContext&) TITANIUM_NOEXCEPT;
 		virtual ~GeolocationModule() = default;
 		GeolocationModule(const GeolocationModule&) = default;
@@ -222,6 +236,8 @@ namespace Titanium
 		TITANIUM_FUNCTION_DEF(getLocationServicesAuthorization);
 		TITANIUM_FUNCTION_DEF(getLocationServicesEnabled);
 		TITANIUM_FUNCTION_DEF(getLastGeolocation);
+		TITANIUM_FUNCTION_DEF(hasLocationPermissions);
+		TITANIUM_FUNCTION_DEF(requestLocationPermissions);
 
 		protected:
 			Geolocation::ACCURACY accuracy__;

--- a/Source/TitaniumKit/src/GeolocationModule.cpp
+++ b/Source/TitaniumKit/src/GeolocationModule.cpp
@@ -348,6 +348,17 @@ namespace Titanium
 		context.JSEvaluateScript(reverseGeocoder_js, export_obj);
 	}
 
+	bool GeolocationModule::hasLocationPermissions(const Titanium::Geolocation::AUTHORIZATION& authorizationType) TITANIUM_NOEXCEPT
+	{
+		TITANIUM_LOG_WARN("GeolocationModule::hasLocationPermissions: Unimplemented");
+		return false;
+	}
+
+	void GeolocationModule::requestLocationPermissions(const Titanium::Geolocation::AUTHORIZATION& authorizationType, JSObject callback) TITANIUM_NOEXCEPT
+	{
+		TITANIUM_LOG_WARN("GeolocationModule::requestLocationPermissions: Unimplemented");
+	}
+
 	void GeolocationModule::JSExportInitialize()
 	{
 		JSExport<GeolocationModule>::SetClassVersion(1);
@@ -412,6 +423,9 @@ namespace Titanium
 
 		TITANIUM_ADD_FUNCTION(GeolocationModule, getLocationServicesEnabled);
 		TITANIUM_ADD_FUNCTION(GeolocationModule, getLastGeolocation);
+
+		TITANIUM_ADD_FUNCTION(GeolocationModule, hasLocationPermissions);
+		TITANIUM_ADD_FUNCTION(GeolocationModule, requestLocationPermissions);
 	}
 
 	TITANIUM_PROPERTY_GETTER(GeolocationModule, accuracy)
@@ -559,6 +573,31 @@ namespace Titanium
 			TITANIUM_ASSERT(_0.IsNumber());
 			const double latitude = static_cast<double>(_0);
 			reverseGeocoder(latitude, 0, get_context().CreateObject());
+		}
+		return get_context().CreateUndefined();
+	}
+
+	TITANIUM_FUNCTION(GeolocationModule, hasLocationPermissions)
+	{
+		if (arguments.size() >= 1) {
+			const auto _0 = arguments.at(0);
+			TITANIUM_ASSERT(_0.IsNumber());
+			const auto authorizationType = Titanium::Geolocation::Constants::to_AUTHORIZATION(static_cast<std::underlying_type<Geolocation::AUTHORIZATION>::type>(_0));
+			return get_context().CreateBoolean(hasLocationPermissions(authorizationType));
+		}
+		return get_context().CreateBoolean(false);
+	}
+
+	TITANIUM_FUNCTION(GeolocationModule, requestLocationPermissions)
+	{
+		if (arguments.size() >= 2) {
+			const auto _0 = arguments.at(0);
+			TITANIUM_ASSERT(_0.IsNumber());
+			const auto _1 = arguments.at(1);
+			TITANIUM_ASSERT(_1.IsObject());
+			const auto authorizationType = Titanium::Geolocation::Constants::to_AUTHORIZATION(static_cast<std::underlying_type<Geolocation::AUTHORIZATION>::type>(_0));
+			const auto callback = static_cast<JSObject>(_1);
+			requestLocationPermissions(authorizationType, callback);
 		}
 		return get_context().CreateUndefined();
 	}


### PR DESCRIPTION
- Implement ``requestLocationPermissions()`` and ``hasLocationPermissions`` for ``Titanium.Geolocation``

###### TEST CASE
```Javascript
var win = Ti.UI.createWindow({backgroundColor: 'purple'}),
    btn_a = Ti.UI.createButton({top: '33%', title:'hasLocationPermissions()'}),
    btn_b = Ti.UI.createButton({top: '66%', title:'requestLocationPermissions()'});

btn_a.addEventListener('click', function () {
    alert('hasLocationPermissions() : ' + Ti.Geolocation.hasLocationPermissions(null));
});
btn_b.addEventListener('click', function () {
    Ti.Geolocation.requestLocationPermissions(null, function (res) {
        alert(JSON.stringify(res, null, ' '));
    });
});

win.add(btn_a);
win.add(btn_b);
win.open();
```

##### NOTE: ``Location`` capability must be present in ``tiapp.xml``. Also, ``requestLocationPermissions()`` is unsupported on Windows 8.1

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23655)