### PR TITLE
Attempt to fix package error for Win 8.1 Store app

### DIFF
--- a/cli/commands/_build/generate.js
+++ b/cli/commands/_build/generate.js
@@ -245,6 +245,11 @@ function generateCmakeList(next) {
 	), next);
 };
 
+var win81M3Capabilities = [ // m3 namespace, phone 8.1 only Capabilities
+		'contacts',
+		'appointments'
+	];
+
 /**
  * Generates capabilities based on API usage
  *
@@ -324,7 +329,10 @@ function generateCapabilities(target, capabilities, deviceCapabilities) {
 					}
 				});
 				apis[api].uapCapability && apis[api].uapCapability.forEach(function(name) {
-					var tag = target == 'win10' ? 'uap:' : (target == 'phone' && name == 'contacts' ? 'm3:' : ''),
+					// Skip Windows Phone 8.1 only capabilities for Store App
+					var win81OnlyCapability = (win81M3Capabilities.indexOf(name) != -1);
+					if (target == 'store' && win81OnlyCapability) return;
+					var tag = target == 'win10' ? 'uap:' : (win81OnlyCapability ? 'm3:' : ''),
 						entry = '<' + tag + 'Capability Name="' + name + '" />';
 					if (!hasCapability(uapCapabilities, name) && !hasCapability(capabilities, name)) {
 						uapCapabilities.push(entry);
@@ -368,10 +376,6 @@ function generateAppxManifestForPlatform(target, properties) {
 			'removableStorage',
 			'sharedUserCertificates',
 			'videosLibrary'
-		],
-		win81M3Capabilities = [ // m3 namespace, phone 8.1 only
-			'contacts',
-			'appointments'
 		],
 		win10UAPCapabilities = [
 			'documentsLibrary',

--- a/cli/commands/_build/generate.js
+++ b/cli/commands/_build/generate.js
@@ -324,7 +324,7 @@ function generateCapabilities(target, capabilities, deviceCapabilities) {
 					}
 				});
 				apis[api].uapCapability && apis[api].uapCapability.forEach(function(name) {
-					var tag = target == 'win10' ? 'uap:' : (name == 'contacts' ? 'm3:' : ''),
+					var tag = target == 'win10' ? 'uap:' : (target == 'phone' && name == 'contacts' ? 'm3:' : ''),
 						entry = '<' + tag + 'Capability Name="' + name + '" />';
 					if (!hasCapability(uapCapabilities, name) && !hasCapability(capabilities, name)) {
 						uapCapabilities.push(entry);


### PR DESCRIPTION
Just found that [Windows 8.1 Store build](http://studio-jenkins.appcelerator.org/job/titanium_mobile_windows_8.1_prs/894) fails due to following package error.

```
21:51:12 [ERROR] :  "C:\Users\appcelerator\.titanium\vsbuild\mocha\store.x86\Mocha.sln" (default target) (1) ->
21:51:12 "C:\Users\appcelerator\.titanium\vsbuild\mocha\store.x86\Mocha.vcxproj.metaproj" (default target) (2) ->
21:51:12 "C:\Users\appcelerator\.titanium\vsbuild\mocha\store.x86\Mocha.vcxproj" (default target) (6) ->
21:51:12 (_ValidatePresenceOfAppxManifestItems target) -> 
21:51:12   C:\Users\appcelerator\.titanium\vsbuild\mocha\store.x86\Package.appxmanifest(54,6): error APPX1402: Content of the file 'C:\Users\appcelerator\.titanium\vsbuild\mocha\store.x86\Package.appxmanifest' is not well-formed XML. 'm3' is an undeclared prefix. Line 54, position 6. [C:\Users\appcelerator\.titanium\vsbuild\mocha\store.x86\Mocha.vcxproj]
21:51:12 
21:51:12     0 Warning(s)
21:51:12     1 Error(s)
21:51:12 
21:51:12 Time Elapsed 00:00:09.72
21:51:12 
```