### PR TITLE
[TIMOB-23734] Fix ListSection events index when without a header

### DIFF
--- a/Source/UI/src/ListView.cpp
+++ b/Source/UI/src/ListView.cpp
@@ -241,7 +241,7 @@ namespace TitaniumWindows
 				}
 			} else if (name == "update" || name == "replace") {
 				// "update" and "replace" are basically same, it removes existing content and insert new one
-				std::uint32_t index = itemIndex + 1; // +1 because index=0 is header
+				std::uint32_t index = section->hasHeader() ? itemIndex + 1 : itemIndex;
 				for (std::uint32_t i = index; i < index + affectedRows; i++) {
 					views->RemoveAt(index);
 					unregisterListViewItemAsLayoutNode(section->getViewForSectionItem(i - 1));
@@ -253,7 +253,7 @@ namespace TitaniumWindows
 					section->setViewForSectionItem(i, view);
 				}
 			} else if (name == "delete") {
-				const std::uint32_t index = itemIndex + 1; // +1 because index=0 is header
+				const std::uint32_t index = section->hasHeader() ? itemIndex + 1 : itemIndex;
 				TITANIUM_ASSERT(views->Size > index);
 				for (std::uint32_t i = index; i < index + itemCount; i++) {
 					views->RemoveAt(index);
@@ -269,7 +269,9 @@ namespace TitaniumWindows
 					// clear section view except header view
 					const auto header = views->GetAt(0);
 					views->Clear();
-					views->Append(header);
+					if (section->hasHeader()) {
+						views->Append(header);
+					}
 				} else {
 					views->Clear();
 				}


### PR DESCRIPTION
- Fix `fireListSectionEvent()` index calculation when `ListSection` has no header

###### TEST CASE
```Javascript
var win = Ti.UI.createWindow({ backgroundColor: 'blue' }),
    section = Ti.UI.createListSection({
        items: [
            { properties: { title: '0: A' } },
            { properties: { title: '1: A' } },
            { properties: { title: '2: C' } },
            { properties: { title: '3: D' } }
        ]
    }),
    listView = Ti.UI.createListView({ sections: [section] });

listView.addEventListener('click', function (e) {
    section.updateItemAt(1, { properties: { title: '1: B' } });
});

win.add(listView);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23734)