### PR TITLE
Investigate Jenkins ListSection.getItems() loop issue

### DIFF
--- a/Examples/NMocha/src/Assets/ti.ui.listview.test.js
+++ b/Examples/NMocha/src/Assets/ti.ui.listview.test.js
@@ -600,4 +600,29 @@ describe('Titanium.UI.ListView', function () {
 
 		finish();
 	});
+
+	it('getItems() loop issue', function (finish) {
+		var section = Ti.UI.createListSection({
+		        items: [
+		            {properties: {title: 'A'}},
+		            {properties: {title: 'B'}},
+		            {properties: {title: 'C'}},
+		            {properties: {title: 'D'}},
+		            {properties: {title: 'E'}},
+		            {properties: {title: 'F'}}
+		        ]
+		    }),
+		    listView = Ti.UI.createListView({sections: [section]});
+
+		var items = section.getItems();
+		should(items.length).be.eql(6);
+		Ti.API.info('items: ' + JSON.stringify(items, null, ' '));
+		for (var i in items) {
+			Ti.API.info('items['+i+']: ' + JSON.stringify(item, null, ' '));
+			var item = items[i].properties.title;
+		    should(item).not.be.undefined;
+		}
+
+		finish();
+	});
 });


### PR DESCRIPTION
- Using `for (var i in items)` iterates through more items than are in the array on Windows 10 Desktop and Windows 8.1 Desktop
- This is a test to see if the issue can be reproduced