### PR TITLE
[TIMOB-23370] Log target Windows SDK

### DIFF
--- a/cli/commands/_build/compile.js
+++ b/cli/commands/_build/compile.js
@@ -31,6 +31,7 @@ function compileApp(next) {
 		vcxproj = path.resolve(this.cmakeTargetDir, cmakeProjectName + '.vcxproj'),
 		nativeVcxProj = path.resolve(this.cmakeTargetDir, 'Native', 'TitaniumWindows_Native.vcxproj');
 
+	this.logger.info(__('Targeting Windows SDK: %s', this.targetPlatformSdkVersion.cyan || this.wpsdk.cyan));
 	this.logger.info(__('Running MSBuild on solution: %s', slnFile.cyan));
 
 	// Modify the vcxproj to inject some properties, so we always bundle


### PR DESCRIPTION
- Provide a clear indication of the Windows SDK being used to build the project

###### TEST CASE
```
appc run -p windows -S 10.0 -- build-only
```
```
[INFO]  Targeting Windows SDK: 10.0
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23370)