### PR TITLE
TIMOB-23895 TIMOB-23878 Improve CLI log message

### DIFF
--- a/cli/commands/_build/config/deviceID.js
+++ b/cli/commands/_build/config/deviceID.js
@@ -58,9 +58,13 @@ module.exports = function configOptionDeviceID(order) {
 		callback(null, value);
 	}
 
+	var sdkTarget   = this.getWindowsSDKTarget(),
+		isWindows10 = sdkTarget ? sdkTarget.startsWith('10.0') : false,
+		targetName  = isWindows10 ? 'Windows 10 Mobile' : 'Windows Phone';
+
 	return {
 		abbr: 'C',
-		desc: __('the Windows Phone device or emulator udid to launch the app on; only applicable when target is %s or %s', 'wp-emulator'.cyan, 'wp-device'.cyan),
+		desc: __('the %s device or emulator udid to launch the app on; only applicable when target is %s or %s', targetName, 'wp-emulator'.cyan, 'wp-device'.cyan),
 		hint: 'udid',
 		order: order,
 		prompt: function (callback) {
@@ -71,8 +75,8 @@ module.exports = function configOptionDeviceID(order) {
 				// this shouldn't happen
 				throw new Error(
 					cli.argv.target === 'wp-emulator'
-						? __('No Windows Phone emulators found')
-						: __('No Windows Phone devices found')
+						? __('No %s emulators found', targetName)
+						: __('Unable to find any devices. Please plug in an %s device, then try again.', targetName)
 				);
 			}
 


### PR DESCRIPTION
[TIMOB-23895](https://jira.appcelerator.org/browse/TIMOB-23895)
[TIMOB-23878](https://jira.appcelerator.org/browse/TIMOB-23878)

When target equals `wp-device` and no devices are connected,

- `--wpsdk 8.1` ... `Unable to find any devices. Please plug in an Windows Phone device, then try again.`
- `--wpsdk 10.0` ...  `Unable to find any devices. Please plug in an Windows 10 Mobile device, then try again.`

When building module,

- Log confirmation of all of the architectures being built rather than just the ones being skipped
- Log the architectures in an easier to understand format, such as `Building <solution> for Windows10.ARM Release`
- If the timodule specifies a certain SDK version, log information regarding that such as `targetSdkVersion: 10.0.10586.0`
- Log the zip location so a user can find the packaged module easily