### PR TITLE
Check duplication for native events and types

### DIFF
--- a/cli/commands/_build/copy.js
+++ b/cli/commands/_build/copy.js
@@ -503,8 +503,8 @@ function copyResources(next) {
 				var from = jsFiles[id],
 					to = path.join(this.buildTargetAssetsDir, id),
 					t_ = this;
-				t_.native_types  = t_.native_types  || [];
-				t_.native_events = t_.native_events || [];
+				t_.native_types  = t_.native_types  || {};
+				t_.native_events = t_.native_events || {};
 
 				// Look for native requires here
 				var fromContent = fs.readFileSync(from, {encoding: 'utf8'});
@@ -524,7 +524,7 @@ function copyResources(next) {
 						var node_value = node.args[0].getValue();
 						if (hasWindowsAPI(node_value)) {
 							t_.logger.info("Detected native API reference: " + node_value);
-							t_.native_types.unshift({name:node_value});
+							t_.native_types[node_value] = {name:node_value};
 						}
 					}
 					if (node instanceof UglifyJS.AST_Call && node.expression.property == 'addEventListener') {
@@ -551,7 +551,7 @@ function copyResources(next) {
 									type:detectedConstructorType,
 									signature:event_name + '_' + detectedConstructorType.replace(/\./g, '_')
 								};
-								t_.native_events.push(native_event);
+								t_.native_events[native_event.signature] = native_event;
 								t_.logger.info('Detected native API event: ' + native_event.name + ' for ' + detectedConstructorType);
 							}
 						}

--- a/cli/lib/stub.js
+++ b/cli/lib/stub.js
@@ -273,8 +273,8 @@ exports.generate = function generate(dest, modules, native_types, native_events,
 	var dest_Native    = path.join(dest, 'Native'),
 		dest_Hyperloop = path.join(dest, 'TitaniumWindows_Hyperloop');
 
-	native_types  = native_types  || [];
-	native_events = native_events || [];
+	native_types  = native_types  || {};
+	native_events = native_events || {};
 
 	var platform = 'win10';
 	if (targetPlatformSdkVersion === '8.1') {
@@ -288,7 +288,7 @@ exports.generate = function generate(dest, modules, native_types, native_events,
 	async.parallel([
 		function(callback) {
 			// generate native types only when hyperloop is used
-			if (native_types.length === 0) {
+			if (Object.keys(native_types).length === 0) {
 				return callback();
 			}
 			async.series([

--- a/templates/build/Native/src/RequireHook.cpp.ejs
+++ b/templates/build/Native/src/RequireHook.cpp.ejs
@@ -68,8 +68,8 @@ namespace TitaniumWindows_Native
 <% for(var i=0; i<native_modules.length; i++) { -%>
 		names->Append("<%= native_modules[i].name %>");
 <% } -%>
-<% for(var i=0; i<native_types.length; i++) { -%>
-		names->Append("<%= native_types[i].name %>");
+<% for(var key in native_types) { -%>
+		names->Append("<%= native_types[key].name %>");
 <% } -%>
 		//// INSERT SUPPORTED NATIVE MODULE NAMES END
 

--- a/templates/build/TitaniumWindows_Hyperloop/src/TypeHelper.cs.ejs
+++ b/templates/build/TitaniumWindows_Hyperloop/src/TypeHelper.cs.ejs
@@ -27,17 +27,17 @@ namespace TitaniumWindows_Hyperloop
     public sealed class EventHelper
     {
 
-<% for(var i=0; i<native_events.length; i++) { -%>
-        public static Event add_<%= native_events[i].signature %>(object target)
+<% for(var key in native_events) { -%>
+        public static Event add_<%= native_events[key].signature %>(object target)
         {
-            Event evt = new Event("<%= native_events[i].name %>", target);
-            ((<%= native_events[i].type %>)target).<%= native_events[i].name %> += evt.HandleEvent;
+            Event evt = new Event("<%= native_events[key].name %>", target);
+            ((<%= native_events[key].type %>)target).<%= native_events[key].name %> += evt.HandleEvent;
             return evt;
         }
 
-        public static void remove_<%= native_events[i].signature %>(object evt, object target)
+        public static void remove_<%= native_events[key].signature %>(object evt, object target)
         {
-            ((<%= native_events[i].type %>)target).<%= native_events[i].name %> -= ((Event)evt).HandleEvent;
+            ((<%= native_events[key].type %>)target).<%= native_events[key].name %> -= ((Event)evt).HandleEvent;
         }
 <% } -%>
     }
@@ -47,15 +47,29 @@ namespace TitaniumWindows_Hyperloop
     {
         private static Dictionary<string, string> KnownTypes = new Dictionary<string, string>()
             {
+                { "Object",           typeof(System.Object).AssemblyQualifiedName },
+                { "String",           typeof(System.String).AssemblyQualifiedName },
                 { "System.Object",    typeof(System.Object).AssemblyQualifiedName },
                 { "System.String",    typeof(System.String).AssemblyQualifiedName },
                 { "System.Exception", typeof(System.Exception).AssemblyQualifiedName },
+                { "System.Double",    typeof(System.Double).AssemblyQualifiedName },
+                { "System.SByte",     typeof(System.SByte).AssemblyQualifiedName },
+                { "System.Byte",      typeof(System.Byte).AssemblyQualifiedName },
+                { "System.Single",    typeof(System.Single).AssemblyQualifiedName },
+                { "System.Decimal",   typeof(System.Decimal).AssemblyQualifiedName },
+                { "System.Int64",     typeof(System.Int64).AssemblyQualifiedName },
+                { "System.Int32",     typeof(System.Int32).AssemblyQualifiedName },
+                { "System.Int16",     typeof(System.Int16).AssemblyQualifiedName },
+                { "System.UInt64",    typeof(System.UInt64).AssemblyQualifiedName },
+                { "System.UInt32",    typeof(System.UInt32).AssemblyQualifiedName },
+                { "System.UInt16",    typeof(System.UInt16).AssemblyQualifiedName },
+                { "System.Boolean",   typeof(System.Boolean).AssemblyQualifiedName }
             };
 
         private static Dictionary<string, string> AssemblyQualifiedName = new Dictionary<string, string>()
             {
-<% for(var i=0; i<native_types.length; i++) { -%>
-                { "<%= native_types[i].name %>", typeof(<%= native_types[i].name %>).AssemblyQualifiedName },
+<% for(var key in native_types) { -%>
+                { "<%= native_types[key].name %>", typeof(<%= native_types[key].name %>).AssemblyQualifiedName },
 <% } -%>
             };
 


### PR DESCRIPTION
Fixes for Hyperloop.

- Fix compile error when you have multiple native `require` and events with same name
- Add some more builtin number types

```javascript
require('Windows.UI.Xaml.Input.TappedRoutedEventArgs');
require('Windows.UI.Xaml.Input.TappedRoutedEventArgs');

var win = Ti.UI.createWindow({ backgroundColor: 'green' }),
    Button = require('Windows.UI.Xaml.Controls.Button'),
    button = new Button();

button.Content = "PUSH";
button.addEventListener('Tapped', function (e) {
    alert('Tapped');
});
button.addEventListener('Tapped', function (e) {
    Ti.API.info('This should not cause compile error');
});

win.add(button);
win.open();
```
