### PR TITLE
[TIMOB-24328] Set Ti.UI.Button underlying control for WindowsViewLayoutDelegate

### DIFF
--- a/Source/UI/src/Button.cpp
+++ b/Source/UI/src/Button.cpp
@@ -43,7 +43,7 @@ namespace TitaniumWindows
 			border__ = ref new Controls::Border();
 			border__->Child = button__;
 
-			getViewLayoutDelegate<WindowsButtonLayoutDelegate>()->setComponent(border__, nullptr, border__);
+			getViewLayoutDelegate<WindowsButtonLayoutDelegate>()->setComponent(border__, button__, border__);
 		}
 
 		void Button::JSExportInitialize()

--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -1031,7 +1031,7 @@ namespace TitaniumWindows
 			}
 			borderColorBrush__ = ref new SolidColorBrush(ColorForName(color));
 
-			if (is_control__ || underlying_control__) {
+			if ((is_control__ || underlying_control__) && !is_border__) {
 				// Xaml::Control descendant has its own border property.
 				// Use it then, it usually works better than Xaml::Border. Note that it doesn't support border radius though...
 				const auto control = underlying_control__ ? underlying_control__ : dynamic_cast<Control^>(component__);


### PR DESCRIPTION
- Set `Titanium.UI.Button` `underlying_control__` for `WindowsViewLayoutDelegate`

###### TEST CASE
```Javascript
var win = Ti.UI.createWindow({ backgroundColor: 'grey' }),
    btn = Ti.UI.createButton({ title: 'BUTTON', touchEnabled: false });

btn.addEventListener('click', function () {
    alert('CLICK');
});

win.add(btn);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24328)