### PR TITLE
[TIMOB-23734] Fix ListView fireListSectionEvent()

### DIFF
--- a/Examples/NMocha/src/Assets/ti.ui.listview.test.js
+++ b/Examples/NMocha/src/Assets/ti.ui.listview.test.js
@@ -515,4 +515,89 @@ describe('Titanium.UI.ListView', function () {
 		win.open();
 	});
 
+	it('fireListSectionEvent', function (finish) {
+		var section = Ti.UI.createListSection({
+		        items: [
+		            { properties: { title: 'B' } },
+		            { properties: { title: 'A' } },
+		            { properties: { title: 'E' } },
+		            { properties: { title: 'G' } }
+		        ]
+		    }),
+		    listView = Ti.UI.createListView({ sections: [section] }),
+		    items_a = [
+		        { properties: { title: 'A' } },
+		    ],
+		    items_b = [
+		        { properties: { title: 'C' } },
+		        { properties: { title: 'D' } }
+		    ],
+		    items_c = [
+		        { properties: { title: 'E' } },
+		        { properties: { title: 'F' } },
+		    ],
+		    validation = ['A', 'B', 'C', 'D', 'E', 'F'];
+
+		section.updateItemAt(0, { properties: { title: 'A' } });
+		section.updateItemAt(1, { properties: { title: 'B' } });
+		section.updateItemAt(3, { properties: { title: 'F' } });
+		section.insertItemsAt(2, items_b);
+		section.deleteItemsAt(0, 1);
+		section.deleteItemsAt(3, 2);
+		section.appendItems(items_c);
+		section.insertItemsAt(0, items_a);
+
+		var items = section.getItems();
+		should(items.length).be.eql(6);
+		for (var i = 0; i < items.length; i++) {
+		    var item = items[i].properties.title;
+		    should(item).be.eql(validation[i]);
+		}
+
+		finish();
+	});
+
+	it('fireListSectionEvent (header and footer)', function (finish) {
+		var section = Ti.UI.createListSection({
+				headerTitle: 'HEADER',
+        		footerTitle: 'FOOTER',
+		        items: [
+		            { properties: { title: 'B' } },
+		            { properties: { title: 'A' } },
+		            { properties: { title: 'E' } },
+		            { properties: { title: 'G' } }
+		        ]
+		    }),
+		    listView = Ti.UI.createListView({ sections: [section] }),
+		    items_a = [
+		        { properties: { title: 'A' } },
+		    ],
+		    items_b = [
+		        { properties: { title: 'C' } },
+		        { properties: { title: 'D' } }
+		    ],
+		    items_c = [
+		        { properties: { title: 'E' } },
+		        { properties: { title: 'F' } },
+		    ],
+		    validation = ['A', 'B', 'C', 'D', 'E', 'F'];
+
+		section.updateItemAt(0, { properties: { title: 'A' } });
+		section.updateItemAt(1, { properties: { title: 'B' } });
+		section.updateItemAt(3, { properties: { title: 'F' } });
+		section.insertItemsAt(2, items_b);
+		section.deleteItemsAt(0, 1);
+		section.deleteItemsAt(3, 2);
+		section.appendItems(items_c);
+		section.insertItemsAt(0, items_a);
+
+		var items = section.getItems();
+		should(items.length).be.eql(6);
+		for (var i = 0; i < items.length; i++) {
+		    var item = items[i].properties.title;
+		    should(item).be.eql(validation[i]);
+		}
+
+		finish();
+	});
 });

--- a/Source/TitaniumKit/src/UI/ListSection.cpp
+++ b/Source/TitaniumKit/src/UI/ListSection.cpp
@@ -139,8 +139,8 @@ namespace Titanium
 		void ListSection::deleteItemsAt(const std::uint32_t& index, const std::uint32_t& count, const std::shared_ptr<ListViewAnimationProperties>& animation) TITANIUM_NOEXCEPT
 		{
 			TITANIUM_ASSERT(items__.size() >= index + count);
-			items__.erase (items__.begin() + index, items__.begin() + index + count);
 			fireListSectionEvent("delete", index, count, count);
+			items__.erase (items__.begin() + index, items__.begin() + index + count);
 		}
 
 		ListDataItem ListSection::getItemAt(const std::uint32_t& index) TITANIUM_NOEXCEPT

--- a/Source/UI/src/ListView.cpp
+++ b/Source/UI/src/ListView.cpp
@@ -233,19 +233,27 @@ namespace TitaniumWindows
 			
 			TITANIUM_ASSERT(views);
 
