### PR TITLE
[TIMOB-24111] Parity issue in TableView touch events

### DIFF
--- a/Source/TitaniumKit/include/Titanium/UI/ListModel.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/ListModel.hpp
@@ -25,6 +25,8 @@ namespace Titanium
 			bool found { false };
 			std::uint32_t sectionIndex { 0 };
 			std::uint32_t rowIndex { 0 };
+			double x { 0 };
+			double y { 0 };
 		};
 
 		/*!

--- a/Source/UI/include/TitaniumWindows/UI/TableView.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/TableView.hpp
@@ -85,6 +85,8 @@ namespace TitaniumWindows
 			void bindCollectionViewSource();
 			void unbindCollectionViewSource();
 
+			void fireTableViewRowEvent(const std::string&, const Titanium::UI::ListRowSearchResult&) TITANIUM_NOEXCEPT;
+
 			::Platform::Collections::Vector<Windows::UI::Xaml::UIElement^>^ createUIElementsForSection(const std::uint32_t& sectionIndex) TITANIUM_NOEXCEPT;
 			Windows::UI::Xaml::Controls::ListViewHeaderItem^ createDefaultHeader(const std::shared_ptr<Titanium::UI::TableViewSection>& seciton = nullptr);
 			Windows::UI::Xaml::Controls::ListViewHeaderItem^ createDefaultFooter(const std::shared_ptr<Titanium::UI::TableViewSection>& seciton = nullptr);
@@ -102,9 +104,9 @@ namespace TitaniumWindows
 			std::uint32_t getRowIndexInCollectionView(const std::shared_ptr<Titanium::UI::TableViewSection>& section, const std::uint32_t& rowIndex) TITANIUM_NOEXCEPT;
 			void setTableHeader();
 			void setTableFooter();
-
 			void registerScrollEvent();
 			void registerScrollendEvent();
+			Titanium::UI::ListRowSearchResult searchRowBySelectedRow(::Platform::Object^);
 
 			Windows::UI::Xaml::Controls::Grid^ parent__;
 			Windows::UI::Xaml::Controls::ListView^ tableview__;
@@ -117,7 +119,12 @@ namespace TitaniumWindows
 			Windows::Foundation::EventRegistrationToken loaded_event__;
 			Windows::Foundation::EventRegistrationToken scroll_event__;
 			Windows::Foundation::EventRegistrationToken scrollend_event__;
-			
+			Windows::Foundation::EventRegistrationToken touchstart_event__;
+			Windows::Foundation::EventRegistrationToken touchend_event__;
+			Windows::Foundation::EventRegistrationToken singletap_event__;
+			Windows::Foundation::EventRegistrationToken doubletap_event__;
+			Windows::Foundation::EventRegistrationToken longpress_event__;
+
 			double oldScrollPosX__ { -1 };
 			double oldScrollPosY__ { -1 };
 #pragma warning(push)

--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -1241,7 +1241,7 @@ namespace TitaniumWindows
 					event_delegate->fireEvent("touchmove", eventArgs);
 				});
 			} else if (event_name == "touchstart") {
-				component->PointerPressed += ref new PointerEventHandler([this](Platform::Object^ sender, PointerRoutedEventArgs^ e) {
+				touchstart_event__ = component->PointerPressed += ref new PointerEventHandler([this](Platform::Object^ sender, PointerRoutedEventArgs^ e) {
 					const auto component = safe_cast<FrameworkElement^>(sender);
 					const auto point = Windows::UI::Input::PointerPoint::GetCurrentPoint(e->Pointer->PointerId);
 					fireSimplePositionEvent("touchstart", component, point->Position);
@@ -1255,10 +1255,10 @@ namespace TitaniumWindows
 					const auto point = Windows::UI::Input::PointerPoint::GetCurrentPoint(e->Pointer->PointerId);
 					fireSimplePositionEvent("touchcancel", component, point->Position);
 				});
-				component->PointerCanceled    += cancel_handler;
-				component->PointerCaptureLost += cancel_handler;
+				touchcancel_event__ = component->PointerCanceled    += cancel_handler;
+				touchcancel_lost_event__ = component->PointerCaptureLost += cancel_handler;
 			} else if (event_name == "touchend") {
-				component->PointerReleased += ref new PointerEventHandler([this](Platform::Object^ sender, PointerRoutedEventArgs^ e) {
+				touchend_event__ = component->PointerReleased += ref new PointerEventHandler([this](Platform::Object^ sender, PointerRoutedEventArgs^ e) {
 					const auto component = safe_cast<FrameworkElement^>(sender);
 					const auto point = Windows::UI::Input::PointerPoint::GetCurrentPoint(e->Pointer->PointerId);
 					fireSimplePositionEvent("touchend", component, point->Position);


### PR DESCRIPTION
*NOT READY FOR MERGE*

This PR is not ready for merge. 

[TIMOB-24111](https://jira.appcelerator.org/browse/TIMOB-24111)

This is parity issue in `TableView` touch related events.

- `click` event should contain `detail`, `index`, `row`, `rowData`, `searchMode` and `section`.
- `touchstart`, `touchend`, `singletap`, `doubletap`, `longpress` should return same properties with `click` event.
- `x` and `y` may be considered optional.

But it turns out that touch events other than `click` does not return any row data, just because platform events (`Tapped`, `Holding` etc) does not return any row-related data such as row index. I tried to get row index by calculating event position but had no luck. Pushing this for review to see if we can get better way to do this from community.
