### PR TITLE
[TIMOB-24268] Fix crash/freeze in HttpClient

### DIFF
--- a/Examples/NMocha/src/Assets/app.js
+++ b/Examples/NMocha/src/Assets/app.js
@@ -43,9 +43,7 @@ require('./ti.internal.test');
 require('./ti.locale.test');
 require('./ti.map.test');
 require('./ti.network.test');
-if (!utilities.isWindows10()) {
 require('./ti.network.httpclient.test');
-}
 require('./ti.network.socket.tcp.test.js');
 require('./ti.platform.test');
 require('./ti.require.test');

--- a/Source/Network/include/TitaniumWindows/Network/HTTPClient.hpp
+++ b/Source/Network/include/TitaniumWindows/Network/HTTPClient.hpp
@@ -37,7 +37,7 @@ namespace TitaniumWindows
 
 			HTTPClient(const JSContext&) TITANIUM_NOEXCEPT;
 
-			virtual ~HTTPClient();
+			virtual ~HTTPClient() = default;
 			HTTPClient(const HTTPClient&) = default;
 			HTTPClient& operator=(const HTTPClient&) = default;
 #ifdef TITANIUM_MOVE_CTOR_AND_ASSIGN_DEFAULT_ENABLE

--- a/Source/Network/include/TitaniumWindows/Network/HTTPClient.hpp
+++ b/Source/Network/include/TitaniumWindows/Network/HTTPClient.hpp
@@ -68,9 +68,6 @@ namespace TitaniumWindows
 			Windows::Web::Http::Filters::HttpBaseProtocolFilter^ filter__;
 			// httpClient__ - higher level HTTP client that provides WinRT API to HTTP sessions and communications
 			Windows::Web::Http::HttpClient^ httpClient__;
-			// cancellationTokenSource__ - HttpClient provides an asynchronous channel to handle HTTP reponses and
-			// errors. Cancellation tokens allow the current HTTP
-			concurrency::cancellation_token_source cancellationTokenSource__;
 			//  timeoutRegistrationToken__ - used to remove the timeout handler
 			Windows::Foundation::EventRegistrationToken timeoutRegistrationToken__;
 			// dispatcherTimer__ - WinRT timer used to cancel a HTTP connection if timeout specified
@@ -99,7 +96,7 @@ namespace TitaniumWindows
 			bool disposed__ { false };
 #pragma warning(pop)
 
-			void startDispatcherTimer();
+			void startDispatcherTimer(concurrency::cancellation_token_source cancellationTokenSource);
 			task<Windows::Storage::Streams::IBuffer^> HTTPClient::HTTPResultAsync(Windows::Storage::Streams::IInputStream^ stream, concurrency::cancellation_token token);
 			Windows::Storage::Streams::IBuffer^ charVecToBuffer(std::vector<std::uint8_t> char_vector);
 

--- a/Source/Network/src/HTTPClient.cpp
+++ b/Source/Network/src/HTTPClient.cpp
@@ -26,16 +26,6 @@ namespace TitaniumWindows
 			TITANIUM_LOG_DEBUG("TitaniumWindows::Network::HTTPClient::ctor");
 		}
 
-		HTTPClient::~HTTPClient()
-		{
-			TITANIUM_LOG_DEBUG("TitaniumWindows::Network::HTTPClient::dtor");
-			abort();
-
-			filter__ = nullptr;
-			httpClient__ = nullptr;
-			dispatcherTimer__ = nullptr;
-		}
-
 		void HTTPClient::JSExportInitialize()
 		{
 			JSExport<HTTPClient>::SetClassVersion(1);

--- a/Source/Network/src/HTTPClient.cpp
+++ b/Source/Network/src/HTTPClient.cpp
@@ -22,7 +22,6 @@ namespace TitaniumWindows
 	{
 		HTTPClient::HTTPClient(const JSContext& js_context) TITANIUM_NOEXCEPT
 		    : Titanium::Network::HTTPClient(js_context)
-		    , cancellationTokenSource__(concurrency::cancellation_token_source())
 		{
 			TITANIUM_LOG_DEBUG("TitaniumWindows::Network::HTTPClient::ctor");
 		}
@@ -45,8 +44,6 @@ namespace TitaniumWindows
 
 		void HTTPClient::abort() TITANIUM_NOEXCEPT
 		{
-			cancellationTokenSource__.cancel();
-
 			if (dispatcherTimer__ != nullptr && dispatcherTimer__->IsEnabled) {
 				dispatcherTimer__->Stop();
 			}
@@ -96,7 +93,6 @@ namespace TitaniumWindows
 			location__ = location;
 			filter__ = ref new Windows::Web::Http::Filters::HttpBaseProtocolFilter();
 			httpClient__ = ref new Windows::Web::Http::HttpClient(filter__);
-			cancellationTokenSource__ = concurrency::cancellation_token_source();
 			filter__->AllowAutoRedirect = true;
 			filter__->CacheControl->ReadBehavior = Windows::Web::Http::Filters::HttpCacheReadBehavior::MostRecent;
 
@@ -216,10 +212,10 @@ namespace TitaniumWindows
 			auto operation = httpClient__->SendRequestAsync(request);
 
 			// Startup a timer that will abort the request after the timeout period is reached.
-			startDispatcherTimer();
+			const concurrency::cancellation_token_source cancellationTokenSource;
+			startDispatcherTimer(cancellationTokenSource);
 
-			// clang-format off
-			const auto token = cancellationTokenSource__.get_token();
+			const auto token = cancellationTokenSource.get_token();
 			create_task(operation, token)
 				.then([this, token](Windows::Web::Http::HttpResponseMessage^ response) {
 				interruption_point();
@@ -392,16 +388,14 @@ namespace TitaniumWindows
 			// clang-format on
 		}
 
-		void HTTPClient::startDispatcherTimer()
+		void HTTPClient::startDispatcherTimer(concurrency::cancellation_token_source cancellationTokenSource)
 		{
 			if (dispatcherTimer__ == nullptr && timeoutSpan__.Duration > 0) {
 				dispatcherTimer__ = ref new Windows::UI::Xaml::DispatcherTimer();
 				dispatcherTimer__->Interval = timeoutSpan__;
-				auto timeoutRegistrationToken__ = dispatcherTimer__->Tick += ref new Windows::Foundation::EventHandler<Platform::Object^>([this](Platform::Object^ sender, Platform::Object^ e) {
-					cancellationTokenSource__.cancel();
+				auto timeoutRegistrationToken__ = dispatcherTimer__->Tick += ref new Windows::Foundation::EventHandler<Platform::Object^>([this, cancellationTokenSource](Platform::Object^ sender, Platform::Object^ e) {
+					cancellationTokenSource.cancel();
 					dispatcherTimer__->Stop();
-					// re-create the CancellationTokenSource.
-					cancellationTokenSource__ = cancellation_token_source();
 				});
 				dispatcherTimer__->Start();
 			}


### PR DESCRIPTION
[TIMOB-24268](https://jira.appcelerator.org/browse/TIMOB-24268)

Attempt to fix crash/freeze in HttpClient.

It may be because we used `concurrency::cancellation_token_source` wrong, we did cancel it twice at HttpClient destructor. We might just want to use it as local variable so it doesn't bother.