### PR TITLE
[TIMOB-23696] Fix Ti.App._restart() functionality

### DIFF
--- a/Source/Ti/include/TitaniumWindows/AppModule.hpp
+++ b/Source/Ti/include/TitaniumWindows/AppModule.hpp
@@ -55,8 +55,6 @@ namespace TitaniumWindows
 		virtual void setProximityDetection(const bool&) TITANIUM_NOEXCEPT override;
 		virtual bool proximityState() const TITANIUM_NOEXCEPT override;
 
-		virtual void _restart() TITANIUM_NOEXCEPT override;
-
 	private:
 
 		static JSObject RectToJS(const JSContext& js_context, const Windows::Foundation::Rect& rect);

--- a/Source/Ti/src/AppModule.cpp
+++ b/Source/Ti/src/AppModule.cpp
@@ -154,9 +154,4 @@ namespace TitaniumWindows
 		return keyboardVisible__;
 	}
 
-	void AppModule::_restart() TITANIUM_NOEXCEPT
-	{
-		Windows::ApplicationModel::Core::CoreApplication::Exit();
-	}
-
 }  // namespace TitaniumWindows

--- a/Source/TitaniumKit/src/App.cpp
+++ b/Source/TitaniumKit/src/App.cpp
@@ -257,7 +257,7 @@ namespace Titanium
 
 	void AppModule::_restart() TITANIUM_NOEXCEPT
 	{
-		TITANIUM_LOG_WARN("AppModule::_restart: Unimplemented");
+		get_context().JSEvaluateScript("eval(Ti.Filesystem.getFile('app.js').read().text)");
 	}
 
 	AppModule& AppModule::PropertiesClass(const JSClass& Properties) TITANIUM_NOEXCEPT


### PR DESCRIPTION
- Remove `_restart()` from `TitaniumWindows_Ti`
- Implement `Ti.App._restart()` in `TitaniumKit`

###### TEST CASE
```Javascript
var win = Ti.UI.createWindow({ backgroundColor: 'blue' }),
	btn = Ti.UI.createButton({ title: 'Ti.App._restart()' });

setTimeout(function () {
    win.backgroundColor = 'red';
}, 2000);

btn.addEventListener('click', function () {
    Ti.App._restart();
});

win.add(btn);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23696)