### PR TITLE
[TIMOB-23776] Avoid use of 'focus' event on mocha

### DIFF
--- a/Examples/NMocha/src/Assets/ti.blob.test.js
+++ b/Examples/NMocha/src/Assets/ti.blob.test.js
@@ -24,7 +24,7 @@ describe('Titanium.Blob', function () {
 		var window = Ti.UI.createWindow();
 		var label = Ti.UI.createLabel({ text: 'test' });
 		window.add(label);
-		window.addEventListener('focus', function () {
+		window.addEventListener('open', function () {
 			var blob = label.toImage(function (blob) {
 				should(blob).be.an.Object;
 				should(blob).be.an.instanceof(Ti.Blob);

--- a/Examples/NMocha/src/Assets/ti.geolocation.test.js
+++ b/Examples/NMocha/src/Assets/ti.geolocation.test.js
@@ -156,7 +156,7 @@ describe('Titanium.Geolocation', function () {
 		finish();
 	});
 
-	it('forwardGeocoder', function (finish) {
+	(utilities.isWindowsDesktop() ? it.skip : it)('forwardGeocoder', function (finish) {
 		this.timeout(6e4);
 		should(Ti.Geolocation.forwardGeocoder).be.a.Function;
 		Ti.Geolocation.forwardGeocoder('440 N Bernardo Ave, Mountain View', function (data) {
@@ -174,7 +174,7 @@ describe('Titanium.Geolocation', function () {
 		});
 	});
 
-	it('reverseGeocoder', function (finish) {
+	(utilities.isWindowsDesktop() ? it.skip : it)('reverseGeocoder', function (finish) {
 		this.timeout(6e4);
 		should(Ti.Geolocation.reverseGeocoder).be.a.Function;
 		Ti.Geolocation.reverseGeocoder(37.3883645, -122.0512682, function (data) {

--- a/Examples/NMocha/src/Assets/ti.network.httpclient.test.js
+++ b/Examples/NMocha/src/Assets/ti.network.httpclient.test.js
@@ -52,7 +52,7 @@ describe('Titanium.Network.HTTPClient', function () {
 		finish();
 	});
 
-	(utilities.isWindows10Desktop() ? it.skip : it)('downloadLargeFile', function (finish) {
+	(utilities.isWindowsDesktop() ? it.skip : it)('downloadLargeFile', function (finish) {
 		this.timeout(6e4);
 
 		var xhr = Ti.Network.createHTTPClient();
@@ -121,7 +121,7 @@ describe('Titanium.Network.HTTPClient', function () {
 
 	// https://appcelerator.lighthouseapp.com/projects/32238/tickets/2156-android-invalid-redirect-alert-on-xhr-file-download
 	// https://appcelerator.lighthouseapp.com/projects/32238/tickets/1381-android-buffer-large-xhr-downloads
-	(utilities.isWindows10Desktop() ? it.skip : it)('largeFileWithRedirect', function (finish) {
+	(utilities.isWindowsDesktop() ? it.skip : it)('largeFileWithRedirect', function (finish) {
 		this.timeout(6e4);
 
 		var xhr = Ti.Network.createHTTPClient();

--- a/Examples/NMocha/src/Assets/ti.ui.button.test.js
+++ b/Examples/NMocha/src/Assets/ti.ui.button.test.js
@@ -58,9 +58,7 @@ describe('Titanium.UI.Button', function () {
 		});
 		var view = Ti.UI.createButton({ title: 'push button' });
 		w.add(view);
-		w.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
+		w.addEventListener('open', function () {
 			view.image = 'Logo.png';
 			should(view.image).be.eql('Logo.png');
 			setTimeout(function () {
@@ -79,9 +77,7 @@ describe('Titanium.UI.Button', function () {
 		});
 		var view = Ti.UI.createButton({ title: 'push button' });
 		w.add(view);
-		w.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
+		w.addEventListener('open', function () {
 			view.image = Ti.Filesystem.getFile('Logo.png').read();
 			should(view.image).be.an.Object;
 			setTimeout(function () {
@@ -99,9 +95,7 @@ describe('Titanium.UI.Button', function () {
 		});
 		var view = Ti.UI.createButton({ title: 'push button' });
 		w.add(view);
-		w.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
+		w.addEventListener('open', function () {
 			should(view.backgroundColor).be.a.String;
 			should(view.backgroundImage).be.a.String;
 			view.backgroundColor = 'white';
@@ -123,9 +117,7 @@ describe('Titanium.UI.Button', function () {
 		});
 		var view = Ti.UI.createButton({ title: 'push button' });
 		w.add(view);
-		w.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
+		w.addEventListener('open', function () {
 			should(view.backgroundFocusedColor).be.a.String;
 			should(view.backgroundFocusedImage).be.a.String;
 			view.backgroundFocusedColor = 'white';
@@ -147,9 +139,7 @@ describe('Titanium.UI.Button', function () {
 		});
 		var view = Ti.UI.createButton({ title: 'push button' });
 		w.add(view);
-		w.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
+		w.addEventListener('open', function () {
 			should(view.backgroundSelectedColor).be.a.String;
 			should(view.backgroundSelectedImage).be.a.String;
 			view.backgroundSelectedColor = 'white';
@@ -171,9 +161,7 @@ describe('Titanium.UI.Button', function () {
 		});
 		var view = Ti.UI.createButton({ title: 'push button' });
 		w.add(view);
-		w.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
+		w.addEventListener('open', function () {
 			should(view.backgroundDisabledColor).be.a.String;
 			should(view.backgroundDisabledImage).be.a.String;
 			view.backgroundDisabledColor = 'white';
@@ -201,9 +189,7 @@ describe('Titanium.UI.Button', function () {
 			colors: [{ color: 'red', offset: 0.0 }, { color: 'blue', offset: 0.25 }, { color: 'red', offset: 1.0 }],
 		};
 		w.add(view);
-		w.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
+		w.addEventListener('open', function () {
 			should(view.backgroundGradient.type).be.eql('linear');
 			should(view.backgroundGradient.startPoint).be.an.Object;
 			should(view.backgroundGradient.endPoint).be.an.Object;
@@ -223,9 +209,7 @@ describe('Titanium.UI.Button', function () {
 		});
 		var view = Ti.UI.createButton({ title: 'push button' });
 		w.add(view);
-		w.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
+		w.addEventListener('open', function () {
 			should(view.borderColor).be.a.String;
 			should(view.borderWidth).be.a.Number;
 			view.borderColor = 'blue';
@@ -248,9 +232,7 @@ describe('Titanium.UI.Button', function () {
 		var view = Ti.UI.createButton({ title: 'push button' });
 		w.add(view);
 
-		w.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
+		w.addEventListener('open', function () {
 			setTimeout(function () {
 				w.close();
 				finish();

--- a/Examples/NMocha/src/Assets/ti.ui.label.test.js
+++ b/Examples/NMocha/src/Assets/ti.ui.label.test.js
@@ -128,9 +128,7 @@ describe('Titanium.UI.Label', function () {
 			didPostLayout = true;
 			should(label.size.width).not.be.greaterThan(win.size.width);
 		});
-		win.addEventListener('focus', function() {
-			if (didFocus) return;
-			didFocus = true;
+		win.addEventListener('open', function() {
 			setTimeout(function() {
 				win.close();
 				finish();
@@ -138,7 +136,7 @@ describe('Titanium.UI.Label', function () {
 		});
 		win.open();
 	});
-	it('height', function (finish) {
+	((utilities.isWindows8_1() && utilities.isWindowsDesktop()) ? it.skip : it)('height', function (finish) {
 		this.timeout(5000);
 		var label = Ti.UI.createLabel({
 			text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec nec ullamcorper massa, eget tempor sapien. Phasellus nisi metus, tempus a magna nec, ultricies rutrum lacus. Aliquam sit amet augue suscipit, dignissim tellus eu, consectetur elit. Praesent ligula velit, blandit vel urna sit amet, suscipit euismod nunc.',
@@ -164,9 +162,7 @@ describe('Titanium.UI.Label', function () {
 			// parent view should be able to handle which areas should be shown in that case.
 			// should(label.size.height).not.be.greaterThan(100);
 		});
-		win.addEventListener('focus', function() {
-			if (didFocus) return;
-			didFocus = true;
+		win.addEventListener('open', function() {
 			setTimeout(function() {
 				win.close();
 				finish();
@@ -184,7 +180,7 @@ describe('Titanium.UI.Label', function () {
 				borderRadius: 5,
 				text: 'this is some text'
 			});
-		win.addEventListener('focus', function () {
+		win.addEventListener('open', function () {
 			setTimeout(function () {
 				should(label.size.width).be.greaterThan(0);
 				should(label.size.height).be.greaterThan(0);

--- a/Examples/NMocha/src/Assets/ti.ui.layout.test.js
+++ b/Examples/NMocha/src/Assets/ti.ui.layout.test.js
@@ -13,14 +13,11 @@ function createWindow(_args, finish) {
 	_args = _args || {};
 	_args.backgroundColor = _args.backgroundColor || 'red';
 	var win = Ti.UI.createWindow(_args);
-	win.addEventListener('focus', function () {
-		Ti.API.info('Got focus event');
-		if (!didFocus) {
-			setTimeout(function () {
-				closeAndFinish(win, finish);
-			}, 3000);
-			didFocus = true;
-		}
+	win.addEventListener('open', function () {
+		Ti.API.info('Got open event');
+		setTimeout(function () {
+			closeAndFinish(win, finish);
+		}, 3000);
 	});
 	return win;
 }

--- a/Examples/NMocha/src/Assets/ti.ui.listview.test.js
+++ b/Examples/NMocha/src/Assets/ti.ui.listview.test.js
@@ -109,10 +109,7 @@ describe('Titanium.UI.ListView', function () {
 		]);
 		listView.appendSection(usSection);
 
-		win.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
-
+		win.addEventListener('open', function () {
 			should(listView.sectionCount).be.eql(2);
 			should(listView.sections[0].items.length).be.eql(3);
 			should(listView.sections[0].items[0].properties.title).be.eql('Lift');
@@ -164,10 +161,7 @@ describe('Titanium.UI.ListView', function () {
 
 		listView.sections = sections;
 
-		win.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
-
+		win.addEventListener('open', function () {
 			should(listView.sectionCount).be.eql(2);
 			should(listView.sections[0].items.length).be.eql(2);
 			should(listView.sections[0].items[0].properties.title).be.eql('Apple');
@@ -253,10 +247,7 @@ describe('Titanium.UI.ListView', function () {
 
 		listView.setSections(sections);
 
-		win.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
-
+		win.addEventListener('open', function () {
 			should(listView.sectionCount).be.eql(3);
 			should(listView.sections[0].items.length).be.eql(2);
 			should(listView.sections[0].items[0].info.text).be.eql('Apple');
@@ -305,10 +296,7 @@ describe('Titanium.UI.ListView', function () {
 
 		listView.sections = [ fruitSection ];
 
-		win.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
-
+		win.addEventListener('open', function () {
 			should(listView.sectionCount).be.eql(1);
 			should(listView.sections[0].items.length).be.eql(2);
 			should(listView.sections[0].items[0].properties.title).be.eql('Apple');
@@ -365,10 +353,7 @@ describe('Titanium.UI.ListView', function () {
 
 		listView.sections = [ fruitSection, fishSection ];
 
-		win.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
-
+		win.addEventListener('open', function () {
 			should(listView.sectionCount).be.eql(2);
 			should(listView.sections[0].items.length).be.eql(2);
 			should(listView.sections[0].items[0].properties.title).be.eql('Apple');
@@ -421,10 +406,7 @@ describe('Titanium.UI.ListView', function () {
 
 		listView.sections = [ fruitSection, vegSection ];
 
-		win.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
-
+		win.addEventListener('open', function () {
 			should(listView.sectionCount).be.eql(2);
 			should(listView.sections[0].items.length).be.eql(2);
 			should(listView.sections[0].items[0].properties.title).be.eql('Apple');
@@ -480,10 +462,7 @@ describe('Titanium.UI.ListView', function () {
 
 		listView.sections = [ fruitSection, vegSection, fishSection ];
 
-		win.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
-
+		win.addEventListener('open', function () {
 			should(listView.sectionCount).be.eql(3);
 			should(listView.sections[0].items.length).be.eql(2);
 			should(listView.sections[0].items[0].properties.title).be.eql('Apple');

--- a/Examples/NMocha/src/Assets/ti.ui.tableview.test.js
+++ b/Examples/NMocha/src/Assets/ti.ui.tableview.test.js
@@ -98,10 +98,7 @@ describe('Titanium.UI.TableView', function () {
 		  data: [ { title:'Red' } ]
 		});
 
-		win.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
-
+		win.addEventListener('open', function () {
 			should(tableView.sectionCount).be.eql(1);
 			should(tableView.sections[0]).be.an.Object;
 			should(tableView.sections[0].rowCount).be.eql(1);
@@ -141,10 +138,7 @@ describe('Titanium.UI.TableView', function () {
 		  data: [section_0]
 		});
 
-		win.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
-
+		win.addEventListener('open', function () {
 			should(tableView.sectionCount).be.eql(1);
 			should(tableView.sections[0]).be.an.Object;
 			should(tableView.sections[0].rowCount).be.eql(1);
@@ -181,10 +175,7 @@ describe('Titanium.UI.TableView', function () {
 		  data: [ { title:'Red' }, { title:'White' } ]
 		});
 
-		win.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
-
+		win.addEventListener('open', function () {
 			should(tableView.sectionCount).be.eql(1);
 			should(tableView.sections[0]).be.an.Object;
 			should(tableView.sections[0].rowCount).be.eql(2);
@@ -220,10 +211,7 @@ describe('Titanium.UI.TableView', function () {
 		  data: [section_0]
 		});
 
-		win.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
-
+		win.addEventListener('open', function () {
 			should(tableView.sectionCount).be.eql(1);
 			should(tableView.sections[0]).be.an.Object;
 			should(tableView.sections[0].rowCount).be.eql(2);
@@ -255,10 +243,7 @@ describe('Titanium.UI.TableView', function () {
 		  data: [ { title:'Red' } ]
 		});
 
-		win.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
-
+		win.addEventListener('open', function () {
 			should(tableView.sectionCount).be.eql(1);
 			should(tableView.sections[0]).be.an.Object;
 			should(tableView.sections[0].rowCount).be.eql(1);
@@ -294,10 +279,7 @@ describe('Titanium.UI.TableView', function () {
 		  data: [ { title:'Red' } ]
 		});
 
-		win.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
-
+		win.addEventListener('open', function () {
 			should(tableView.sectionCount).be.eql(1);
 			should(tableView.sections[0]).be.an.Object;
 			should(tableView.sections[0].rowCount).be.eql(1);
@@ -338,10 +320,7 @@ describe('Titanium.UI.TableView', function () {
 		  data: [section_0]
 		});
 
-		win.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
-
+		win.addEventListener('open', function () {
 			should(tableView.sectionCount).be.eql(1);
 			should(tableView.sections[0]).be.an.Object;
 			should(tableView.sections[0].rowCount).be.eql(1);
@@ -377,10 +356,7 @@ describe('Titanium.UI.TableView', function () {
 		  data: [section_0]
 		});
 
-		win.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
-
+		win.addEventListener('open', function () {
 			should(tableView.sectionCount).be.eql(1);
 			should(tableView.sections[0]).be.an.Object;
 			should(tableView.sections[0].rowCount).be.eql(1);
@@ -416,10 +392,7 @@ describe('Titanium.UI.TableView', function () {
 		  data: [section_0]
 		});
 
-		win.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
-
+		win.addEventListener('open', function () {
 			should(tableView.sectionCount).be.eql(1);
 			should(tableView.sections[0]).be.an.Object;
 			should(tableView.sections[0].rowCount).be.eql(3);
@@ -464,10 +437,7 @@ describe('Titanium.UI.TableView', function () {
 		  data: [section_0]
 		});
 
-		win.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
-
+		win.addEventListener('open', function () {
 			should(tableView.sectionCount).be.eql(1);
 			should(tableView.sections[0]).be.an.Object;
 			should(tableView.sections[0].rowCount).be.eql(3);
@@ -504,10 +474,7 @@ describe('Titanium.UI.TableView', function () {
 		  data: [section_0]
 		});
 
-		win.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
-
+		win.addEventListener('open', function () {
 			should(tableView.sections[0].rowCount).be.eql(3);
 			tableView.updateRow(1, Ti.UI.createTableViewRow({ title: 'Green' }));
 			should(tableView.sections[0].rowCount).be.eql(3);
@@ -544,10 +511,7 @@ describe('Titanium.UI.TableView', function () {
 		  data: [section_0]
 		});
 
-		win.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
-
+		win.addEventListener('open', function () {
 			should(tableView.sectionCount).be.eql(1);
 			should(tableView.sections[0]).be.eql(section_0);
 			should(tableView.sections[0].rows[0].title).be.eql('Red');
@@ -593,10 +557,7 @@ describe('Titanium.UI.TableView', function () {
 		  data: [section_0, section_1]
 		});
 
-		win.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
-
+		win.addEventListener('open', function () {
 			should(tableView.sectionCount).be.eql(2);
 			should(tableView.sections[0]).be.eql(section_0);
 			should(tableView.sections[1]).be.eql(section_1);
@@ -651,10 +612,7 @@ describe('Titanium.UI.TableView', function () {
 		  data: [section_0, section_1]
 		});
 
-		win.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
-
+		win.addEventListener('open', function () {
 			tableView.updateSection(1, section_2);
 
 			should(tableView.sectionCount).be.eql(2);
@@ -711,10 +669,7 @@ describe('Titanium.UI.TableView', function () {
 		  data: [section_0, section_1]
 		});
 
-		win.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
-
+		win.addEventListener('open', function () {
 			should(tableView.sectionCount).be.eql(2);
 			should(tableView.sections[0]).be.eql(section_0);
 			should(tableView.sections[1]).be.eql(section_1);
@@ -772,10 +727,7 @@ describe('Titanium.UI.TableView', function () {
 		  data: [section_0, section_1]
 		});
 
-		win.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
-
+		win.addEventListener('open', function () {
 			should(tableView.sectionCount).be.eql(2);
 			should(tableView.sections[0]).be.eql(section_0);
 			should(tableView.sections[1]).be.eql(section_1);

--- a/Examples/NMocha/src/Assets/ti.ui.textfield.test.js
+++ b/Examples/NMocha/src/Assets/ti.ui.textfield.test.js
@@ -104,7 +104,7 @@ describe('Titanium.UI.TextField', function () {
 			backgroundColor: '#ddd'
 		});
 		win.add(textfield);
-		win.addEventListener('focus', function () {
+		win.addEventListener('open', function () {
 			should(win.width).be.greaterThan(100);
 			should(textfield.width).not.be.greaterThan(win.width);
 			setTimeout(function() {
@@ -133,9 +133,7 @@ describe('Titanium.UI.TextField', function () {
 		bgView.add(textfield);
 		win.add(bgView);
 
-		win.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
+		win.addEventListener('open', function () {
 			should(bgView.height).be.eql(100);
 			should(textfield.height).not.be.greaterThan(100);
 			setTimeout(function() {

--- a/Examples/NMocha/src/Assets/ti.ui.view.test.js
+++ b/Examples/NMocha/src/Assets/ti.ui.view.test.js
@@ -25,9 +25,7 @@ describe('Titanium.UI.View', function () {
 		});
 		var view = Ti.UI.createView({ width:Ti.UI.FILL, height:Ti.UI.FILL });
 		w.add(view);
-		w.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
+		w.addEventListener('open', function () {
 			should(view.backgroundColor).be.a.String;
 			should(view.backgroundImage).be.a.String;
 			view.backgroundColor = 'white';
@@ -48,9 +46,7 @@ describe('Titanium.UI.View', function () {
 		});
 		var view = Ti.UI.createView({ width:Ti.UI.FILL, height:Ti.UI.FILL });
 		w.add(view);
-		w.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
+		w.addEventListener('open', function () {
 			should(view.backgroundFocusedColor).be.a.String;
 			should(view.backgroundFocusedImage).be.a.String;
 			view.backgroundFocusedColor = 'white';
@@ -71,9 +67,7 @@ describe('Titanium.UI.View', function () {
 		});
 		var view = Ti.UI.createView({ width:Ti.UI.FILL, height:Ti.UI.FILL });
 		w.add(view);
-		w.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
+		w.addEventListener('open', function () {
 			should(view.backgroundSelectedColor).be.a.String;
 			should(view.backgroundSelectedImage).be.a.String;
 			view.backgroundSelectedColor = 'white';
@@ -94,9 +88,7 @@ describe('Titanium.UI.View', function () {
 		});
 		var view = Ti.UI.createView({ width:Ti.UI.FILL, height:Ti.UI.FILL });
 		w.add(view);
-		w.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
+		w.addEventListener('open', function () {
 			should(view.backgroundDisabledColor).be.a.String;
 			should(view.backgroundDisabledImage).be.a.String;
 			view.backgroundDisabledColor = 'white';
@@ -123,9 +115,7 @@ describe('Titanium.UI.View', function () {
 			colors: [{ color: 'red', offset: 0.0 }, { color: 'blue', offset: 0.25 }, { color: 'red', offset: 1.0 }],
 		};
 		w.add(view);
-		w.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
+		w.addEventListener('open', function () {
 			should(view.backgroundGradient.type).be.eql('linear');
 			should(view.backgroundGradient.startPoint).be.an.Object;
 			should(view.backgroundGradient.endPoint).be.an.Object;
@@ -145,9 +135,7 @@ describe('Titanium.UI.View', function () {
 		});
 		var view = Ti.UI.createView({ width:Ti.UI.FILL, height:Ti.UI.FILL });
 		w.add(view);
-		w.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
+		w.addEventListener('open', function () {
 			should(view.borderColor).be.a.String;
 			should(view.borderWidth).be.a.Number;
 			view.borderColor = 'blue';
@@ -169,9 +157,7 @@ describe('Titanium.UI.View', function () {
 		var view = Ti.UI.createView({ width:Ti.UI.FILL, height:Ti.UI.FILL });
 		w.add(view);
 
-		w.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
+		w.addEventListener('open', function () {
 			setTimeout(function () {
 				w.close();
 				finish();
@@ -200,10 +186,8 @@ describe('Titanium.UI.View', function () {
 			backgroundColor: 'blue'
 		});
 
-		w.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
-			Ti.API.info('Got focus event');
+		w.addEventListener('open', function () {
+			Ti.API.info('Got open event');
 			should(w.visible).be.true;
 			w.hide();
 			should(w.visible).be.false;
@@ -422,9 +406,7 @@ describe('Titanium.UI.View', function () {
 		a.add(b);
 		w.add(a);
 
-		w.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
+		w.addEventListener('open', function () {
 			setTimeout(function () {
 				w.close();
 				finish();

--- a/Examples/NMocha/src/Assets/ti.ui.window.test.js
+++ b/Examples/NMocha/src/Assets/ti.ui.window.test.js
@@ -53,9 +53,7 @@ describe('Titanium.UI.Window', function () {
 			width: 100,
 			height: 100
 		});
-		w.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
+		w.addEventListener('open', function () {
 			should(w.size.width).not.be.eql(100);
 			should(w.size.height).not.be.eql(100);
 			setTimeout(function () {
@@ -73,9 +71,7 @@ describe('Titanium.UI.Window', function () {
 			left: 100,
 			right: 100
 		});
-		w.addEventListener('focus', function () {
-			if (didFocus) return;
-			didFocus = true;
+		w.addEventListener('open', function () {
 			should(w.rect.left).not.be.eql(100);
 			should(w.rect.right).not.be.eql(100);
 			setTimeout(function () {
@@ -109,9 +105,7 @@ describe('Titanium.UI.Window', function () {
 			backgroundColor: 'gray'
 		});
 		var view = Ti.UI.createView();
-		win.addEventListener('focus', function() {
-			if (didFocus) return;
-			didFocus = true;
+		win.addEventListener('open', function() {
 			should(win.children.length).be.eql(1);
 			win.remove(win.children[0]);
 			should(win.children.length).be.eql(0);
@@ -177,10 +171,7 @@ describe('Titanium.UI.Window', function () {
 			win2 = Ti.UI.createWindow({backgroundColor:'blue' }),
 			win3 = Ti.UI.createWindow({backgroundColor:'gray' });
 
-		win1.addEventListener('focus', function(e) {
-			if (didFocus) return;
-			didFocus = true;
-
+		win1.addEventListener('open', function(e) {
 			win2.open();
 			setTimeout(function () {
 				win3.open();
@@ -206,10 +197,7 @@ describe('Titanium.UI.Window', function () {
 			win2 = Ti.UI.createWindow({backgroundColor:'blue' }),
 			win3 = Ti.UI.createWindow({backgroundColor:'gray' });
 
-		win1.addEventListener('focus', function(e) {
-			if (didFocus) return;
-			didFocus = true;
-
+		win1.addEventListener('open', function(e) {
 			win2.open();
 			setTimeout(function () {
 				win3.open();
@@ -234,10 +222,7 @@ describe('Titanium.UI.Window', function () {
 			win2 = Ti.UI.createWindow({backgroundColor:'blue' }),
 			win3 = Ti.UI.createWindow({backgroundColor:'gray' });
 
-		win1.addEventListener('focus', function(e) {
-			if (didFocus) return;
-			didFocus = true;
-
+		win1.addEventListener('open', function(e) {
 			win2.open();
 			setTimeout(function () {
 				win3.open();
@@ -269,9 +254,7 @@ describe('Titanium.UI.Window', function () {
 		var win = Ti.UI.createWindow({
 			backgroundColor: 'yellow'
 		});
-		win.addEventListener('focus', function (e) {
-			if (didFocus) return;
-			didFocus = true;
+		win.addEventListener('open', function (e) {
 			should(Ti.UI.currentWindow).be.eql(win);
 			setTimeout(function () {
 				win.close();

--- a/Source/TitaniumKit/src/Analytics.cpp
+++ b/Source/TitaniumKit/src/Analytics.cpp
@@ -69,21 +69,30 @@ namespace Titanium
 
 	TITANIUM_PROPERTY_GETTER(Analytics, _receivedResponse)
 	{
-		auto func = ti_analytics__.GetProperty("getReceivedResponse");
-		return static_cast<JSObject>(func)(get_context().get_global_object());
+		if (ti_analytics__.HasProperty("getReceivedResponse")) {
+			auto func = ti_analytics__.GetProperty("getReceivedResponse");
+			return static_cast<JSObject>(func)(get_context().get_global_object());
+		}
+		return get_context().CreateUndefined();
 	}
 
 	TITANIUM_PROPERTY_SETTER(Analytics, _receivedResponse)
 	{
-		auto func = ti_analytics__.GetProperty("setReceivedResponse");
-		static_cast<JSObject>(func)({argument}, get_context().get_global_object());
-		return true;
+		if (ti_analytics__.HasProperty("setReceivedResponse")) {
+			auto func = ti_analytics__.GetProperty("setReceivedResponse");
+			static_cast<JSObject>(func)({argument}, get_context().get_global_object());
+			return true;
+		}
+		return false;
 	}
 
 	TITANIUM_PROPERTY_GETTER(Analytics, lastEvent)
 	{
-		auto func = ti_analytics__.GetProperty("lastEvent");
-		return static_cast<JSObject>(func)(get_context().get_global_object());
+		if (ti_analytics__.HasProperty("lastEvent")) {
+			auto func = ti_analytics__.GetProperty("lastEvent");
+			return static_cast<JSObject>(func)(get_context().get_global_object());
+		}
+		return get_context().CreateUndefined();
 	}
 
 	TITANIUM_FUNCTION(Analytics, _start)


### PR DESCRIPTION
We've been learning that use of `focus` event to trigger `finish` callback on `NMocha` tests does not actually work well on desktop environment. Avoid use of it when possible.