### PR TITLE
[TIMOB-23696] Fix Ti.App._restart() functionality

### DIFF
--- a/Source/Ti/include/TitaniumWindows/AppModule.hpp
+++ b/Source/Ti/include/TitaniumWindows/AppModule.hpp
@@ -55,8 +55,6 @@ namespace TitaniumWindows
 		virtual void setProximityDetection(const bool&) TITANIUM_NOEXCEPT override;
 		virtual bool proximityState() const TITANIUM_NOEXCEPT override;
 
-		virtual void _restart() TITANIUM_NOEXCEPT override;
-
 	private:
 
 		static JSObject RectToJS(const JSContext& js_context, const Windows::Foundation::Rect& rect);

--- a/Source/Ti/src/AppModule.cpp
+++ b/Source/Ti/src/AppModule.cpp
@@ -154,9 +154,4 @@ namespace TitaniumWindows
 		return keyboardVisible__;
 	}
 
-	void AppModule::_restart() TITANIUM_NOEXCEPT
-	{
-		Windows::ApplicationModel::Core::CoreApplication::Exit();
-	}
-
 }  // namespace TitaniumWindows

--- a/Source/TitaniumKit/include/Titanium/GlobalObject.hpp
+++ b/Source/TitaniumKit/include/Titanium/GlobalObject.hpp
@@ -85,7 +85,7 @@ namespace Titanium
 
 		  @result Exported exports object of the required module (Object).
 		*/
-		virtual JSValue requireModule(const JSObject& parent, const std::string& moduleId) final;
+		virtual JSValue requireModule(const JSObject& parent, const std::string& moduleId, const bool& reload = false) final;
 
 		/*!
 		  @method

--- a/Source/TitaniumKit/include/Titanium/Module.hpp
+++ b/Source/TitaniumKit/include/Titanium/Module.hpp
@@ -164,6 +164,19 @@ namespace Titanium
 		TITANIUM_FUNCTION_DEF(applyProperties);
 		TITANIUM_FUNCTION_DEF(fireEvent);
 
+		/*
+		* Stop firing all events, especially used when module is closed/hidden.
+		*/
+		virtual void disableEvents() TITANIUM_NOEXCEPT
+		{
+			enableEvents__ = false;
+		}
+
+		virtual void enableEvents() TITANIUM_NOEXCEPT
+		{
+			enableEvents__ = true;
+		}
+
 	protected:
 		/*!
 		  @method
@@ -192,19 +205,6 @@ namespace Titanium
 		  @result void
 		*/
 		virtual void disableEvent(const std::string& event_name) TITANIUM_NOEXCEPT;
-
-		/*
-		 * Stop firing all events, especially used when module is closed/hidden.
-		 */
-		virtual void disableEvents() TITANIUM_NOEXCEPT
-		{
-			enableEvents__ = false;
-		}
-
-		virtual void enableEvents() TITANIUM_NOEXCEPT
-		{
-			enableEvents__ = true;
-		}
 
 		template<typename T>
 		std::shared_ptr<T> get_shared_ptr_for_module()

--- a/Source/TitaniumKit/include/Titanium/UI/Window.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/Window.hpp
@@ -264,6 +264,8 @@ namespace Titanium
 
 			static void JSExportInitialize();
 
+			static void Restart() TITANIUM_NOEXCEPT;
+
 			TITANIUM_FUNCTION_DEF(close);
 			TITANIUM_FUNCTION_DEF(open);
 
@@ -328,6 +330,8 @@ namespace Titanium
 // need to be exported from a DLL.
 #pragma warning(push)
 #pragma warning(disable : 4251)
+			static std::vector<std::shared_ptr<Window>> window_stack__;
+			static bool restarting__;
 			std::string barColor__;
 			bool exitOnClose__;
 			std::unordered_set<EXTEND_EDGE> extendEdges__;
@@ -342,7 +346,6 @@ namespace Titanium
 			std::string title__;
 			std::string titleid__;
 			bool translucent__;
-
 			JSObject openWindowParams_ctor__;
 			JSObject closeWindowParams_ctor__;
 

--- a/Source/TitaniumKit/src/App.cpp
+++ b/Source/TitaniumKit/src/App.cpp
@@ -9,6 +9,8 @@
 #include "Titanium/detail/TiImpl.hpp"
 #include "Titanium/App.hpp"
 #include "Titanium/App/Properties.hpp"
