### PR TITLE
[TIMOB-24088] Missing coordinates for ScrollView.scroll

### DIFF
--- a/Source/UI/src/ScrollView.cpp
+++ b/Source/UI/src/ScrollView.cpp
@@ -166,16 +166,19 @@ namespace TitaniumWindows
 			} else if (event_name == "scroll") {
 				scroll_event__ = scroll_viewer__->ViewChanging += ref new Windows::Foundation::EventHandler<Windows::UI::Xaml::Controls::ScrollViewerViewChangingEventArgs ^>(
 					[=](Platform::Object ^sender, Windows::UI::Xaml::Controls::ScrollViewerViewChangingEventArgs ^args) {
-						auto eventArgs = get_context().CreateObject();
-						auto dragging = args->FinalView->HorizontalOffset != 0 || args->FinalView->VerticalOffset != 0;
-						auto zoom = args->FinalView->ZoomFactor;
-						auto zooming = zoom != 1;
-						eventArgs.SetProperty("dragging", get_context().CreateBoolean(dragging)); // test this
-						eventArgs.SetProperty("zooming", get_context().CreateBoolean(zooming)); // test this
-						eventArgs.SetProperty("curZoomScale", get_context().CreateNumber(zoom));
-						fireEvent("scroll", eventArgs);
-					}
-				);
+					const auto ctx = get_context();
+					auto eventArgs = ctx.CreateObject();
+					auto dragging = args->FinalView->HorizontalOffset != 0 || args->FinalView->VerticalOffset != 0;
+					auto zoom = args->FinalView->ZoomFactor;
+					auto zooming = zoom != 1;
+
+					eventArgs.SetProperty("x", ctx.CreateNumber(args->FinalView->HorizontalOffset));
+					eventArgs.SetProperty("y", ctx.CreateNumber(args->FinalView->VerticalOffset));
+					eventArgs.SetProperty("dragging", ctx.CreateBoolean(dragging)); // test this
+					eventArgs.SetProperty("zooming", ctx.CreateBoolean(zooming)); // test this
+					eventArgs.SetProperty("curZoomScale", ctx.CreateNumber(zoom));
+					fireEvent("scroll", eventArgs);
+				});
 			} else if (event_name == "scrollend" || event_name == "scrollEnd") {
 				scrollend_event__ = scroll_viewer__->ViewChanged += ref new Windows::Foundation::EventHandler<Windows::UI::Xaml::Controls::ScrollViewerViewChangedEventArgs ^>(
 					[=](Platform::Object ^sender, Windows::UI::Xaml::Controls::ScrollViewerViewChangedEventArgs ^args) {

--- a/apidoc/Titanium/UI/ScrollView.yml
+++ b/apidoc/Titanium/UI/ScrollView.yml
@@ -48,4 +48,20 @@ methods:
     platforms: [windowsphone]
   - name: setShowVerticalScrollIndicator
     platforms: [windowsphone]
-
+events:
+  - name: scroll
+    platforms: [windowsphone]
+  - name: scrollend
+    platforms: [windowsphone]
+  - name: scrollEnd
+    platforms: [windowsphone]
+  - name: scale
+    platforms: [windowsphone]
+  - name: dragstart
+    platforms: [windowsphone]
+  - name: dragStart
+    platforms: [windowsphone]
+  - name: dragend
+    platforms: [windowsphone]
+  - name: dragEnd
+    platforms: [windowsphone]


### PR DESCRIPTION
[TIMOB-24088](https://jira.appcelerator.org/browse/TIMOB-24088)

- `x` and `y` properties are missing in `ScrollView.scroll` event.

```js
var win = Ti.UI.createWindow({ backgroundColor: 'green' });

var scrollView = Ti.UI.createScrollView({
    showVerticalScrollIndicator: true,
    showHorizontalScrollIndicator: true,
    height: '80%',
    width: '80%'
});
var view = Ti.UI.createView({
    backgroundColor: '#336699',
    borderRadius: 10,
    top: 10,
    height: 2000,
    width: 1000
});
scrollView.add(view);
win.add(scrollView);

var offset_half = view.height * 0.5;

scrollView.addEventListener('scroll', function (e) {
    Ti.API.info('x=' + e.x + ' y=' + e.y);
    // let's change view color when 50% of the view is scrolled
    if (e.y > offset_half) {
        view.backgroundColor = 'blue';
    }
});
win.open();
```