### PR TITLE
[TIMOB-23686][TIMOB-23687] Fix default camera, implement CameraOptionsType.whichCamera

### DIFF
--- a/Source/Media/include/TitaniumWindows/Media.hpp
+++ b/Source/Media/include/TitaniumWindows/Media.hpp
@@ -203,6 +203,7 @@ namespace TitaniumWindows
 #if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 		void updatePreviewOrientation();
 #endif
+		void findCameraDevices();
 		Windows::Storage::FileProperties::PhotoOrientation toPhotoOrientation();
 		std::uint32_t orientationToDegrees();
 
@@ -216,6 +217,7 @@ namespace TitaniumWindows
 		Titanium::Media::PhotoGalleryOptionsType openPhotoGalleryOptionsState__;
 		Titanium::Media::MusicLibraryOptionsType openMusicLibraryOptionsState__;
 		JSFunction js_beep__;
+		Windows::Devices::Enumeration::DeviceInformationCollection^ cameraDevices__{ nullptr };
 #if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 		Titanium::Media::CameraOptionsTypeCallbacks cameraCallbacks__;
 		std::shared_ptr<Titanium::UI::View> cameraOverlay__;

--- a/Source/TitaniumKit/include/Titanium/Media/CameraOptionsType.hpp
+++ b/Source/TitaniumKit/include/Titanium/Media/CameraOptionsType.hpp
@@ -61,6 +61,7 @@ namespace Titanium
 			std::shared_ptr<Titanium::UI::TwoDMatrix> transform;
 			std::chrono::milliseconds videoMaximumDuration;
 			Quality videoQuality;
+			CameraOption whichCamera;
 			CameraOptionsTypeCallbacks callbacks;
 		};
 		

--- a/Source/TitaniumKit/src/Media/CameraOptionsType.cpp
+++ b/Source/TitaniumKit/src/Media/CameraOptionsType.cpp
@@ -51,6 +51,15 @@ namespace Titanium
 			
 			const auto js_transform = object.GetProperty("transform");
 			ENSURE_MODULE_OBJECT(js_transform, transform, Titanium::UI::TwoDMatrix)
+
+			const auto js_whichCamera = object.GetProperty("whichCamera");
+			auto whichCamera = CameraOption::NotDetermined;
+			if (!js_whichCamera.IsUndefined()) {
+				const auto value = static_cast<CameraOption>(static_cast<uint32_t>(js_whichCamera));
+				if (value == CameraOption::Front || value == CameraOption::Rear) {
+					whichCamera = value;
+				}
+			}
 			
 			const auto success_property = object.GetProperty("success");
 			const auto onsuccess = [success_property](const CameraMediaItemType& item) {
@@ -113,6 +122,7 @@ namespace Titanium
 				transform,
 				std::chrono::milliseconds::min(),
 				Quality::High,
+				whichCamera,
 				callbacks
 			};
 			
@@ -157,6 +167,7 @@ namespace Titanium
 			object.SetProperty("showControls", js_context.CreateBoolean(config.showControls));
 			object.SetProperty("success", config.callbacks.success);
 			object.SetProperty("videoMaximumDuration", js_context.CreateNumber(static_cast<double>(config.videoMaximumDuration.count())));
+			object.SetProperty("whichCamera", js_context.CreateNumber(static_cast<std::uint32_t>(config.whichCamera)));
 			object.SetProperty("videoQuality", js_context.CreateNumber(static_cast<std::uint32_t>(config.videoQuality)));
 			return object;
 		}


### PR DESCRIPTION
- Always use default camera of the device or rear camera if a default is not specified
- Implemented ``CameraOptionsType.whichCamera`` to specify either front or rear camera to use

###### TEST CASE
```Javascript
var win = Ti.UI.createWindow({backgroundColor: 'green', layout: 'vertical'}),
    imageView = Ti.UI.createImageView({width: Ti.UI.FILL, height: '70%'});

Ti.Media.showCamera({
    whichCamera: Titanium.Media.CAMERA_FRONT, // Titanium.Media.CAMERA_REAR
    mediaTypes: [Ti.Media.MEDIA_TYPE_PHOTO],
    overlay: Ti.UI.createView(), // dont use Windows capture UI
    success: function (e) {
        imageView.image = e.media;
    },
    error: function (e) {
        alert('showCamera() error: ' + JSON.stringify(e));
    }
});

win.add(imageView);
win.open();
```

[TIMOB-23687](https://jira.appcelerator.org/browse/TIMOB-23687)
[TIMOB-23686](https://jira.appcelerator.org/browse/TIMOB-23686)