### PR TITLE
[6_0_X] [TIMOB-23371] Only report a device when one has been detected

### DIFF
--- a/cli/commands/_build/utils.js
+++ b/cli/commands/_build/utils.js
@@ -29,6 +29,11 @@ function getTargetDevices() {
 		return this.deviceCache;
 	}
 
+	// For backward compatibility reasons windowslib could return empty device
+	function isPlaceHolderDevice(d) {
+		return (d.name == 'Device' && d.udid == 0 && d.index == 0 && d.wpsdk == null);
+	}
+
 	var target = this.cli.argv.target,
 		wpsdk = this.cli.argv['wp-sdk'],
 		wpsdkDefault = this.cli.argv['$_'].indexOf('-S') === -1 && this.cli.argv['$_'].indexOf('--wp-sdk') === -1;
@@ -50,6 +55,9 @@ function getTargetDevices() {
 			var device = devices[d];
 			// only list local devices
 			if (device.ip && device.ip !== "127.0.0.1") {
+				devices.splice(d, 1);
+			// TIMOB-23371: Remove placeholder device
+			} else if (isPlaceHolderDevice(device)) {
 				devices.splice(d, 1);
 			}
 		}

--- a/cli/lib/info.js
+++ b/cli/lib/info.js
@@ -23,6 +23,10 @@ exports.name = 'windows';
 exports.title = 'Windows';
 
 exports.detect = function (types, config, next) {
+	// For backward compatibility reasons windowslib could return empty device
+	function isPlaceHolderDevice(d) {
+		return (d.name == 'Device' && d.udid == 0 && d.index == 0 && d.wpsdk == null);
+	}
 	windowslib.detect({
 		powershell:                       config.get('windows.executables.powershell'),
 		preferredWindowsPhoneSDK:         config.get('windows.wpsdk.selectedVersion'),
@@ -40,6 +44,11 @@ exports.detect = function (types, config, next) {
 		results.windowsphone && delete results.windowsphone['8.0'];
 		results.windows && delete results.windows['8.0'];
 		results.emulators && delete results.emulators['8.0'];
+
+		// TIMOB-23371: Remove placeholder device
+		if (results.devices && results.devices[0] && isPlaceHolderDevice(results.devices[0])) {
+			results.devices.shift();
+		}
 
 		results.tisdk = path.basename((function scan(dir) {
 			var file = path.join(dir, 'manifest.json');


### PR DESCRIPTION
[TIMOB-23371](https://jira.appcelerator.org/browse/TIMOB-23371)

**Steps to reproduce**

## Pattern 1
1. Connect no devie
2. `appc ti info -p windows -o json`

**Expected**

Placeholder device (see below) should not be shown

```
 {
         "name": "Device",
         "udid": 0,
         "index": 0,
         "wpsdk": null
 },
```

## Pattern 2
1. Connect multiple devices
2. Build using appc run -p windows -T wp-device

**Expected**

Placeholder deivce `   1)  Device                    (udid: 0)` should not be shown

The reason because we still let `windowslib` outputs empty placeholder device is to keep backward compatibility as a library. (See discussions in https://github.com/appcelerator/windowslib/pull/49)