### PR TITLE
[TIMOB-23723] Top and bottom, left and right should not override a set width and height

### DIFF
--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -1564,7 +1564,8 @@ namespace TitaniumWindows
 			}
 
 			if (!skipWidth && ((!is_panel__ && setWidthOnWidget) || setWidth)) {
-				if (layout_node__->properties.left.valueType != Titanium::LayoutEngine::None &&
+				if (get_width().empty() &&
+					layout_node__->properties.left.valueType != Titanium::LayoutEngine::None &&
 					layout_node__->properties.right.valueType != Titanium::LayoutEngine::None &&
 					component->ActualWidth == rect.width) {
 					rect.width = oldRect__.width;
@@ -1573,7 +1574,8 @@ namespace TitaniumWindows
 			}
 
 			if (!skipHeight && ((!is_panel__ && setHeightOnWidget) || setHeight)) {
-				if (layout_node__->properties.top.valueType != Titanium::LayoutEngine::None &&
+				if (get_height().empty() &&
+					layout_node__->properties.top.valueType != Titanium::LayoutEngine::None &&
 					layout_node__->properties.bottom.valueType != Titanium::LayoutEngine::None &&
 					component->ActualHeight == rect.height) {
 					rect.height = oldRect__.height;


### PR DESCRIPTION
- When `top`, `bottom` and `height` or `left`, `right` and `width` are set. The `height` or `width` should have priority

###### TEST CASE
```Javascript
var win = Ti.UI.createWindow({backgroundColor: 'purple'}),
    img = Ti.UI.createImageView({
        image: 'Logo.png',
        backgroundColor: 'red',
        left: 0,
        top: 0,
        bottom: 0,
        width: Ti.UI.SIZE,
        height: Ti.UI.SIZE
    });
win.add(img);
win.open();
```
```
Image should be visible
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23723)