### PR TITLE
[TIMOB-23678] Fix Ti.Network.HTTPClient.send() concurrency

### DIFF
--- a/Source/TitaniumKit/include/Titanium/Network/HTTPClient.hpp
+++ b/Source/TitaniumKit/include/Titanium/Network/HTTPClient.hpp
@@ -19,11 +19,11 @@ namespace Titanium
 	namespace Network
 	{
 		enum class RequestState {
-			Loading,
-			Opened,
-			Done,
 			Unsent,
-			Headers_Received
+			Opened,
+			Headers_Received,
+			Loading,
+			Done
 		};
 
 		enum class RequestMethod {


### PR DESCRIPTION
#791 + Workaround for Windows 10 desktop. We've been seeing intermittent crash on Windows 10 desktop with async HTTPClient.