### PR TITLE
[TIMOB-23760] --wp-sdk option should handle actual Windows SDK versions

### DIFF
--- a/Examples/NG/CMakeLists.txt
+++ b/Examples/NG/CMakeLists.txt
@@ -5,7 +5,7 @@
 # Please see the LICENSE included with this distribution for details.
 cmake_minimum_required(VERSION 3.0.0)
 
-if (${CMAKE_SYSTEM_VERSION} STREQUAL "10.0")
+if (${CMAKE_SYSTEM_VERSION} MATCHES "^10.0")
   set(PLATFORM win10)
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsPhone")
   set(PLATFORM wp)

--- a/Examples/NMocha/CMakeLists.txt
+++ b/Examples/NMocha/CMakeLists.txt
@@ -3,7 +3,7 @@
 # Please see the LICENSE included with this distribution for details.
 cmake_minimum_required(VERSION 3.0.0)
 
-if (${CMAKE_SYSTEM_VERSION} STREQUAL "10.0")
+if (${CMAKE_SYSTEM_VERSION} MATCHES "^10.0")
   set(PLATFORM win10)
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsPhone")
   set(PLATFORM wp)

--- a/cli/commands/_build/config/deviceID.js
+++ b/cli/commands/_build/config/deviceID.js
@@ -26,8 +26,8 @@ module.exports = function configOptionDeviceID(order) {
 		if (((cli.argv.target === 'wp-emulator' && value === 'xd') ||
 			 (cli.argv.target === 'wp-device' && value === 'de')) && devices[0]) {
 
-			// use wpsdk for device
-			if (devices[0].wpsdk) {
+			// if wp-sdk is not specified, use wpsdk for device
+			if (devices[0].wpsdk && this.cli.argv.$_.indexOf('--wp-sdk') === -1 && this.cli.argv.$_.indexOf('-S') === -1) {
 				cli.argv['wp-sdk'] = devices[0].wpsdk;
 			}
 			return callback(null, devices[0].udid);
@@ -46,8 +46,8 @@ module.exports = function configOptionDeviceID(order) {
 			return callback(new Error(__('Invalid device id "%s"', value)));
 		}
 
-		// use wpsdk specified for device
-		if (dev.wpsdk) {
+		// if wp-sdk is not specified, use wpsdk specified for device
+		if (dev.wpsdk && this.cli.argv.$_.indexOf('--wp-sdk') === -1 && this.cli.argv.$_.indexOf('-S') === -1) {
 			cli.argv['wp-sdk'] = dev.wpsdk;
 		}
 

--- a/cli/commands/_build/config/wpSDK.js
+++ b/cli/commands/_build/config/wpSDK.js
@@ -25,13 +25,24 @@ module.exports = function configOptionWPSDK(order) {
 		}
 	}
 
+	sdkTargets = sdkTargets.concat(this.windowsInfo.windowsphone[version].sdks);
+
+	function isWindows10(wpsdk) {
+		return (wpsdk && wpsdk.startsWith && wpsdk.startsWith('10.0'));
+	}
+
 	return {
 		abbr: 'S',
 		callback: function (value) {
+			// target various Windows 10.0.X SDKs
+			if (value.startsWith('10.0.')) {
+				this.targetPlatformSdkVersion = value;
+				this.cli.argv['wp-sdk'] = '10.0';
+			}
 			// We can use built-in temp key for local/emulator builds. For dist,
 			// insist on user/generated PFX when app requires one
 			if (this.conf.options['target'] == 'dist-winstore' ||
-				(value == '10.0' && this.conf.options['target'] == 'dist-phonestore')) {
+				(isWindows10(value) && this.conf.options['target'] == 'dist-phonestore')) {
 				this.conf.options['ws-cert'].required = true;
 			}
 		}.bind(this),

--- a/cli/commands/_build/generate.js
+++ b/cli/commands/_build/generate.js
@@ -222,6 +222,14 @@ function generateCmakeList(next) {
 		}
 	}
 
+	this.targetPlatformSdkVersion   = this.targetPlatformSdkVersion || this.tiapp.windows['TargetPlatformVersion'] || this.wpsdk;
+	this.targetPlatformSdkMinVersion = this.targetPlatformSdkMinVersion || this.tiapp.windows['TargetPlatformMinVersion'] || this.targetPlatformSdkVersion;
+
+	// '10.0' is not valid for MinVersion because it requires build number
+	if (this.targetPlatformSdkMinVersion.match(/^[0-9]{1,2}\.[0-9]$/)) {
+		this.targetPlatformSdkMinVersion = '';
+	}
+
 	this.cli.createHook('build.windows.writeCMakeLists', this, function (manifest, cb) {
 		fs.existsSync(this.buildDir) || wrench.mkdirSyncRecursive(this.buildDir)
 
@@ -250,7 +258,8 @@ function generateCmakeList(next) {
 			phoneProductId: this.phoneProductId,
 			sourceGroups: sourceGroups,
 			i18nVSResources: this.i18nVSResources,
-			native_modules: native_modules
+			native_modules: native_modules,
+			targetPlatformSdkMinVersion: this.targetPlatformSdkMinVersion
 		}
 	), next);
 };

--- a/cli/commands/_build/run.js
+++ b/cli/commands/_build/run.js
@@ -89,6 +89,13 @@ function runCmake(next) {
 		generatorName += ' ARM';
 	}
 
+	this.logger.debug(this.cmake + ' ' +
+		JSON.stringify([
+			'-G', generatorName,
+			'-DCMAKE_SYSTEM_NAME=' + this.cmakePlatform,
+			'-DCMAKE_SYSTEM_VERSION=' + this.targetPlatformSdkVersion,
+			this.buildDir
+		], null, 2));
 	fs.existsSync(this.cmakeTargetDir) || wrench.mkdirSyncRecursive(this.cmakeTargetDir);
 	// Use spawn directly so we can pipe output as we go
 	var cmake = this.cmake;
@@ -96,7 +103,7 @@ function runCmake(next) {
 		[
 			'-G', generatorName,
 			'-DCMAKE_SYSTEM_NAME=' + this.cmakePlatform,
-			'-DCMAKE_SYSTEM_VERSION=' + this.wpsdk,
+			'-DCMAKE_SYSTEM_VERSION=' + this.targetPlatformSdkVersion,
 			this.buildDir
 		],
 		{

--- a/templates/build/CMakeLists.txt.ejs
+++ b/templates/build/CMakeLists.txt.ejs
@@ -3,7 +3,7 @@
 # Please see the LICENSE included with this distribution for details.
 cmake_minimum_required(VERSION 3.0.0)
 
-if (${CMAKE_SYSTEM_VERSION} STREQUAL "10.0")
+if (${CMAKE_SYSTEM_VERSION} MATCHES "^10.0")
   set(PLATFORM win10)
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsPhone")
   set(PLATFORM phone)
@@ -169,6 +169,12 @@ target_include_directories(${EXE_NAME} PUBLIC
   ${<%= native_modules[i].projectname %>_INCLUDE_DIRS}
 <% } -%>
 )
+
+<% if (targetPlatformSdkMinVersion) { -%>
+set_property(TARGET ${EXE_NAME}
+  PROPERTY VS_WINDOWS_TARGET_PLATFORM_MIN_VERSION
+  "<%= targetPlatformSdkMinVersion %>")
+<% } -%>
 
 set_property(TARGET ${EXE_NAME}
   PROPERTY VS_WINRT_REFERENCES

--- a/templates/build/Native/CMakeLists.txt.ejs
+++ b/templates/build/Native/CMakeLists.txt.ejs
@@ -5,7 +5,7 @@
 # Please see the LICENSE included with this distribution for details.
 cmake_minimum_required(VERSION 3.0.0)
 
-if (${CMAKE_SYSTEM_VERSION} STREQUAL "10.0")
+if (${CMAKE_SYSTEM_VERSION} MATCHES "^10.0")
   set(PLATFORM win10)
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsPhone")
   set(PLATFORM phone)

--- a/templates/build/cmake/FindHAL.cmake
+++ b/templates/build/cmake/FindHAL.cmake
@@ -48,7 +48,7 @@ unset(_targetsDefined)
 unset(_targetsNotDefined)
 unset(_expectedTargets)
 
-if (${CMAKE_SYSTEM_VERSION} STREQUAL "10.0")
+if (${CMAKE_SYSTEM_VERSION} MATCHES "^10.0")
   set(PLATFORM win10)
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsPhone")
   set(PLATFORM phone)

--- a/templates/build/cmake/FindLayoutEngine.cmake
+++ b/templates/build/cmake/FindLayoutEngine.cmake
@@ -48,7 +48,7 @@ unset(_expectedTargets)
 
 # Create imported target LayoutEngine
 
-if (${CMAKE_SYSTEM_VERSION} STREQUAL "10.0")
+if (${CMAKE_SYSTEM_VERSION} MATCHES "^10.0")
   set(PLATFORM win10)
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsPhone")
   set(PLATFORM phone)

--- a/templates/build/cmake/FindNativeModule.cmake.ejs
+++ b/templates/build/cmake/FindNativeModule.cmake.ejs
@@ -8,7 +8,7 @@
 # Author: <%= module.manifest.author %>
 # Created: <%= new Date().toDateString() %>
 
-if (${CMAKE_SYSTEM_VERSION} STREQUAL "10.0")
+if (${CMAKE_SYSTEM_VERSION} MATCHES "^10.0")
   set(PLATFORM win10)
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsPhone")
   set(PLATFORM phone)

--- a/templates/build/cmake/FindTitaniumKit.cmake
+++ b/templates/build/cmake/FindTitaniumKit.cmake
@@ -48,7 +48,7 @@ unset(_targetsNotDefined)
 unset(_expectedTargets)
 
 
-if (${CMAKE_SYSTEM_VERSION} STREQUAL "10.0")
+if (${CMAKE_SYSTEM_VERSION} MATCHES "^10.0")
   set(PLATFORM win10)
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsPhone")
   set(PLATFORM phone)

--- a/templates/build/cmake/FindTitaniumWindows.cmake
+++ b/templates/build/cmake/FindTitaniumWindows.cmake
@@ -8,7 +8,7 @@
 # Author: Chris Williams
 # Created: 2014.12.02
 
-if (${CMAKE_SYSTEM_VERSION} STREQUAL "10.0")
+if (${CMAKE_SYSTEM_VERSION} MATCHES "^10.0")
   set(PLATFORM win10)
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsPhone")
   set(PLATFORM phone)

--- a/templates/build/cmake/FindTitaniumWindows_Filesystem.cmake
+++ b/templates/build/cmake/FindTitaniumWindows_Filesystem.cmake
@@ -8,7 +8,7 @@
 # Author: Chris Williams
 # Created: 2014.12.02
 
-if (${CMAKE_SYSTEM_VERSION} STREQUAL "10.0")
+if (${CMAKE_SYSTEM_VERSION} MATCHES "^10.0")
   set(PLATFORM win10)
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsPhone")
   set(PLATFORM phone)

--- a/templates/build/cmake/FindTitaniumWindows_Global.cmake
+++ b/templates/build/cmake/FindTitaniumWindows_Global.cmake
@@ -8,7 +8,7 @@
 # Author: Chris Williams
 # Created: 2014.12.02
 
-if (${CMAKE_SYSTEM_VERSION} STREQUAL "10.0")
+if (${CMAKE_SYSTEM_VERSION} MATCHES "^10.0")
   set(PLATFORM win10)
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsPhone")
   set(PLATFORM phone)

--- a/templates/build/cmake/FindTitaniumWindows_Map.cmake
+++ b/templates/build/cmake/FindTitaniumWindows_Map.cmake
@@ -8,7 +8,7 @@
 # Author: Chris Williams
 # Created: 2014.12.02
 
-if (${CMAKE_SYSTEM_VERSION} STREQUAL "10.0")
+if (${CMAKE_SYSTEM_VERSION} MATCHES "^10.0")
   set(PLATFORM win10)
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsPhone")
   set(PLATFORM phone)

--- a/templates/build/cmake/FindTitaniumWindows_Media.cmake
+++ b/templates/build/cmake/FindTitaniumWindows_Media.cmake
@@ -8,7 +8,7 @@
 # Author: Chris Williams
 # Created: 2014.12.02
 
-if (${CMAKE_SYSTEM_VERSION} STREQUAL "10.0")
+if (${CMAKE_SYSTEM_VERSION} MATCHES "^10.0")
   set(PLATFORM win10)
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsPhone")
   set(PLATFORM phone)

--- a/templates/build/cmake/FindTitaniumWindows_Network.cmake
+++ b/templates/build/cmake/FindTitaniumWindows_Network.cmake
@@ -8,7 +8,7 @@
 # Author: Chris Williams
 # Created: 2014.12.02
 
-if (${CMAKE_SYSTEM_VERSION} STREQUAL "10.0")
+if (${CMAKE_SYSTEM_VERSION} MATCHES "^10.0")
   set(PLATFORM win10)
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsPhone")
   set(PLATFORM phone)

--- a/templates/build/cmake/FindTitaniumWindows_Sensors.cmake
+++ b/templates/build/cmake/FindTitaniumWindows_Sensors.cmake
@@ -8,7 +8,7 @@
 # Author: Chris Williams
 # Created: 2014.12.02
 
-if (${CMAKE_SYSTEM_VERSION} STREQUAL "10.0")
+if (${CMAKE_SYSTEM_VERSION} MATCHES "^10.0")
   set(PLATFORM win10)
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsPhone")
   set(PLATFORM phone)

--- a/templates/build/cmake/FindTitaniumWindows_Ti.cmake
+++ b/templates/build/cmake/FindTitaniumWindows_Ti.cmake
@@ -8,7 +8,7 @@
 # Author: Chris William
 # Created: 2014.12.02
 
-if (${CMAKE_SYSTEM_VERSION} STREQUAL "10.0")
+if (${CMAKE_SYSTEM_VERSION} MATCHES "^10.0")
   set(PLATFORM win10)
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsPhone")
   set(PLATFORM phone)

--- a/templates/build/cmake/FindTitaniumWindows_UI.cmake
+++ b/templates/build/cmake/FindTitaniumWindows_UI.cmake
@@ -8,7 +8,7 @@
 # Author: Chris Williams
 # Created: 2014.12.02
 
-if (${CMAKE_SYSTEM_VERSION} STREQUAL "10.0")
+if (${CMAKE_SYSTEM_VERSION} MATCHES "^10.0")
   set(PLATFORM win10)
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsPhone")
   set(PLATFORM phone)

--- a/templates/build/cmake/FindTitaniumWindows_Utility.cmake
+++ b/templates/build/cmake/FindTitaniumWindows_Utility.cmake
@@ -8,7 +8,7 @@
 # Author: Chris Williams
 # Created: 2014.12.02
 
-if (${CMAKE_SYSTEM_VERSION} STREQUAL "10.0")
+if (${CMAKE_SYSTEM_VERSION} MATCHES "^10.0")
   set(PLATFORM win10)
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsPhone")
   set(PLATFORM phone)


### PR DESCRIPTION
Note: ~~This needs [windowslib 0.4.17](https://github.com/appcelerator/windowslib/pull/52) merged for [titanium_mobile](https://github.com/appcelerator/titanium_mobile)~~ -> *Merged*.

[TIMOB-23760](https://jira.appcelerator.org/browse/TIMOB-23760)
[TIMOB-23758](https://jira.appcelerator.org/browse/TIMOB-23758)
[TIMOB-23759](https://jira.appcelerator.org/browse/TIMOB-23759)

```
appc run -p windows --wp-sdk 10.0.10586.0 --target wp-device -l trace
```