### PR TITLE
[TIMOB-24223] Titanium event does not return correct source

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
@@ -527,9 +527,11 @@ namespace TitaniumWindows
 			virtual void updateDisabledBackground();
 			Windows::UI::Xaml::Media::Brush^ getBackground();
 
+
 			virtual std::shared_ptr<Titanium::UI::View> rescueGetView(const JSObject& view) TITANIUM_NOEXCEPT override;
-			virtual void fireSimplePositionEvent(const std::string& event_name, Windows::UI::Xaml::FrameworkElement^ sender, Windows::Foundation::Point position);
+			virtual void fireSimplePositionEvent(const std::string& event_name, Windows::Foundation::Point position);
 			virtual void firePostLayoutEvent();
+			virtual std::shared_ptr<Titanium::UI::View> getHierarchyEventSource(Windows::Foundation::Point position) const TITANIUM_NOEXCEPT;
 
 			static Windows::UI::Xaml::Media::ImageBrush^ CreateImageBrushFromPath(const std::string& path);
 			static Windows::UI::Xaml::Media::ImageBrush^ CreateImageBrushFromBitmapImage(Windows::UI::Xaml::Media::Imaging::BitmapImage^ image);


### PR DESCRIPTION
[TIMOB-24223](https://jira.appcelerator.org/browse/TIMOB-24223)

```js
var win = Ti.UI.createWindow({
    backgroundColor: 'green',
    id: 'win',
    layout:'vertical'
});

var view1 = Ti.UI.createView({
    backgroundColor: 'red',
    width: 100, height: 100,
    id: 'view1'
}),
view2 = Ti.UI.createView({
    backgroundColor: 'black',
    width: 100, height: 100,
    id: 'view2'
}),
view3 = Ti.UI.createView({
    backgroundColor: 'blue',
    width: 100, height: 100,
    id: 'view3'
}),
view4 = Ti.UI.createView({
    backgroundColor: 'yellow',
    width: 100, height: 100,
    id: 'view4'
});

win.addEventListener('click', function (e) {
    alert(e.source.id);
});

win.add(view1);
win.add(view2);
win.add(view3);
win.add(view4);
win.open();
```