### PR TITLE
Test: Avoid use of JSObject for storing Timer callback

### DIFF
--- a/Examples/NMocha/src/Assets/app.js
+++ b/Examples/NMocha/src/Assets/app.js
@@ -45,9 +45,9 @@ require('./ti.platform.test');
 require('./ti.require.test');
 require('./ti.stream.test');
 require('./ti.test');
-// TODO FIXME TIMOB-23776 Skip tests on Windows Desktop
-if (utilities.isWindowsDesktop()) {
-    Ti.API.info('TIMOB-23776: Skipping UI tests on Windows Desktop');
+// TODO FIXME TIMOB-23776 Skip tests on Windows 8.1 Desktop
+if (utilities.isWindows8_1() && utilities.isWindowsDesktop()) {
+    Ti.API.info('TIMOB-23776: Skipping UI tests on Windows 8.1 Desktop');
 } else {
 require('./ti.ui.2dmatrix.test');
 require('./ti.ui.activityindicator.test');

--- a/Source/Global/src/GlobalObject.cpp
+++ b/Source/Global/src/GlobalObject.cpp
@@ -196,10 +196,16 @@ namespace TitaniumWindows
 	{
 #pragma warning(pop)
 	public:
-		Timer(Titanium::GlobalObject::Callback_t callback, const std::chrono::milliseconds& interval)
-		    : Titanium::GlobalObject::Timer(callback, interval), callback__(callback)
+		Timer(Titanium::GlobalObject::Callback_t callback, const std::chrono::milliseconds& _interval)
+		    : Titanium::GlobalObject::Timer(callback, _interval), callback__(callback)
 		{
 			TITANIUM_LOG_DEBUG("Timer: ctor");
+
+			std::chrono::milliseconds interval = _interval;
+			// Avoid zero interval
+			if (interval.count() == 0) {
+				interval = std::chrono::milliseconds(static_cast<std::chrono::milliseconds::rep>(100));
+			}
 
 			// A Windows::Foundation::TimeSpan is a time period expressed in
 			// 100-nanosecond units.

--- a/Source/TitaniumKit/include/Titanium/GlobalObject.hpp
+++ b/Source/TitaniumKit/include/Titanium/GlobalObject.hpp
@@ -312,8 +312,6 @@ namespace Titanium
 		void StartTimer(Callback_t&& callback, const unsigned& timerId, const std::chrono::milliseconds& delay) TITANIUM_NOEXCEPT;
 		void StopTimer(const unsigned& timerId) TITANIUM_NOEXCEPT;
 
-		JSObject callback_map__;
-
 // Silence 4251 on Windows since private member variables do not
 // need to be exported from a DLL.
 #pragma warning(push)
@@ -322,6 +320,7 @@ namespace Titanium
 		std::unordered_map<std::string, JSValue> module_cache__;
 		std::string currentDir__;
 		std::unordered_map<unsigned, std::shared_ptr<Timer>> timer_map__;
+		std::unordered_map<unsigned, JSObject> timer_callback_map__;
 
 		static std::atomic<unsigned> timer_id_generator__;
 #pragma warning(pop)

--- a/Tools/Scripts/setup.js
+++ b/Tools/Scripts/setup.js
@@ -32,9 +32,9 @@ var async = require('async'),
 	WIN_8_1 = '8.1',
 	WIN_10 = '10.0',
 	// Default JSC URL to build for Win 8.1.
-	JSC_81_URL = 'http://timobile.appcelerator.com.s3.amazonaws.com/jscore/dist/JavaScriptCore-Windows-1471873372.zip',
+	JSC_81_URL = 'http://timobile.appcelerator.com.s3.amazonaws.com/jscore/dist/JavaScriptCore-Windows-1472849469.zip',
 	// Default JSC URL for building against Win 10
-	JSC_10_URL = 'http://timobile.appcelerator.com.s3.amazonaws.com/jscore/dist/JavaScriptCore-Windows-1471873372-win10.zip',
+	JSC_10_URL = 'http://timobile.appcelerator.com.s3.amazonaws.com/jscore/dist/JavaScriptCore-Windows-1472849469-win10.zip',
 	JSC_DIR = 'JavaScriptCore', // directory inside zipfile
 	GTEST_URL = (os.platform() === 'win32') ? 'http://timobile.appcelerator.com.s3.amazonaws.com/gtest-1.7.0-windows.zip' : 'http://timobile.appcelerator.com.s3.amazonaws.com/gtest-1.7.0-osx.zip',
 	GTEST_DIR = (os.platform() === 'win32') ? 'gtest-1.7.0-windows' : 'gtest-1.7.0-osx', // directory inside zipfile


### PR DESCRIPTION
Part of [TIMOB-23776](https://jira.appcelerator.org/browse/TIMOB-23776)

- Avoid use of JSObject for storing Timer callback because it is heavy weight operation with few benefits. Trying to see how it works on Jenkins.
- Avoid using `0` interval for `setTimeout`. It intermittently freezes `DispatcherTimer`.
- Update JavaScriptCore, it fixes the intermittent crash issue on Windows 10. We are able to re-enable failing UI tests too. 👍 

Note that it does not fix the issue on Windows 8.1. It's because Windows 8.1 and Windows Phone 8.1 is missing required function ([GetThreadContext](https://msdn.microsoft.com/en-us/library/windows/desktop/ms679362(v=vs.85).aspx)) and currently I don't have a workaround for it.