### PR TITLE
[TIMOB-23759] Add ability to set Windows 10 TargetPlatformVersion

### DIFF
--- a/cli/commands/_build/config/wpSDK.js
+++ b/cli/commands/_build/config/wpSDK.js
@@ -18,6 +18,7 @@ module.exports = function configOptionWPSDK(order) {
 		for (var version in this.windowsInfo.windowsphone) {
 			if (unsupportedTargets.indexOf(version) === -1) {
 				sdkTargets.push(version);
+				sdkTargets = sdkTargets.concat(this.windowsInfo.windowsphone[version].sdks);
 			}
 			if (this.windowsInfo.windowsphone[version].selected) {
 				defaultTarget = version;
@@ -28,6 +29,11 @@ module.exports = function configOptionWPSDK(order) {
 	return {
 		abbr: 'S',
 		callback: function (value) {
+			// target various Windows 10.0.X SDKs
+			if (value.startsWith('10.0.')) {
+				this.targetSdk = value;
+				this.cli.argv['wp-sdk'] = '10.0';
+			}
 			// We can use built-in temp key for local/emulator builds. For dist,
 			// insist on user/generated PFX when app requires one
 			if (this.conf.options['target'] == 'dist-winstore' ||

--- a/cli/commands/_build/run.js
+++ b/cli/commands/_build/run.js
@@ -54,6 +54,7 @@ function run(logger, config, cli, finished) {
 		'generateCmakeList',
 		'runCmake',
 		'addI18nVSResources',
+		'setTargetPlatformVersion',
 		'compileApp',
 		'writeBuildManifest',
 		'copyResultsToProject',


### PR DESCRIPTION
- Implement ability to set `TargetPlatformVersion` and `TargetPlatformMinVersion` from `tiapp.xml`
- Ability to select a target SDK with `--wp-sdk`

###### tiapp.xml
```
...
<windows>
    ...
    <TargetPlatformVersion>10.0.10586.0</TargetPlatformVersion>
    <TargetPlatformMinVersion>10.0.10240.0</TargetPlatformMinVersion>
    ...
</windows>
...
```
```
appc run -p windows -T wp-device -S 10.0.10586.0 --build-only
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23759)