### PR TITLE
[6_0_X] Skip reverse/forward geocoder on desktop 

### DIFF
--- a/Examples/NMocha/src/Assets/app.js
+++ b/Examples/NMocha/src/Assets/app.js
@@ -44,9 +44,9 @@ require('./ti.platform.test');
 require('./ti.require.test');
 require('./ti.stream.test');
 require('./ti.test');
-// TODO FIXME TIMOB-23776 Skip tests on Windows 8.1 Desktop
-if (utilities.isWindows8_1() && utilities.isWindowsDesktop()) {
-    Ti.API.info('TIMOB-23776: Skipping UI tests on Windows 8.1 Desktop');
+// TODO FIXME TIMOB-23776 Skip tests on Windows Desktop due to intermittent crash
+if (utilities.isWindowsDesktop()) {
+    Ti.API.info('TIMOB-23776: Skipping UI tests on Windows Desktop');
 } else {
 require('./ti.ui.2dmatrix.test');
 require('./ti.ui.activityindicator.test');

--- a/Examples/NMocha/src/Assets/ti.geolocation.test.js
+++ b/Examples/NMocha/src/Assets/ti.geolocation.test.js
@@ -156,7 +156,7 @@ describe('Titanium.Geolocation', function () {
 		finish();
 	});
 
-	it('forwardGeocoder', function (finish) {
+	(utilities.isWindowsDesktop() ? it.skip : it)('forwardGeocoder', function (finish) {
 		this.timeout(6e4);
 		should(Ti.Geolocation.forwardGeocoder).be.a.Function;
 		Ti.Geolocation.forwardGeocoder('440 N Bernardo Ave, Mountain View', function (data) {
@@ -174,7 +174,7 @@ describe('Titanium.Geolocation', function () {
 		});
 	});
 
-	it('reverseGeocoder', function (finish) {
+	(utilities.isWindowsDesktop() ? it.skip : it)('reverseGeocoder', function (finish) {
 		this.timeout(6e4);
 		should(Ti.Geolocation.reverseGeocoder).be.a.Function;
 		Ti.Geolocation.reverseGeocoder(37.3883645, -122.0512682, function (data) {


### PR DESCRIPTION
Skip reverse/forward geocoder on desktop because of intermittent network issue