### PR TITLE
Skip network tests on Windows 10

### DIFF
--- a/Examples/NMocha/src/Assets/app.js
+++ b/Examples/NMocha/src/Assets/app.js
@@ -43,8 +43,10 @@ require('./ti.internal.test');
 require('./ti.locale.test');
 require('./ti.map.test');
 require('./ti.network.test');
+if (utilities.isWindows10()) {
 require('./ti.network.httpclient.test');
 require('./ti.network.socket.tcp.test.js');
+}
 require('./ti.platform.test');
 require('./ti.require.test');
 require('./ti.stream.test');


### PR DESCRIPTION
Skip network tests on Jenkins Windows 10 node because it's behind firewall.