### PR TITLE
[TIMOB-24103] TabGroup disappears on closing new Window

### DIFF
--- a/Source/UI/src/Window.cpp
+++ b/Source/UI/src/Window.cpp
@@ -218,7 +218,13 @@ namespace TitaniumWindows
 
 				} else {
 					window_stack__.pop_back();
-					const auto next_window = std::dynamic_pointer_cast<Window>(window_stack__.back());
+					auto next_window = std::dynamic_pointer_cast<Window>(window_stack__.back());
+					if (next_window->tab__) {
+						const auto tab = next_window;
+						window_stack__.pop_back();
+						next_window = std::dynamic_pointer_cast<Window>(window_stack__.back());
+						tab->open(nullptr);
+					}
 
 					if (is_last_window) {
 						ExitApp(get_context());


### PR DESCRIPTION
[TIMOB-24103](https://jira.appcelerator.org/browse/TIMOB-24103)

```javascript
var win = Ti.UI.createWindow({ backgroundColor: 'green'});
var win2 = Ti.UI.createWindow({ backgroundColor: 'pink'});
var tabGroup = Ti.UI.createTabGroup();
var acceptanceTab = Titanium.UI.createTab({
	title : 'Acceptance',
	window : win
});
var aboutTab = Titanium.UI.createTab({
	title : 'About'
});
tabGroup.addTab(acceptanceTab);
tabGroup.addTab(aboutTab);
var tableData = [ {title: 'Apples'}, {title: 'Bananas'}, {title: 'Carrots'}, {title: 'Potatoes'} ];
var table = Ti.UI.createTableView({
  data: tableData
});
win.add(table);
table.addEventListener('click', function(){
	win2.open();
});
tabGroup.open();
```