### PR TITLE
[TIMOB-24299] Allow font file to be specified when declaring fontFamily

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/View.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/View.hpp
@@ -80,7 +80,8 @@ namespace TitaniumWindows
 
 #pragma warning(push)
 #pragma warning(disable : 4251)
-			static std::unordered_map<std::string, std::string> CustomFonts__;
+			static std::unordered_map<std::string, std::string> fonts__;
+			static std::vector<std::string> View::fontFiles__;
 #pragma warning(pop)
 
 		};


### PR DESCRIPTION
- Replace internal Javascript with native functions
- Allow font file to be specified in `fontFamily` (Windows limitation) [FontFamily](https://msdn.microsoft.com/en-us/library/windows/apps/windows.ui.xaml.media.fontfamily)

###### TEST CASE
```Javascript
var win = Ti.UI.createWindow({
        backgroundColor: 'gray',
        layout: 'vertical'
    });

win.add(Ti.UI.createLabel({
    text: 'Hello World, Bold',
    font: {
        fontSize: 36,
        fontFamily: 'segoeuib.ttf#Segoe UI 8'
    }
}));

win.add(Ti.UI.createLabel({
    text: 'Hello World, Italic',
    font: {
        fontSize: 36,
        fontFamily: 'segoeuii.ttf#Segoe UI 8'
    }
}));

win.add(Ti.UI.createLabel({
    text: 'Hello World, Light',
    font: {
        fontSize: 36,
        fontFamily: 'segoeuil.ttf#Segoe UI 8'
    }
}));

win.open();
```

[fonts.zip](https://jira.appcelerator.org/secure/attachment/61303/fonts.zip)

##### TODO
- Update docs http://docs.appcelerator.com/platform/latest/#!/api/Font

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24299)