+#include "Titanium/UI/Window.hpp"
+#include "Titanium/GlobalObject.hpp"
 
 namespace Titanium
 {
@@ -257,7 +259,10 @@ namespace Titanium
 
 	void AppModule::_restart() TITANIUM_NOEXCEPT
 	{
-		TITANIUM_LOG_WARN("AppModule::_restart: Unimplemented");
+		Titanium::UI::Window::Restart();
+		const auto globalObject = get_context().get_global_object();
+		const auto globalObject_ptr = globalObject.GetPrivate<Titanium::GlobalObject>();
+		globalObject_ptr->requireModule(globalObject, "/app", true);
 	}
 
 	AppModule& AppModule::PropertiesClass(const JSClass& Properties) TITANIUM_NOEXCEPT

--- a/Source/TitaniumKit/src/GlobalObject.cpp
+++ b/Source/TitaniumKit/src/GlobalObject.cpp
@@ -262,7 +262,7 @@ namespace Titanium
 		return js_context.CreateUndefined();
 	}
 
-	JSValue GlobalObject::requireModule(const JSObject& parent, const std::string& moduleId)
+	JSValue GlobalObject::requireModule(const JSObject& parent, const std::string& moduleId, const bool& reload)
 	{
 		TITANIUM_GLOBALOBJECT_LOCK_GUARD;
 		const auto js_context = parent.get_context();
@@ -293,7 +293,7 @@ namespace Titanium
 		}
 
 		// check if we have already loaded the module
-		if (module_cache__.find(module_path) != module_cache__.end()) {
+		if (!reload && module_cache__.find(module_path) != module_cache__.end()) {
 			return module_cache__.at(module_path);
 		}
 

--- a/Source/TitaniumKit/src/UI/Window.cpp
+++ b/Source/TitaniumKit/src/UI/Window.cpp
@@ -26,6 +26,10 @@ namespace Titanium
 {
 	namespace UI
 	{
+
+		std::vector<std::shared_ptr<Window>> Window::window_stack__;
+		bool Window::restarting__(false);
+
 		Window::Window(const JSContext& js_context) TITANIUM_NOEXCEPT
 		    : View(js_context, "Ti.UI.Window"),
 		      openWindowParams_ctor__(js_context.CreateObject(JSExport<Titanium::UI::OpenWindowParams>::Class())),
@@ -51,6 +55,17 @@ namespace Titanium
 		Window::~Window() TITANIUM_NOEXCEPT
 		{
 			TITANIUM_LOG_DEBUG("Window:: dtor ", this);
+		}
+
+		void Window::Restart() TITANIUM_NOEXCEPT
+		{
+			restarting__ = true;
+			while (!window_stack__.empty()) {
+				auto window = window_stack__.at(0);
+				window->disableEvents();
+				window->close(nullptr);
+			}
+			restarting__ = false;
 		}
 
 		void Window::close(const std::shared_ptr<CloseWindowParams>& params) TITANIUM_NOEXCEPT

--- a/Source/UI/include/TitaniumWindows/UI/Window.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/Window.hpp
@@ -105,7 +105,6 @@ namespace TitaniumWindows
 #pragma warning(push)
 #pragma warning(disable : 4251)
 			Windows::UI::Xaml::Controls::Canvas^ canvas__;
-			static std::vector<std::shared_ptr<Window>> window_stack__;
 			std::shared_ptr<TitaniumWindows::UI::WindowsXaml::CommandBar> bottomAppBar__;
 			Windows::Foundation::EventRegistrationToken backpressed_event__;
 			bool is_tabgroup_container__ { false };


### PR DESCRIPTION
Take over #794

- Remove `_restart()` from `TitaniumWindows_Ti`
- Implement `Ti.App._restart()` in `TitaniumKit`

Note: This implementation is simple, but good enough for now I think.
This does not actually reset all application state but

- Close all existing `Window` but do not exit the app
- After all `Window` is closed, then reload the app using `require('app')`

###### TEST CASE
```Javascript
var win = Ti.UI.createWindow({ backgroundColor: 'blue' }),
	btn = Ti.UI.createButton({ title: 'Ti.App._restart()' });

setTimeout(function () {
    win.backgroundColor = 'red';
}, 2000);

btn.addEventListener('click', function () {
    Ti.App._restart();
});

win.add(btn);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23696)