### PR TITLE
[TIMOB-23752] Async HTTPClient crashes on Win10 Desktop

### DIFF
--- a/Source/Network/src/HTTPClient.cpp
+++ b/Source/Network/src/HTTPClient.cpp
@@ -14,14 +14,6 @@
 #include "TitaniumWindows/LogForwarder.hpp"
 #include "TitaniumWindows/WindowsMacros.hpp"
 
-// FIXME: Workaround to select current thread on Windows 10 desktop. Need to revisit.
-#if defined(IS_WINDOWS_MOBILE)
-#define SELECT_CONTINUATION_CONTEXT \
-  IS_WINDOWS_MOBILE ? task_continuation_context::use_arbitrary() : task_continuation_context::use_current()
-#else
-#define SELECT_CONTINUATION_CONTEXT task_continuation_context::use_arbitrary()
-#endif
-
 using namespace concurrency;
 
 namespace TitaniumWindows
@@ -238,7 +230,7 @@ namespace TitaniumWindows
 				SerializeHeaders(response);
 
 				return create_task(response->Content->ReadAsInputStreamAsync(), token);
-			}, SELECT_CONTINUATION_CONTEXT)
+			}, task_continuation_context::use_arbitrary())
 				.then([this, token](Windows::Storage::Streams::IInputStream^ stream) {
 				interruption_point();
 
@@ -247,7 +239,7 @@ namespace TitaniumWindows
 				// FIXME Fire ondatastream/onsendstream callbacks throughout!
 
 				return HTTPResultAsync(stream, token);
-			}, SELECT_CONTINUATION_CONTEXT)
+			}, task_continuation_context::use_arbitrary())
 				.then([this](task<Windows::Storage::Streams::IBuffer^> previousTask) {
 				try {
 					// Check if any previous task threw an exception.
@@ -290,7 +282,7 @@ namespace TitaniumWindows
 						onerror(-1, error, false);
 					}
 				}
-			}, SELECT_CONTINUATION_CONTEXT);
+			}, task_continuation_context::use_arbitrary());
 			// clang-format on
 		}
 
@@ -396,7 +388,7 @@ namespace TitaniumWindows
 				
 				// FIXME How do we pass the token on in case of readTask?
 				return responseBuffer->Length ? HTTPResultAsync(stream, token) : readTask;
-			}, SELECT_CONTINUATION_CONTEXT);
+			}, task_continuation_context::use_arbitrary());
 			// clang-format on
 		}
 

--- a/Tools/Scripts/setup.js
+++ b/Tools/Scripts/setup.js
@@ -32,9 +32,9 @@ var async = require('async'),
 	WIN_8_1 = '8.1',
 	WIN_10 = '10.0',
 	// Default JSC URL to build for Win 8.1.
-	JSC_81_URL = 'http://timobile.appcelerator.com.s3.amazonaws.com/jscore/JavaScriptCore-Windows-1469754731.zip',
+	JSC_81_URL = 'http://timobile.appcelerator.com.s3.amazonaws.com/jscore/dist/JavaScriptCore-Windows-1471873372.zip',
 	// Default JSC URL for building against Win 10
-	JSC_10_URL = 'http://timobile.appcelerator.com.s3.amazonaws.com/jscore/JavaScriptCore-Windows-1469754731-win10.zip',
+	JSC_10_URL = 'http://timobile.appcelerator.com.s3.amazonaws.com/jscore/dist/JavaScriptCore-Windows-1471873372-win10.zip',
 	JSC_DIR = 'JavaScriptCore', // directory inside zipfile
 	GTEST_URL = (os.platform() === 'win32') ? 'http://timobile.appcelerator.com.s3.amazonaws.com/gtest-1.7.0-windows.zip' : 'http://timobile.appcelerator.com.s3.amazonaws.com/gtest-1.7.0-osx.zip',
 	GTEST_DIR = (os.platform() === 'win32') ? 'gtest-1.7.0-windows' : 'gtest-1.7.0-osx', // directory inside zipfile


### PR DESCRIPTION
[TIMOB-23752](https://jira.appcelerator.org/browse/TIMOB-23752)

Async HTTPClient introduced crash at NMocha test on Windows 10 Desktop. Reducing temporary memory for JavaScriptCore seems to be fixing this.