### PR TITLE
[TIMOB-24285] Windows: Build fails when no target is specified

### DIFF
--- a/cli/commands/_build/config.js
+++ b/cli/commands/_build/config.js
@@ -46,7 +46,7 @@ function config(logger, config, cli) {
 		supportedVisualStudioVersions: windowsPackageJson.vendorDependencies['visual studio'],
 		supportedWindowsPhoneSDKVersions: windowsPackageJson.vendorDependencies['windows phone sdk'],
 		tasklist: config.get('windows.executables.tasklist'),
-		skipWpTool: cli.argv['build-only'] || (target !== 'wp-device' && target !== 'wp-emulator')
+		skipWpTool: cli.argv['build-only'] || (target !== 'wp-device' && target !== 'wp-emulator' && target !== undefined)
 	};
 
 	this.ignoreDirs = new RegExp(config.get('cli.ignoreDirs'));


### PR DESCRIPTION
[JIRA](https://jira.appcelerator.org/browse/TIMOB-24285)

When building without the --target option it will be undefined, so check don't set skipWpTool if it's undefined