### PR TITLE
[TIMOB-23678] Fix Ti.Network.HTTPClient.send() concurrency

### DIFF
--- a/Source/TitaniumKit/include/Titanium/Network/HTTPClient.hpp
+++ b/Source/TitaniumKit/include/Titanium/Network/HTTPClient.hpp
@@ -19,11 +19,11 @@ namespace Titanium
 	namespace Network
 	{
 		enum class RequestState {
-			Loading,
-			Opened,
-			Done,
 			Unsent,
-			Headers_Received
+			Opened,
+			Headers_Received,
+			Loading,
+			Done
 		};
 
 		enum class RequestMethod {


### PR DESCRIPTION
- Fixed ``RequestState`` enum order
- ``Titanium.Network.HTTPClient.send()`` is now fully asynchronous

###### TEST CASE
```Javascript
var win = Ti.UI.createWindow(),
    btn = Ti.UI.createButton({
        title: 'HTTP GET'
    });

btn.addEventListener('click', function () {
    var request = Ti.Network.createHTTPClient({
            onload: function () {
                alert('onload:\n\treadyState: ' + request.readyState);
            },
            onerror: function (e) {
                alert('onerror:\n\treadyState: ' + request.readyState + '\n\terror: ' + e.error);
            }
        }),
        timeout = new Date().getTime() + 5000,
        host = 'http://www.google.com/',
        done = false;

    request.cache = false;
    request.open('GET', host);
    request.send();

    while (!done) {
        if (request.readyState === 4 || request.status === 404) {
            done = true;
            alert('success');
        } else if ((timeout - (new Date()).getTime()) <= 0) {
            done = true;
            alert('failed');
        }
    }
});

win.add(btn);
win.open();
```
```
onload:
    readyState: 4
```
```
success
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23678)