### PR TITLE
[TIMOB-24266] Detach TCP stream after read/write

### DIFF
--- a/Source/Network/src/Socket/TCP.cpp
+++ b/Source/Network/src/Socket/TCP.cpp
@@ -205,6 +205,8 @@ namespace TitaniumWindows
 					}, concurrency::task_continuation_context::use_arbitrary()
 				);
 				evt.wait();
+				reader->DetachStream();
+
 				buffer->construct(data);
 				return totalBytesProcessed__ = data.size();
 			}
@@ -242,6 +244,7 @@ namespace TitaniumWindows
 					}, concurrency::task_continuation_context::use_arbitrary()
 				);
 				evt.wait();
+				writer->DetachStream();
 
 				return count;
 			}


### PR DESCRIPTION
- Always detach data stream after read/write

###### TEST CASE
##### SERVER - index.js
```Javascript
var net = require('net'),
    port = 6262;

net.createServer(function (socket) {

    console.log('client ' + socket.remoteAddress + ' connected');

    socket.on('data', function (data) {
        console.log('recv: ' + data);
    });

    socket.on('end', function () {
        console.log('client ' + socket.remoteAddress + ' disconnected');
    });

}).listen(port);

console.log('server listening on port ' + port);
```
##### CLIENT - app.js
```Javascript
var socket = Ti.Network.Socket.createTCP({
        host: '127.0.0.1',
        port: 6262,
        timeout: 3000,

        connected: function (e) {
            Ti.API.info("connected to server");

            var i = setInterval(function () {
                if (!socket) {
                    clearInterval(i);
                    return;
                }
                
                Ti.API.info('sending data...');
                Ti.Stream.write(socket, Ti.createBuffer({value: 'test'}), function () {
                    Ti.API.info('sent');
                });
            }, 3000);
        },
        error: function (e) {
            clearInterval(i);
            socket = null;
            console.error(e);
        }
    });

Ti.API.info('connecting...');
socket.connect();
```
```
server listening on port 6262
client ::ffff:127.0.0.1 connected
recv: test
recv: test
client ::ffff:127.0.0.1 disconnected
```
[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24226)