### PR TITLE
[TIMOB-23683] Select appropriate wp-sdk for platform when targeting ws-local

### DIFF
--- a/cli/commands/_build/config/target.js
+++ b/cli/commands/_build/config/target.js
@@ -26,6 +26,18 @@ module.exports = function configOptionTarget(order) {
 			if (value === 'dist-phonestore' || value === 'dist-winstore') {
 				this.conf.options['output-dir'].required = true;
 			}
+
+			// targeting ws-local without SDK specified, select most appropriate for platform
+			if (value === 'ws-local' && this.cli.argv.$_.indexOf('--wp-sdk') === -1 && this.cli.argv.$_.indexOf('-S') === -1) {
+				var sdk = '10.0',
+					os = require('os').release();
+
+				// not on Windows 10, default to 8.1 sdk
+				if (!os.startsWith('10.0')) {
+					sdk = '8.1';
+				}
+				this.cli.argv['wp-sdk'] = sdk;
+			}
 		}.bind(this),
 		default: this.defaultTarget,
 		desc: __('the target to build for'),


### PR DESCRIPTION
- Default to `10.0` otherwise default to `8.1` if not on Windows 10

###### TEST CASE
```
appc run -p windows -T wp-local
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23683)