### PR TITLE
[6_0_X] [TIMOB-23870] Don't fire onerror callback on tap-to-focus

### DIFF
--- a/Source/Media/include/TitaniumWindows/Media.hpp
+++ b/Source/Media/include/TitaniumWindows/Media.hpp
@@ -194,7 +194,7 @@ namespace TitaniumWindows
 		void clearScreenshotResources();
 		void takeScreenshotToFile(JSObject callback);
 
-		void focus(const Titanium::Media::CameraOptionsType&) TITANIUM_NOEXCEPT;
+		void focus(const Titanium::Media::CameraOptionsType&, const bool& reportError = true) TITANIUM_NOEXCEPT;
 
 #if !defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)
 		void showDefaultCamera(const Titanium::Media::CameraOptionsType& options) TITANIUM_NOEXCEPT;


### PR DESCRIPTION
Cherry-pick #857 for 6_0_X
