### PR TITLE
Attempt to fix Win10 Jenkins build

### DIFF
--- a/Tools/Scripts/setup.js
+++ b/Tools/Scripts/setup.js
@@ -234,14 +234,15 @@ function downloadIfNecessary(envKey, defaultDest, expectedDir, url, next) {
 			// What if it _does_ exist and is out of date? We should "wipe it", or move it...
 			if (fs.existsSync(destination)) {
 				var urlFile = path.join(destination, 'SOURCE_URL');
-				var contents = fs.readFileSync(urlFile);
-				var base = path.basename(contents.slice(7), '.zip');
-				var byURL = path.normalize(path.join(destination, '..', base));
-				console.log('Destination for ' + url + ' already exists, moving existing directory to ' + byURL + ' before extracting.');
-				if (!fs.existsSync(byURL)) {
-					wrench.copyDirSyncRecursive(destination, byURL);
+				if (fs.existsSync(urlFile)) {
+					var contents = fs.readFileSync(urlFile);
+					var base = path.basename(contents.slice(7), '.zip');
+					var byURL = path.normalize(path.join(destination, '..', base));
+					console.log('Destination for ' + url + ' already exists, moving existing directory to ' + byURL + ' before extracting.');
+					if (!fs.existsSync(byURL)) {
+						wrench.copyDirSyncRecursive(destination, byURL);
+					}
 				}
-
 				wrench.rmdirSyncRecursive(destination);
 			}
 			// Extract to parent of destination...


### PR DESCRIPTION
Make sure to check if `SOURCE_FILE` exists before reading its contents.

```
21:02:24 C:\Jenkins\workspace\titanium_mobile_windows_10_prs\Tools\Scripts>call npm install . 
21:02:26 npm WARN package.json windowssdksetup@0.0.1 license should be a valid SPDX license expression
21:02:26 Installing JSC built for Windows 10
21:02:26 Setting up Boost libraries...
21:02:26 [32mâˆš BOOST_ROOT set[39m
21:02:26 Setting up GTest...
21:02:26 [32mâˆš GTEST_ROOT set[39m
21:02:26 Setting up JavaScriptCore pre-built libraries...
21:02:26 Downloading [36mhttp://timobile.appcelerator.com.s3.amazonaws.com/jscore/JavaScriptCore-Windows-1469754731-win10.zip[39m
21:02:54 fs.js:549
21:02:54   return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
21:02:54                  ^
21:02:54 
21:02:54 Error: ENOENT: no such file or directory, open 'C:\Users\tester\JavaScriptCore\SOURCE_URL'
21:02:54     at Error (native)
21:02:54     at Object.fs.openSync (fs.js:549:18)
21:02:54     at Object.fs.readFileSync (fs.js:397:15)
21:02:54     at C:\Jenkins\workspace\titanium_mobile_windows_10_prs\Tools\Scripts\setup.js:237:23
21:02:54     at WriteStream.<anonymous> (C:\Jenkins\workspace\titanium_mobile_windows_10_prs\Tools\Scripts\setup.js:100:5)
21:02:54     at emitNone (events.js:72:20)
21:02:54     at WriteStream.emit (events.js:166:7)
21:02:54     at fs.js:1772:14
21:02:54     at FSReqWrap.oncomplete (fs.js:82:15)
```