### PR TITLE
[TIMOB-23834] Optimize windowslib usage

### DIFF
--- a/cli/commands/_build/config.js
+++ b/cli/commands/_build/config.js
@@ -42,7 +42,8 @@ function config(logger, config, cli) {
 		supportedMSBuildVersions: windowsPackageJson.vendorDependencies['msbuild'],
 		supportedVisualStudioVersions: windowsPackageJson.vendorDependencies['visual studio'],
 		supportedWindowsPhoneSDKVersions: windowsPackageJson.vendorDependencies['windows phone sdk'],
-		tasklist: config.get('windows.executables.tasklist')
+		tasklist: config.get('windows.executables.tasklist'),
+		skipWpTool: (cli.argv['target'] || cli.argv['T']) !== 'wp-device' || cli.argv['build-only']
 	};
 
 	this.ignoreDirs = new RegExp(config.get('cli.ignoreDirs'));


### PR DESCRIPTION
- Only detect devices when targeting a windows device
  - Saves time when building for `ws-local` or `--build-only`
- Remove unnecessary `windowslib.detect()`

##### DEPENDS ON
- https://github.com/appcelerator/windowslib/pull/56

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23834)