### PR TITLE
Add config option to specify preferred Windows SDK

### DIFF
--- a/cli/commands/_build/config.js
+++ b/cli/commands/_build/config.js
@@ -38,6 +38,7 @@ function config(logger, config, cli) {
 		powershell: config.get('windows.executables.powershell'),
 		pvk2pfx: config.get('windows.executables.pvk2pfx'),
 		preferredWindowsPhoneSDK: config.get('windows.wpsdk.selectedVersion'),
+		preferredWindowsSDK: config.get('windows.sdk.selectedVersion'),
 		preferredVisualStudio: config.get('windows.visualstudio.selectedVersion'),
 		supportedMSBuildVersions: windowsPackageJson.vendorDependencies['msbuild'],
 		supportedVisualStudioVersions: windowsPackageJson.vendorDependencies['visual studio'],

--- a/cli/lib/info.js
+++ b/cli/lib/info.js
@@ -30,6 +30,7 @@ exports.detect = function (types, config, next) {
 	windowslib.detect({
 		powershell:                       config.get('windows.executables.powershell'),
 		preferredWindowsPhoneSDK:         config.get('windows.wpsdk.selectedVersion'),
+		preferredWindowsSDK:              config.get('windows.sdk.selectedVersion'),
 		preferredVisualStudio:            config.get('windows.visualstudio.selectedVersion'),
 		supportedMSBuildVersions:         windowsPackageJson.vendorDependencies['msbuild'],
 		supportedVisualStudioVersions:    windowsPackageJson.vendorDependencies['visual studio'],


### PR DESCRIPTION
Related to [TIMOB-23661](https://jira.appcelerator.org/browse/TIMOB-23661)

This needs https://github.com/appcelerator/windowslib/pull/57 to be merged and bumped into https://github.com/appcelerator/titanium_mobile .

*windows.wpsdk.selectedVersion*

1. `appc ti info -p windows -json` and see which Windows Phone SDK is marked `selected`
2. `appc ti config windows.wpsdk.selectedVersion 10.0` 
3. `appc ti info -p windows -json` and see if Windows 10.0 Phone SDK is marked `selected`

*windows.sdk.selectedVersion*

1. `appc ti info -p windows -json` and see which Windows SDK is marked `selected`
2. `appc ti config windows.sdk.selectedVersion 10.0` 
3. `appc ti info -p windows -json` and see if Windows 10.0 SDK is marked `selected`
