### PR TITLE
[6_0_X] [TIMOB-23875] __filename should not be messed with nested require

### DIFF
--- a/Examples/NMocha/src/Assets/ti.require.test.js
+++ b/Examples/NMocha/src/Assets/ti.require.test.js
@@ -148,6 +148,8 @@ describe('requireJS', function () {
 		should(with_index_js.sub).be.eql('sub2.js');
 		// Was also failing if same file had multiple relative requires
 		should(with_index_js.sub3).be.eql('sub3.js');
+		// __filename should not be messed with nested require
+		should(with_index_js.filename).be.eql('/with_index_js/sub1.js');
 		finish();
 	});
 

--- a/Examples/NMocha/src/Assets/with_index_js/sub1.js
+++ b/Examples/NMocha/src/Assets/with_index_js/sub1.js
@@ -3,6 +3,7 @@ var sub2 = require('./sub2'),
 
 module.exports = {
     name: 'sub1.js',
+    filename: __filename,
     sub: sub2.name,
     sub3: sub3.name
 };

--- a/Source/TitaniumKit/src/GlobalObject.cpp
+++ b/Source/TitaniumKit/src/GlobalObject.cpp
@@ -328,7 +328,7 @@ namespace Titanium
 				if (moduleId == "/app") {
 					result = js_context.JSEvaluateScript(module_js, js_context.get_global_object());
 				} else {
-					const std::string require_module_js = "(function(global) { var exports={},__OXP=exports,module={'exports':exports},__dirname='" + currentDir__ + "';__filename='/"
+					const std::string require_module_js = "(function(global) { var exports={},__OXP=exports,module={'exports':exports},__dirname='" + currentDir__ + "',__filename='/"
 						+ module_path + "';" + module_js + R"JS(
 						if(module.exports !== __OXP){
 							return module.exports;


### PR DESCRIPTION
[TIMOB-23875](https://jira.appcelerator.org/browse/TIMOB-23875)

app.js
```javascript
var test = require('./index');
console.log(test.filename);
```

index.js
```javascript
var sub = require('./sub');
module.exports = {
    filename: __filename,
    name: 'index.js',
    sub: sub.name
};
```

sub.js
```javascript
module.exports = {
    name: 'sub.js',
};
```