### PR TITLE
[TIMOB-23656] Implement Ti.Media requestCameraPermissions() and hasCameraPermissions()

### DIFF
--- a/Source/Media/include/TitaniumWindows/Media.hpp
+++ b/Source/Media/include/TitaniumWindows/Media.hpp
@@ -150,6 +150,20 @@ namespace TitaniumWindows
 		*/
 		virtual void vibrate(std::vector<std::chrono::milliseconds> pattern) TITANIUM_NOEXCEPT override;
 
+		/*!
+		  @method
+		  @abstract hasCameraPermissions
+		  @discussion Returns true if the app has camera access.
+		*/
+		virtual bool hasCameraPermissions() TITANIUM_NOEXCEPT override;
+
+		/*!
+		  @method
+		  @abstract requestCameraPermissions
+		  @discussion Requests for camera access.
+		*/
+		virtual void requestCameraPermissions(JSValue callback) TITANIUM_NOEXCEPT override;
+
 		MediaModule(const JSContext&) TITANIUM_NOEXCEPT;
 
 		virtual ~MediaModule();

--- a/Source/TitaniumKit/include/Titanium/MediaModule.hpp
+++ b/Source/TitaniumKit/include/Titanium/MediaModule.hpp
@@ -275,6 +275,20 @@ namespace Titanium
 		*/
 		virtual void requestAuthorization(JSValue callback) TITANIUM_NOEXCEPT;
 
+		/*!
+		  @method
+		  @abstract hasCameraPermissions
+		  @discussion Returns true if the app has camera access.
+		*/
+		virtual bool hasCameraPermissions() TITANIUM_NOEXCEPT;
+
+		/*!
+		  @method
+		  @abstract requestCameraPermissions
+		  @discussion Requests for camera access.
+		*/
+		virtual void requestCameraPermissions(JSValue callback) TITANIUM_NOEXCEPT;
+
 		MediaModule(const JSContext&) TITANIUM_NOEXCEPT;
 		virtual ~MediaModule()                     = default;
 		MediaModule(const MediaModule&)            = default;
@@ -441,6 +455,8 @@ namespace Titanium
 		TITANIUM_FUNCTION_DEF(takeScreenshot);
 		TITANIUM_FUNCTION_DEF(vibrate);
 		TITANIUM_FUNCTION_DEF(requestAuthorization);
+		TITANIUM_FUNCTION_DEF(hasCameraPermissions);
+		TITANIUM_FUNCTION_DEF(requestCameraPermissions);
 		TITANIUM_FUNCTION_DEF(createAudioPlayer);
 		TITANIUM_FUNCTION_DEF(createAudioRecorder);
 		TITANIUM_FUNCTION_DEF(createSound);

--- a/Source/TitaniumKit/src/MediaModule.cpp
+++ b/Source/TitaniumKit/src/MediaModule.cpp
@@ -165,6 +165,17 @@ namespace Titanium
 		TITANIUM_LOG_WARN("MediaModule::requestAuthorization: Unimplemented");
 	}
 
+	bool MediaModule::hasCameraPermissions() TITANIUM_NOEXCEPT
+	{
+		TITANIUM_LOG_WARN("MediaModule::hasCameraPermissions: Unimplemented");
+		return false;
+	}
+
+	void MediaModule::requestCameraPermissions(JSValue callback) TITANIUM_NOEXCEPT
+	{
+		TITANIUM_LOG_WARN("MediaModule::requestCameraPermissions: Unimplemented");
+	}
+
 	void MediaModule::JSExportInitialize()
 	{
 		JSExport<MediaModule>::SetClassVersion(1);
@@ -325,6 +336,8 @@ namespace Titanium
 		TITANIUM_ADD_FUNCTION(MediaModule, takeScreenshot);
 		TITANIUM_ADD_FUNCTION(MediaModule, vibrate);
 		TITANIUM_ADD_FUNCTION(MediaModule, requestAuthorization);
+		TITANIUM_ADD_FUNCTION(MediaModule, hasCameraPermissions);
+		TITANIUM_ADD_FUNCTION(MediaModule, requestCameraPermissions);
 		TITANIUM_ADD_FUNCTION(MediaModule, createAudioPlayer);
 		TITANIUM_ADD_FUNCTION(MediaModule, createAudioRecorder);
 		TITANIUM_ADD_FUNCTION(MediaModule, createSound);
@@ -1241,6 +1254,18 @@ namespace Titanium
 	{
 		ENSURE_OBJECT_AT_INDEX(callback, 0);
 		requestAuthorization(callback);
+		return get_context().CreateUndefined();
+	}
+
+	TITANIUM_FUNCTION(MediaModule, hasCameraPermissions)
+	{
+		return get_context().CreateBoolean(hasCameraPermissions());
+	}
+
+	TITANIUM_FUNCTION(MediaModule, requestCameraPermissions)
+	{
+		ENSURE_OBJECT_AT_INDEX(callback, 0);
+		requestCameraPermissions(callback);
 		return get_context().CreateUndefined();
 	}
 


### PR DESCRIPTION
- Implement ``requestCameraPermissions()`` and ``hasCameraPermissions`` for ``Titanium.Media``

###### TEST CASE
```Javascript
var win = Ti.UI.createWindow({backgroundColor: 'purple'}),
    btn_a = Ti.UI.createButton({top: '33%', title:'hasCameraPermissions()'}),
    btn_b = Ti.UI.createButton({top: '66%', title:'requestCameraPermissions()'});

btn_a.addEventListener('click', function () {
    alert('hasCameraPermissions() : ' + Ti.Media.hasCameraPermissions());
});
btn_b.addEventListener('click', function () {
    Ti.Media.requestCameraPermissions(function (res) {
        alert(JSON.stringify(res, null, ' '));
    });
});

win.add(btn_a);
win.add(btn_b);
win.open();
```

##### NOTES
- ``webcam`` capability must be present in ``tiapp.xml``
- ``requestLocationPermissions()`` is unsupported on both Windows 8.1 and 10

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23656)