### PR TITLE
[TIMOB-24331] Ability to re-run cmake for module project

### DIFF
--- a/templates/module/default/template/windows/README.md
+++ b/templates/module/default/template/windows/README.md
@@ -1,0 +1,14 @@
+# Module project for Titanium Windows
+
+This is module project for Titanium Windows
+
+# How to Build
+
+```
+> appc ti build -p windows --build-only -l trace
+```
+
+## License
+
+See the [LICENSE](../LICENSE.md) text for full details.
+Copyright (c) 2015-2016 by Appcelerator, Inc. All Rights Reserved.

--- a/templates/module/default/template/windows/plugins/hooks/windows.js
+++ b/templates/module/default/template/windows/plugins/hooks/windows.js
@@ -1,0 +1,82 @@
+var spawn = require('child_process').spawn,
+    async = require('async'),
+    path = require('path'),
+    fs   = require('fs'),
+    ejs  = require('ejs'),
+    appc = require('node-appc');
+
+exports.cliVersion = ">=3.2";
+exports.init = function(logger, config, cli, nodeappc) {
+    /*
+     * CLI Hook for re-run cmake
+     */
+    cli.on('build.module.pre.compile', function (data, callback) {
+        if (cli.argv.hasOwnProperty('run-cmake')) {
+            var tasks = [
+                function(next) {
+                    runCmake(data, 'WindowsStore', 'Win32', '10.0', next);
+                },
+                function(next) {
+                    runCmake(data, 'WindowsStore', 'ARM', '10.0', next);
+                },
+                function(next) {
+                    runCmake(data, 'WindowsPhone', 'Win32', '8.1', next);
+                },
+                function(next) {
+                    runCmake(data, 'WindowsPhone', 'ARM', '8.1', next);
+                },
+                function(next) {
+                    runCmake(data, 'WindowsStore', 'Win32', '8.1', next);
+                }
+            ];
+
+            async.series(tasks, function(err) {
+                callback(err, data);
+            });
+        } else {
+            callback(null, data);
+        }
+    });
+    
+};
+
+function runCmake(data, platform, arch, sdkVersion, next) {
+    var logger = data.logger,
+        generatorName = 'Visual Studio 14 2015' + (arch==='ARM' ? ' ARM' : ''),
+        cmakeProjectName = (sdkVersion === '10.0' ? 'Windows10' : platform) + '.' + arch,
+        cmakeWorkDir = path.resolve(__dirname,'..','..',cmakeProjectName);
+
+    logger.debug('Run CMake on ' + cmakeWorkDir);
+
+    if (!fs.existsSync(cmakeWorkDir)) {
+        fs.mkdirSync(cmakeWorkDir);
+    }
+
+    var p = spawn(path.join(data.titaniumSdkPath,'windows','cli','vendor','cmake','bin','cmake.exe'),
+        [
+            '-G', generatorName,
+            '-DCMAKE_SYSTEM_NAME=' + platform,
+            '-DCMAKE_SYSTEM_VERSION=' + sdkVersion,
+            '-DCMAKE_BUILD_TYPE=Debug',
+            path.resolve(__dirname,'..','..')
+        ],
+        {
+            cwd: cmakeWorkDir
+        });
+    p.on('error', function(err) {
+        logger.error(cmake);
+        logger.error(err);
+    });
+    p.stdout.on('data', function (data) {
+        logger.info(data.toString().trim());
+    });
+    p.stderr.on('data', function (data) {
+        logger.warn(data.toString().trim());
+    });
+    p.on('close', function (code) {
+        if (code != 0) {
+            process.exit(1); // Exit with code from cmake?
+        }
+        next();
+    });
+}


### PR DESCRIPTION
[TIMOB-24331](https://jira.appcelerator.org/browse/TIMOB-24331)

Currently CMake configuration file (CMakeLists.txt) and Visual Studio project is created only when you create Titanium Windows module project (`appc new`), but sometimes you need to update the VS project based on CMakeLists and re-run `cmake` manually in order to change project configuration (add files, add dependencies etc). Titanium CLI should be able to re-run `cmake` when `--run-cmake` is specificed behind the scenes.