### PR TITLE
[TIMOB-24263] Investigate crash on HttpClient

### DIFF
--- a/Examples/NMocha/src/Assets/app.js
+++ b/Examples/NMocha/src/Assets/app.js
@@ -43,9 +43,7 @@ require('./ti.internal.test');
 require('./ti.locale.test');
 require('./ti.map.test');
 require('./ti.network.test');
-if (!utilities.isWindows10()) {
 require('./ti.network.httpclient.test');
-}
 require('./ti.network.socket.tcp.test.js');
 require('./ti.platform.test');
 require('./ti.require.test');

--- a/Source/Network/src/HTTPClient.cpp
+++ b/Source/Network/src/HTTPClient.cpp
@@ -30,7 +30,6 @@ namespace TitaniumWindows
 		HTTPClient::~HTTPClient()
 		{
 			TITANIUM_LOG_DEBUG("TitaniumWindows::Network::HTTPClient::dtor");
-			abort();
 
 			filter__ = nullptr;
 			httpClient__ = nullptr;


### PR DESCRIPTION
DO NOT MERGE

[TIMOB-24263](https://jira.appcelerator.org/browse/TIMOB-24263)

We've been seeing that Windows 10 node on Jenkins tends to crash around UI tests (ListView etc) when we enable HttpClient test. I suspect something is leaking/blocking after use of HttpClient.
