### PR TITLE
Test: Avoid zero-interval for setTimeout

### DIFF
--- a/Examples/NMocha/src/Assets/app.js
+++ b/Examples/NMocha/src/Assets/app.js
@@ -45,10 +45,6 @@ require('./ti.platform.test');
 require('./ti.require.test');
 require('./ti.stream.test');
 require('./ti.test');
-// TODO FIXME TIMOB-23776 Skip tests on Windows Desktop
-if (utilities.isWindowsDesktop()) {
-    Ti.API.info('TIMOB-23776: Skipping UI tests on Windows Desktop');
-} else {
 require('./ti.ui.2dmatrix.test');
 require('./ti.ui.activityindicator.test');
 require('./ti.ui.alertdialog.test');
@@ -75,7 +71,6 @@ require('./ti.ui.window.test');
 require('./ti.ui.windows.commandbar.test');
 require('./ti.utils.test');
 require('./ti.xml.test');
-}
 // ============================================================================
 
 

--- a/Source/Global/src/GlobalObject.cpp
+++ b/Source/Global/src/GlobalObject.cpp
@@ -196,10 +196,16 @@ namespace TitaniumWindows
 	{
 #pragma warning(pop)
 	public:
-		Timer(Titanium::GlobalObject::Callback_t callback, const std::chrono::milliseconds& interval)
-		    : Titanium::GlobalObject::Timer(callback, interval), callback__(callback)
+		Timer(Titanium::GlobalObject::Callback_t callback, const std::chrono::milliseconds& _interval)
+		    : Titanium::GlobalObject::Timer(callback, _interval), callback__(callback)
 		{
 			TITANIUM_LOG_DEBUG("Timer: ctor");
+
+			std::chrono::milliseconds interval = _interval;
+			// Avoid zero interval
+			if (interval.count() == 0) {
+				interval = std::chrono::milliseconds(static_cast<std::chrono::milliseconds::rep>(100));
+			}
 
 			// A Windows::Foundation::TimeSpan is a time period expressed in
 			// 100-nanosecond units.

--- a/Source/Network/src/HTTPClient.cpp
+++ b/Source/Network/src/HTTPClient.cpp
@@ -16,10 +16,9 @@
 
 // FIXME: Workaround to select current thread on Windows 10 desktop. Need to revisit.
 #if defined(IS_WINDOWS_MOBILE)
-#define SELECT_CONTINUATION_CONTEXT \
-  IS_WINDOWS_MOBILE ? task_continuation_context::use_arbitrary() : task_continuation_context::use_current()
+#define SELECT_CONTINUATION_CONTEXT task_continuation_context::use_current()
 #else
-#define SELECT_CONTINUATION_CONTEXT task_continuation_context::use_arbitrary()
+#define SELECT_CONTINUATION_CONTEXT task_continuation_context::use_current()
 #endif
 
 using namespace concurrency;

--- a/Tools/Scripts/setup.js
+++ b/Tools/Scripts/setup.js
@@ -32,9 +32,9 @@ var async = require('async'),
 	WIN_8_1 = '8.1',
 	WIN_10 = '10.0',
 	// Default JSC URL to build for Win 8.1.
-	JSC_81_URL = 'http://timobile.appcelerator.com.s3.amazonaws.com/jscore/JavaScriptCore-Windows-1469754731.zip',
+	JSC_81_URL = 'http://studio-jenkins.appcelerator.org/job/JavaScriptCore/lastSuccessfulBuild/artifact/dist/JavaScriptCore-Windows-1471873372.zip',
 	// Default JSC URL for building against Win 10
-	JSC_10_URL = 'http://timobile.appcelerator.com.s3.amazonaws.com/jscore/JavaScriptCore-Windows-1469754731-win10.zip',
+	JSC_10_URL = 'http://studio-jenkins.appcelerator.org/job/JavaScriptCore-Win10/lastSuccessfulBuild/artifact/dist/JavaScriptCore-Windows-1471873372-win10.zip',
 	JSC_DIR = 'JavaScriptCore', // directory inside zipfile
 	GTEST_URL = (os.platform() === 'win32') ? 'http://timobile.appcelerator.com.s3.amazonaws.com/gtest-1.7.0-windows.zip' : 'http://timobile.appcelerator.com.s3.amazonaws.com/gtest-1.7.0-osx.zip',
 	GTEST_DIR = (os.platform() === 'win32') ? 'gtest-1.7.0-windows' : 'gtest-1.7.0-osx', // directory inside zipfile


### PR DESCRIPTION
DO NOT MERGE

I've been seeing avoiding zero interval for Xaml `DispatcherTimer` makes the app more stable. Trying to see if this makes Jenkins work better.