+			std::uint32_t index = section->hasHeader() ? itemIndex + 1 : itemIndex;
 			if (name == "append") {
 				for (std::uint32_t i = itemIndex; i < itemIndex + itemCount; i++) {
 					const auto view = createSectionItemViewAt<TitaniumWindows::UI::View>(sectionIndex, i);
+					UIElement^ footer = nullptr;
+					if (section->hasFooter()) {
+						footer = views->GetAt(views->Size-1);
+						views->RemoveAtEnd();
+					}
 					appendListViewItemForSection(view, views);
+					if (footer) {
+						views->Append(footer);
+					}
 					section->setViewForSectionItem(i, view);
 				}
 			} else if (name == "update" || name == "replace") {
 				// "update" and "replace" are basically same, it removes existing content and insert new one
-				std::uint32_t index = section->hasHeader() ? itemIndex + 1 : itemIndex;
-				for (std::uint32_t i = index; i < index + affectedRows; i++) {
+				for (std::uint32_t i = itemIndex; i < itemIndex + affectedRows; i++) {
 					views->RemoveAt(index);
-					unregisterListViewItemAsLayoutNode(section->getViewForSectionItem(i - 1));
-					section->setViewForSectionItem(i - 1, nullptr);
+					unregisterListViewItemAsLayoutNode(section->getViewForSectionItem(i));
+					section->setViewForSectionItem(i, nullptr);
 				}
 				for (std::uint32_t i = itemIndex; i < itemIndex + itemCount; i++) {
 					const auto view = createSectionItemViewAt<TitaniumWindows::UI::View>(sectionIndex, i);
@@ -253,12 +261,11 @@ namespace TitaniumWindows
 					section->setViewForSectionItem(i, view);
 				}
 			} else if (name == "delete") {
-				const std::uint32_t index = section->hasHeader() ? itemIndex + 1 : itemIndex;
 				TITANIUM_ASSERT(views->Size > index);
-				for (std::uint32_t i = index; i < index + itemCount; i++) {
+				for (std::uint32_t i = itemIndex; i < itemIndex + itemCount; i++) {
 					views->RemoveAt(index);
-					unregisterListViewItemAsLayoutNode(section->getViewForSectionItem(i - 1));
-					section->setViewForSectionItem(i - 1, nullptr);
+					unregisterListViewItemAsLayoutNode(section->getViewForSectionItem(i));
+					section->setViewForSectionItem(i, nullptr);
 				}
 			} else if (name == "clear") {
 				for (std::uint32_t i = itemIndex; i < itemIndex + itemCount; i++) {
@@ -278,7 +285,7 @@ namespace TitaniumWindows
 			} else if (name == "insert") {
 				for (std::uint32_t i = itemIndex; i < itemIndex + itemCount; i++) {
 					const auto view = createSectionItemViewAt<TitaniumWindows::UI::View>(sectionIndex, i);
-					insertListViewItemForSection(view, views, i);
+					insertListViewItemForSection(view, views, index++);
 					section->setViewForSectionItem(i, view);
 				}
 			}


### PR DESCRIPTION
- Fixed `fireListSectionEvent()` handling of `ListView` item indexes
- Fixed `Titanium.ListSection.deleteItemsAt()` erasing items before unregistering the layout node
- Added test cases to test all events of `fireListSectionEvent()` with and without a header and footer

###### TEST CASE
```Javascript
var win = Ti.UI.createWindow({ backgroundColor: 'blue' }),
    section = Ti.UI.createListSection({
        //headerTitle: 'HEADER',
        //footerTitle: 'FOOTER',
        items: [
            { properties: { title: 'B' } },
            { properties: { title: 'A' } },
            { properties: { title: 'E' } },
            { properties: { title: 'G' } }
        ]
    }),
    listView = Ti.UI.createListView({ sections: [section] }),
    items_a = [
        { properties: { title: 'A' } },
    ],
    items_b = [
        { properties: { title: 'C' } },
        { properties: { title: 'D' } }
    ],
    items_c = [
        { properties: { title: 'E' } },
        { properties: { title: 'F' } },
    ];

listView.addEventListener('click', function (e) {
    section.updateItemAt(0, { properties: { title: 'A' } });
    section.updateItemAt(1, { properties: { title: 'B' } });
    section.updateItemAt(3, { properties: { title: 'F' } });
    section.insertItemsAt(2, items_b);
    section.deleteItemsAt(0, 1);
    section.deleteItemsAt(3, 2);
    section.appendItems(items_c);
    section.insertItemsAt(0, items_a);
});

win.add(listView);
win.open();
```
```
A
B
C
D
E
F
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23734)