### PR TITLE
[TIMOB-23682] borderRadius for ProgressBar

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/ProgressBar.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/ProgressBar.hpp
@@ -31,6 +31,7 @@ namespace TitaniumWindows
 			// Shows progress Bar and starts the animation.
 			virtual void show() TITANIUM_NOEXCEPT override;
 
+			virtual void set_borderWidth(const uint32_t& borderWidth) TITANIUM_NOEXCEPT override;
 		protected:
 			Windows::UI::Xaml::Controls::ProgressBar^ bar__;
 			bool isIndeterminate__ { false };

--- a/Source/UI/src/ProgressBar.cpp
+++ b/Source/UI/src/ProgressBar.cpp
@@ -38,6 +38,16 @@ namespace TitaniumWindows
 			bar__->IsIndeterminate = false;
 		}
 
+		void ProgressBarLayoutDelegate::set_borderWidth(const uint32_t& borderWidth) TITANIUM_NOEXCEPT
+		{
+			WindowsViewLayoutDelegate::set_borderWidth(borderWidth);
+
+			// set margin to the progress bar to make both border and bar shown.
+			auto margin = bar__->Margin;
+			margin.Bottom = borderWidth * 2;
+			bar__->Margin = margin;
+		}
+
 		void ProgressBar::postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) 
 		{
 			Titanium::UI::ProgressBar::postCallAsConstructor(js_context, arguments);
@@ -82,7 +92,7 @@ namespace TitaniumWindows
 			Titanium::UI::ProgressBar::setLayoutDelegate<ProgressBarLayoutDelegate>(bar__);
 			layoutDelegate__->set_defaultHeight(Titanium::UI::LAYOUT::SIZE);
 			layoutDelegate__->set_defaultWidth(Titanium::UI::LAYOUT::SIZE);
-			getViewLayoutDelegate<ProgressBarLayoutDelegate>()->setComponent(panel__, bar__);
+			getViewLayoutDelegate<ProgressBarLayoutDelegate>()->setComponent(panel__);
 		}
 
 		ProgressBar::ProgressBar(const JSContext& js_context) TITANIUM_NOEXCEPT


### PR DESCRIPTION
[TIMOB-23682](https://jira.appcelerator.org/browse/TIMOB-23682)

```javascript
var win = Ti.UI.createWindow({ backgroundColor: 'purple' }),
    progressBar = Ti.UI.createProgressBar({
    borderWidth: 5,
    borderColor: 'yellow',
    borderRadius: 5,
    min: 0,
    max: 10,
    value: 5,
message: 'Downloading 5 of 10',
width: Ti.UI.FILL
});

win.add(progressBar)
win.open();
```

![timob-23682](https://cloud.githubusercontent.com/assets/1661068/18005922/eb102b26-6bd7-11e6-944b-144df962d2fd.png)

Side note: On iOS, `borderRadius` doesn't work well for `ProgressBar`