### PR TITLE
DO NOT MERGE: Ti.Network.HTTPClient TEST

### DIFF
--- a/Source/TitaniumKit/include/Titanium/Network/HTTPClient.hpp
+++ b/Source/TitaniumKit/include/Titanium/Network/HTTPClient.hpp
@@ -255,7 +255,7 @@ namespace Titanium
 
 			HTTPClient(const JSContext&) TITANIUM_NOEXCEPT;
 
-			virtual ~HTTPClient() = default;
+			virtual ~HTTPClient();
 			HTTPClient(const HTTPClient&) = default;
 			HTTPClient& operator=(const HTTPClient&) = default;
 #ifdef TITANIUM_MOVE_CTOR_AND_ASSIGN_DEFAULT_ENABLE

--- a/Source/TitaniumKit/src/Network/HTTPClient.cpp
+++ b/Source/TitaniumKit/src/Network/HTTPClient.cpp
@@ -31,6 +31,15 @@ namespace Titanium
 			setHTTPStatusPhrase();
 		}
 
+		HTTPClient::~HTTPClient()
+		{
+			onload__ = get_context().CreateNull();
+			onerror__ = get_context().CreateNull();
+			ondatastream__ = get_context().CreateNull();
+			onsendstream__ = get_context().CreateNull();
+			onreadystatechange__ = get_context().CreateNull();
+		}
+
 		TITANIUM_PROPERTY_READWRITE(HTTPClient, std::chrono::milliseconds, timeout)
 		TITANIUM_PROPERTY_READWRITE(HTTPClient, std::string, file)
 		TITANIUM_PROPERTY_READWRITE(HTTPClient, std::string, username)


### PR DESCRIPTION
_DO NOT MERGE_

I'm not sure following test should really work, because `onload` callback could be called _after_ HTTPClient (`xhr`) is garbage collected in this case. (And it actually does.) I think HTTPClient callbacks should not be called after HTTPClient is garbage collected because it does not make sense.

```javascript
it('responseXML', function (finish) {
	this.timeout(6e4);

	var xhr = Ti.Network.createHTTPClient();
	xhr.setTimeout(6e4);

	xhr.onload = function (e) {
		should(xhr.responseXML === null).be.false;
		should(xhr.responseXML.nodeType).eql(9); // DOCUMENT_NODE
		finish();
	};
	xhr.onerror = function (e) {
		Ti.API.debug(e);
		finish(new Error('failed to retrieve RSS feed: ' + e));
	};

	xhr.open('GET', 'http://www.appcelerator.com/feed');
	xhr.send();
});
```