### PR TITLE
[TIMOB-23728] Fix missing parity report entries

### DIFF
--- a/Source/TitaniumKit/src/UI/AttributedString.cpp
+++ b/Source/TitaniumKit/src/UI/AttributedString.cpp
@@ -45,7 +45,7 @@ namespace Titanium
 		};
 
 		AttributedString::AttributedString(const JSContext& js_context) TITANIUM_NOEXCEPT
-			: Module(js_context)
+			: Module(js_context, "Ti.UI.AttributedString")
 		{
 		}
 

--- a/apidoc/whitelist.txt
+++ b/apidoc/whitelist.txt
@@ -320,6 +320,15 @@ M removeEventListener
 M setBubbleParent
 M setLifecycleContainer
 
+C Titanium.UI.ListItem
+P backgroundColor
+P backgroundGradient
+P backgroundImage
+P color
+P itemId
+P subtitle
+P title
+
 C Titanium.UI.ListSection
 P footerTitle
 P headerTitle


### PR DESCRIPTION
- Fix missing `Titanium.UI.AttributedString`
- Whitelist `Titanium.UI.ListItem`

NOTE: Do we need to include all `Module.Cloud` entries? [Parity Report](http://builds.appcelerator.com/mobile/master/mobilesdk-6.1.0.v20160831204323-parity.html)

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23728)