### PR TITLE
[TIMOB-23717] Execute Ti.UI.ImageView.toImage() only after an image has loaded

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/ImageView.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/ImageView.hpp
@@ -109,6 +109,8 @@ namespace TitaniumWindows
 			Windows::UI::Xaml::Controls::Image^ image__{ nullptr };
 			Windows::UI::Xaml::Media::Animation::Storyboard^ storyboard__;
 			bool sizeChanged__{ true };
+			bool imageOpened__{ false };
+			std::vector<JSObject> to_image_queue__;
 
 #pragma warning(pop)
 		};

--- a/Source/UI/src/ImageView.cpp
+++ b/Source/UI/src/ImageView.cpp
@@ -97,6 +97,15 @@ namespace TitaniumWindows
 					this->image__->ActualHeight
 					);
 				layout->onComponentSizeChange(rect);
+
+				// image loaded, empty toImage queue
+				if (!imageOpened__) {
+					imageOpened__ = true;
+					for (auto callback : to_image_queue__) {
+						toImage(callback, false);
+					}
+					to_image_queue__.clear();
+				}
 			});
 
 			Titanium::UI::ImageView::setLayoutDelegate<WindowsImageViewLayoutDelegate>(image__);
@@ -410,6 +419,10 @@ namespace TitaniumWindows
 
 		std::shared_ptr<Titanium::Blob> ImageView::toImage(JSObject& callback, const bool& honorScaleFactor) TITANIUM_NOEXCEPT
 		{
+			if (!imageOpened__) {
+				to_image_queue__.push_back(callback);
+				return nullptr;
+			}
 			return getViewLayoutDelegate()->toImage(callback, honorScaleFactor, get_object());
 		}
 	} // namespace UI


### PR DESCRIPTION
- Queue up `toImage` calls before an image is loaded
- Currently the windows `toImage` method only supports retrieving a `Blob` from the callback

```Javascript
var win = Ti.UI.createWindow({backgroundColor: 'purple'}),
    img = Ti.UI.createImageView({image: 'Logo.png'});
 
img.toImage(function (blob) {
    Ti.API.info('success');
});
 
win.add(img);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23717)