### PR TITLE
[TIMOB-20286] Expose Ti.UI.View.getViewById method

### DIFF
--- a/Source/TitaniumKit/include/Titanium/UI/View.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/View.hpp
@@ -148,6 +148,13 @@ namespace Titanium
 			*/
 			virtual void add(const JSObject&) TITANIUM_NOEXCEPT;
 
+			/*!
+			  @method
+			  @abstract get_children
+			  @discussion Returns array of this view's child views
+			*/
+			virtual std::vector<std::shared_ptr<Titanium::UI::View>> get_children() const TITANIUM_NOEXCEPT;
+
 			View(const JSContext&, const std::string& apiName = "Titanium.UI.View") TITANIUM_NOEXCEPT;
 
 			virtual ~View() TITANIUM_NOEXCEPT;  //= default;
@@ -286,6 +293,7 @@ namespace Titanium
 			TITANIUM_FUNCTION_DEF(setViewShadowColor);
 			TITANIUM_FUNCTION_DEF(getViewShadowOffset);
 			TITANIUM_FUNCTION_DEF(setViewShadowOffset);
+			TITANIUM_FUNCTION_DEF(getViewById);
 			TITANIUM_FUNCTION_DEF(getVisible);
 			TITANIUM_FUNCTION_DEF(setVisible);
 			TITANIUM_FUNCTION_DEF(getHorizontalWrap);


### PR DESCRIPTION
[TIMOB-20286](https://jira.appcelerator.org/browse/TIMOB-20286)

Expose `Ti.UI.View.getViewById` to find a child view by its `id`
Basically based on a logic done in https://github.com/appcelerator/titanium_mobile/pull/8677

```js
var win = Ti.UI.createWindow({
    backgroundColor: '#fff'
});

var container = Ti.UI.createView({
    width: 300,
    height: 300,
    backgroundColor: 'red'
});

var btn = Ti.UI.createButton({
    title: 'Get view by ID',
    id: 'myButton'
});

btn.addEventListener('click', function () {
    var myButton = win.getViewById('myButton');

    // If no button is found, it will return null
    if (myButton) {
        myButton.setTitle('Worked! ');
    }
});

container.add(btn);
win.add(container);
win.open();
```