### PR TITLE
[TIMOB-20544] Align method name for Ti.Media.AudioRecorder

### DIFF
--- a/Source/TitaniumKit/include/Titanium/MediaModule.hpp
+++ b/Source/TitaniumKit/include/Titanium/MediaModule.hpp
@@ -455,6 +455,7 @@ namespace Titanium
 		TITANIUM_FUNCTION_DEF(takeScreenshot);
 		TITANIUM_FUNCTION_DEF(vibrate);
 		TITANIUM_FUNCTION_DEF(requestAuthorization);
+		TITANIUM_FUNCTION_DEF(requestRecorderPermission);
 		TITANIUM_FUNCTION_DEF(hasCameraPermissions);
 		TITANIUM_FUNCTION_DEF(requestCameraPermissions);
 		TITANIUM_FUNCTION_DEF(createAudioPlayer);

--- a/Source/TitaniumKit/src/MediaModule.cpp
+++ b/Source/TitaniumKit/src/MediaModule.cpp
@@ -336,6 +336,7 @@ namespace Titanium
 		TITANIUM_ADD_FUNCTION(MediaModule, takeScreenshot);
 		TITANIUM_ADD_FUNCTION(MediaModule, vibrate);
 		TITANIUM_ADD_FUNCTION(MediaModule, requestAuthorization);
+		TITANIUM_ADD_FUNCTION(MediaModule, requestRecorderPermission);
 		TITANIUM_ADD_FUNCTION(MediaModule, hasCameraPermissions);
 		TITANIUM_ADD_FUNCTION(MediaModule, requestCameraPermissions);
 		TITANIUM_ADD_FUNCTION(MediaModule, createAudioPlayer);
@@ -1253,6 +1254,13 @@ namespace Titanium
 	}
 
 	TITANIUM_FUNCTION(MediaModule, requestAuthorization)
+	{
+		ENSURE_OBJECT_AT_INDEX(callback, 0);
+		requestAuthorization(callback);
+		return get_context().CreateUndefined();
+	}
+
+	TITANIUM_FUNCTION(MediaModule, requestRecorderPermission)
 	{
 		ENSURE_OBJECT_AT_INDEX(callback, 0);
 		requestAuthorization(callback);


### PR DESCRIPTION
[TIMOB-20544](https://jira.appcelerator.org/browse/TIMOB-20544)

- This defines `Ti.Media.requestRecorderPermission()` as alias of `Ti.Media.requestAuthorization()`
- On Windows, `requestRecorderPermission` basically does nothing because there's no equivalent function in WinRT and recorder permission should be defined in `tiapp.xml` instead.

```js
// Should show "function"
alert(typeof Ti.Media.requestRecorderPermission);
```