### PR TITLE
[TIMOB-23870] Don't fire onerror callback on tap-to-focus

### DIFF
--- a/Source/Media/include/TitaniumWindows/Media.hpp
+++ b/Source/Media/include/TitaniumWindows/Media.hpp
@@ -194,7 +194,7 @@ namespace TitaniumWindows
 		void clearScreenshotResources();
 		void takeScreenshotToFile(JSObject callback);
 
-		void focus(const Titanium::Media::CameraOptionsType&) TITANIUM_NOEXCEPT;
+		void focus(const Titanium::Media::CameraOptionsType&, const bool& reportError = true) TITANIUM_NOEXCEPT;
 
 #if !defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 		void showDefaultCamera(const Titanium::Media::CameraOptionsType& options) TITANIUM_NOEXCEPT;


### PR DESCRIPTION
[TIMOB-23870](https://jira.appcelerator.org/browse/TIMOB-23870)

Stop firing `onerror` callback on tap-to-focus when camera does not support focus operation.

```javascript
var win = Ti.UI.createWindow({ backgroundColor: 'green', layout: 'vertical' }),
    openButton = Ti.UI.createButton({ title: 'OPEN CAMERA', backgroundColor: 'blue' }),
    imageView = Ti.UI.createImageView({ width: Ti.UI.FILL, height: '70%' });
 
var overlay = Ti.UI.createView({
    layout: 'vertical',
    height: '20%', width: Ti.UI.FILL,
    bottom: 0
}),
takeButton = Ti.UI.createButton({ title: 'TAKE A PHOTO', backgroundColor: 'red' }),
hideButton = Ti.UI.createButton({ title: 'HIDE PREVIEW', backgroundColor: 'red' });
 
takeButton.addEventListener('click', function () {
    Ti.Media.takePicture();
});
hideButton.addEventListener('click', function () {
    Ti.Media.hideCamera();
});
overlay.add(takeButton);
overlay.add(hideButton);
 
openButton.addEventListener('click', function () {
    Ti.Media.showCamera({
        mediaTypes: [Ti.Media.MEDIA_TYPE_PHOTO],
        whichCamera: Ti.Media.CAMERA_FRONT,
        overlay: overlay,
        success: function (e) {
            Ti.API.info('showCamera() success');
            imageView.image = e.media;
        },
        error: function (e) {
            alert('showCamera() error: ' + JSON.stringify(e));
            Ti.API.info(JSON.stringify(e));
        }
    });
});
 
win.add(openButton);
win.add(imageView);
win.open();
```