### PR TITLE
[TIMOB-23785] Log warnings for out of range index in ListSection

### DIFF
--- a/Source/TitaniumKit/src/UI/ListSection.cpp
+++ b/Source/TitaniumKit/src/UI/ListSection.cpp
@@ -124,6 +124,7 @@ namespace Titanium
 
 		void ListSection::insertItemsAt(const std::uint32_t& index, const std::vector<ListDataItem>& dataItems, const std::shared_ptr<ListViewAnimationProperties>& animation) TITANIUM_NOEXCEPT
 		{
+			TITANIUM_ASSERT(items__.size() > index);
 			items__.insert(items__.begin() + index, dataItems.begin(), dataItems.end());
 			fireListSectionEvent("insert", index, static_cast<std::uint32_t>(dataItems.size()));
 		}
@@ -140,18 +141,23 @@ namespace Titanium
 		{
 			TITANIUM_ASSERT(items__.size() >= index + count);
 			fireListSectionEvent("delete", index, count, count);
-			items__.erase (items__.begin() + index, items__.begin() + index + count);
+			items__.erase(items__.begin() + index, items__.begin() + index + count);
 		}
 
 		ListDataItem ListSection::getItemAt(const std::uint32_t& index) TITANIUM_NOEXCEPT
 		{
+			TITANIUM_ASSERT(items__.size() > index);
 			return items__.at(index);
 		}
 
 		void ListSection::updateItemAt(const std::uint32_t& index, const ListDataItem& dataItem, const std::shared_ptr<ListViewAnimationProperties>& animation) TITANIUM_NOEXCEPT
 		{
-			items__.at(index) = dataItem;
-			fireListSectionEvent("update", index);
+			try {
+				items__.at(index) = dataItem;
+				fireListSectionEvent("update", index);
+			} catch (std::out_of_range e) {
+				TITANIUM_API_LOG_WARN("ListSection::updateItemAt() index is out of range");
+			}
 		}
 
 		void ListSection::fireListSectionEvent(const std::string& event_name, const std::uint32_t& index, const std::uint32_t& itemCount, const std::uint32_t& affectedRows)


### PR DESCRIPTION
- Display warnings for out of range index when using `ListSection` functions

###### TEST CASE
```Javascript
var win = Ti.UI.createWindow({ backgroundColor: 'blue' }),
    section = Ti.UI.createListSection({
        items: [
            { properties: { title: 'A' } },
            { properties: { title: 'B' } },
            { properties: { title: 'C' } },
            { properties: { title: 'D' } }
        ]
    }),
    listView = Ti.UI.createListView({ sections: [section] });

section.updateItemAt(4, { properties: { title: 'E' } });
 
win.add(listView);
win.open();
```
```
[WARN] ListView::updateItemAt() index is out of range
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23785)