### PR TITLE
[TIMOB-23952] Analytics.featureEvent should be able to send undefined

### DIFF
--- a/Source/TitaniumKit/src/analytics.js
+++ b/Source/TitaniumKit/src/analytics.js
@@ -76,10 +76,6 @@ function validateFeatureEvent(obj, level) {
 		Ti.API.warn('Feature event exceeds ' + FEATURE_MAX_LEVELS + ' level limit.');
 		return false;
 	}
-	if (!(obj instanceof Object)) {
-		Ti.API.warn('Feature event data object must be serializable as JSON.');
-		return false;
-	}
 	if (level == 0 && JSON.stringify(obj).length > FEATURE_MAX_SIZE) {
 		Ti.API.warn('Feature event data object exceeds ' + FEATURE_MAX_SIZE + ' size limit.');
 		return false;
@@ -194,6 +190,7 @@ Analytics.prototype.createBackgroundEvent = function backgroundEvent() {
  * @private
  */
 Analytics.prototype.createFeatureEvent = function featureEvent(name, data) {
+	data = data || {};
 	if (validateFeatureEvent(data, 0)) {
 		data['eventName'] = name;
 		this.createEvent(EVENT_APP_FEATURE, data);


### PR DESCRIPTION
[TIMOB-23952](https://jira.appcelerator.org/browse/TIMOB-23952)

`Ti.Analytics.featureEvent` should be able to send `undefined` data. Basically reverts what we have done in #875 
