### PR TITLE
[6_0_X] [TIMOB-24019] ListView should keep "original" data even when filtered

### DIFF
--- a/Examples/NMocha/src/Assets/ti.ui.listview.test.js
+++ b/Examples/NMocha/src/Assets/ti.ui.listview.test.js
@@ -600,4 +600,58 @@ describe('Titanium.UI.ListView', function () {
 
 		finish();
 	});
+
+	// Making sure sections data is saved even when it's filtered (TIMOB-24019)
+	it('TIMOB-24019', function (finish) {
+	    var win = Ti.UI.createWindow({ backgroundColor: 'green' });
+	    var listView = Ti.UI.createListView({ width: Ti.UI.FILL, height: Ti.UI.FILL, caseInsensitiveSearch: true });
+
+	    var fruitSection = Ti.UI.createListSection({ headerTitle: 'Fruits' });
+	    var fruitDataSet = [
+			{ properties: { title: 'Apple', searchableText: 'Apple' } },
+			{ properties: { title: 'Banana', searchableText: 'Banana' } },
+	    ];
+	    fruitSection.setItems(fruitDataSet);
+
+	    var vegSection = Ti.UI.createListSection({ headerTitle: 'Vegetables' });
+	    var vegDataSet = [
+			{ properties: { title: 'Carrots', searchableText: 'Carrots' } },
+			{ properties: { title: 'Potatoes', searchableText: 'Potatoes' } },
+	    ];
+	    vegSection.setItems(vegDataSet);
+
+	    listView.sections = [fruitSection, vegSection];
+
+	    win.addEventListener('open', function () {
+	        should(listView.sectionCount).be.eql(2);
+	        should(listView.sections[0].items.length).be.eql(2);
+	        should(listView.sections[0].items[0].properties.title).be.eql('Apple');
+	        should(listView.sections[0].items[1].properties.title).be.eql('Banana');
+	        should(listView.sections[1].items.length).be.eql(2);
+	        should(listView.sections[1].items[0].properties.title).be.eql('Carrots');
+	        should(listView.sections[1].items[1].properties.title).be.eql('Potatoes');
+
+	        // This should show 'Apple' and 'Potatoes'
+	        listView.searchText = 'p';
+
+	        setTimeout(function () {
+	            // Make sure ListView reserves original data
+	            should(listView.sectionCount).be.eql(2);
+	            should(listView.sections[0].items.length).be.eql(2);
+	            should(listView.sections[0].items[0].properties.title).be.eql('Apple');
+	            should(listView.sections[0].items[1].properties.title).be.eql('Banana');
+	            should(listView.sections[1].items.length).be.eql(2);
+	            should(listView.sections[1].items[0].properties.title).be.eql('Carrots');
+	            should(listView.sections[1].items[1].properties.title).be.eql('Potatoes');
+
+	            win.close();
+	            finish();
+	        }, 2000);
+	    });
+
+	    win.add(listView);
+	    win.open();
+	});
+
+
 });

--- a/Examples/NMocha/src/Assets/ti.ui.searchbar.test.js
+++ b/Examples/NMocha/src/Assets/ti.ui.searchbar.test.js
@@ -7,6 +7,7 @@
 var should = require('./should');
 
 describe('Ti.UI.SearchBar', function () {
+	this.timeout(10000);
 	it('TableView', function (finish) {
 		var win = Ti.UI.createWindow();
 		var sb = Titanium.UI.createSearchBar({

--- a/Source/TitaniumKit/include/Titanium/UI/TableViewSection.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/TableViewSection.hpp
@@ -104,6 +104,16 @@ namespace Titanium
 
 			/*!
 			  @method
+			  @abstract getItemAt
+			  @discussion Returns a row in this section. This method is for compatibility with ListModel
+			*/
+			virtual std::shared_ptr<TableViewRow> getItemAt(const uint32_t& index) TITANIUM_NOEXCEPT
+			{
+				return rowAtIndex(index);
+			}
+
+			/*!
+			  @method
 			  @abstract update
 			  @discussion Update a table view row from this section by index.
 			*/

--- a/Source/UI/src/ListView.cpp
+++ b/Source/UI/src/ListView.cpp
@@ -102,7 +102,7 @@ namespace TitaniumWindows
 
 					const auto result  = model__->searchRowBySelectedIndex(selectedIndex);
 					if (result.found) {
-						const auto section = model__->getSectionAtIndex(result.sectionIndex);
+						const auto section = model__->getFilteredSectionAtIndex(result.sectionIndex);
 						auto this_object = get_object();
 
 						TITANIUM_ASSERT(section->get_items().size() > static_cast<std::uint32_t>(result.rowIndex));


### PR DESCRIPTION
[TIMOB-24019](https://jira.appcelerator.org/browse/TIMOB-24019)

- `ListView` `sections` and `sectionCount` should keep its original data even when it's filtered
- `ListView` `itemclick` event should return "original" position even when it's filtered

For instance when you search "p" on following app and then click on the second item (`Potatoes`), it should return its original position (`sectionIndex=1`, `itemIndex=1`).

```javascript
var win = Ti.UI.createWindow();
var win = Ti.UI.createWindow({ backgroundColor: 'green', layout: 'vertical' });
var searchText = Ti.UI.createTextField({ width: Ti.UI.FILL, height: '10%' });

var listView = Ti.UI.createListView({ width: Ti.UI.FILL, height: '90%', caseInsensitiveSearch: true });
var sections = [];

var fruitSection = Ti.UI.createListSection({ headerTitle: 'Fruits' });
var fruitDataSet = [
    { properties: { title: 'Apple', searchableText: 'Apple' } },
    { properties: { title: 'Banana', searchableText: 'Banana' } },
];
fruitSection.setItems(fruitDataSet);
sections.push(fruitSection);

var vegSection = Ti.UI.createListSection({ headerTitle: 'Vegetables' });
var vegDataSet = [
    { properties: { title: 'Carrots', searchableText: 'Carrots' } },
    { properties: { title: 'Potatoes', searchableText: 'Potatoes' } },
];
vegSection.setItems(vegDataSet);
sections.push(vegSection);

listView.sections = sections;

searchText.addEventListener('change', function () {
    listView.searchText = searchText.value;
});

listView.addEventListener('itemclick', function (evt) {
    var clickItemIndex = evt.itemIndex;
    var clickSectionIndex = evt.sectionIndex;

    alert('sectionCount=' + listView.sectionCount + ' section=' + clickSectionIndex + ' item=' + clickItemIndex + '\r\n' + listView.sections[clickSectionIndex].items[clickItemIndex].properties.title);
});

win.add(searchText);
win.add(listView);
win.open();
```