### PR TITLE
[TIMOB-23930] ScrollView content size should be SIZE

### DIFF
--- a/Source/UI/src/ScrollView.cpp
+++ b/Source/UI/src/ScrollView.cpp
@@ -9,6 +9,8 @@
 #include "TitaniumWindows/UI/ScrollView.hpp"
 #include "TitaniumWindows/UI/View.hpp"
 
+using namespace Windows::UI::Xaml;
+
 namespace TitaniumWindows
 {
 	namespace UI
@@ -82,10 +84,15 @@ namespace TitaniumWindows
 
 			contentView__.SetProperty("top", get_context().CreateNumber(0));
 			contentView__.SetProperty("left", get_context().CreateNumber(0));
-			contentView__.SetProperty("width", get_context().CreateString(Titanium::UI::Constants::to_string(Titanium::UI::LAYOUT::FILL)));
-			contentView__.SetProperty("height", get_context().CreateString(Titanium::UI::Constants::to_string(Titanium::UI::LAYOUT::FILL)));
+			contentView__.SetProperty("width", get_context().CreateString(Titanium::UI::Constants::to_string(Titanium::UI::LAYOUT::SIZE)));
+			contentView__.SetProperty("height", get_context().CreateString(Titanium::UI::Constants::to_string(Titanium::UI::LAYOUT::SIZE)));
 
 			auto content = contentView__.GetPrivate<TitaniumWindows::UI::View>();
+			scroll_viewer__->SizeChanged += ref new SizeChangedEventHandler([this, content](Platform::Object^ sender, SizeChangedEventArgs^ e) {
+				const auto component = content->getComponent();
+				component->MinHeight = e->NewSize.Height;
+				component->MinWidth  = e->NewSize.Width;
+			});
 			scroll_viewer__->Content = content->getComponent();
 
 			Titanium::UI::ScrollView::setLayoutDelegate<ScrollViewLayoutDelegate>(this, contentView__);


### PR DESCRIPTION
[TIMOB-23930](https://jira.appcelerator.org/browse/TIMOB-23930)

ScrollView content should `FILL` the ScrollView view, but it should extend its size when child components needs larger size.

```javascript
var win = Ti.UI.createWindow({
    backgroundColor: 'green'
});

function createRow(i) {
    var row = Ti.UI.createView({
        backgroundColor: 'blue',
        borderColor: '#bbb',
        borderWidth: 1,
        width: '100%', height: 70,
        top: 0, left: 0
    });
    var inputTextField = Ti.UI.createTextField({
        hintText: 'Enter value ' + i,
        keyboardType: Ti.UI.KEYBOARD_NUMBERS_PUNCTUATION,
        top: 10, left: '10%',
        width: '80%', height: 60
    });
    row.add(inputTextField);
    return row;
}

var scrollView = Ti.UI.createScrollView({
    bottom: 120,
    layout: 'vertical',
});

for (var i = 0; i <= 20; i++) {
    var row = createRow(i);
    scrollView.add(row);
}

win.add(scrollView);

var label = Ti.UI.createLabel({
    backgroundColor: 'darkgray',
    text: 'Your advert here',
    textAlign: 'center',
    bottom: 0,
    width: Titanium.UI.FILL,
    height: 100
});
win.add(label);
win.open();
```

ScrollView should also fill the requirements described in [TIMOB-23350](https://jira.appcelerator.org/browse/TIMOB-23350) and [TIMOB-23384](https://jira.appcelerator.org/browse/TIMOB-23384).

```javascript
var win = Ti.UI.createWindow(),
    scrollView = Ti.UI.createScrollView({
        layout: "vertical",
        backgroundColor: 'red'
    }),
    view = Ti.UI.createView({
        backgroundColor: 'orange',
        top: 10,
        left: 10,
        height: Ti.UI.SIZE,
        width: Ti.UI.SIZE
    }),
    label = Ti.UI.createLabel({
        left: 10,
        right: 10,
        color: "green",
        backgroundColor: 'yellow',
        text: "this is test text"
    });
view.add(label);
scrollView.add(view);
win.add(scrollView);
win.open();
```
