### PR TITLE
[TIMOB-23613] Attempt to split encryption process

### DIFF
--- a/cli/commands/_build/encrypt.js
+++ b/cli/commands/_build/encrypt.js
@@ -54,7 +54,7 @@ function processEncryptionByChunk(next, jsfiles) {
 	var titaniumPrep = 'titanium_prep.win32.exe';
 
 	// encrypt the javascript
-	var args = [this.tiapp.guid, this.tiapp.id, this.buildTargetAssetsDir].concat(jsfiles),
+	var args = [this.tiapp.guid, this.titanium_prep_seed, this.buildTargetAssetsDir].concat(jsfiles),
 		opts = {
 			env: appc.util.mix({}, process.env, this.jdkInfo ? {
 				// we force the JAVA_HOME so that titanium_prep doesn't complain
@@ -78,10 +78,13 @@ function processEncryptionByChunk(next, jsfiles) {
 					});
 				}
 
-				var mainCPPPath = path.join(this.buildDir, 'src', 'main.cpp'),
-					mainCPPContents = fs.readFileSync(mainCPPPath, 'utf-8')
-						.replace(/TitaniumWindows::Application\(\);/, 'TitaniumWindows::Application("' + out.trim() + '");');
-				fs.writeFileSync(mainCPPPath, mainCPPContents);
+				if (!this.titanium_prep_seed) {
+					this.titanium_prep_seed = '--Seed--' + out.trim();
+					var mainCPPPath = path.join(this.buildDir, 'src', 'main.cpp'),
+						mainCPPContents = fs.readFileSync(mainCPPPath, 'utf-8')
+							.replace(/TitaniumWindows::Application\(\);/, 'TitaniumWindows::Application("' + out.trim() + '");');
+					fs.writeFileSync(mainCPPPath, mainCPPContents);
+				}
 
 				done();
 			}.bind(this));


### PR DESCRIPTION
Relates to [TIMOB-23613](https://jira.appcelerator.org/browse/TIMOB-23613)

Attempt to split encryption process due to the issue around `spawn ENAMETOOLONG`.
This needs new `titanium_prep` because we need a way to specify encryption key for following commands. https://github.com/appcelerator/titanium_prep/pull/26
