### PR TITLE
[TIMOB-24336] Improve Ti.Network.TCP error handling

### DIFF
--- a/Source/Network/include/TitaniumWindows/Network/Socket/TCP.hpp
+++ b/Source/Network/include/TitaniumWindows/Network/Socket/TCP.hpp
@@ -60,6 +60,8 @@ namespace TitaniumWindows
 				virtual void writeAsync(const std::shared_ptr<Titanium::Buffer>& buffer, const std::uint32_t& offset, const std::uint32_t& length, const std::function<void(const Titanium::ErrorResponse&, const std::int32_t&)>& callback) override;
 
 				void accepted(StreamSocket^ socket);
+
+				void error(const std::string& message);
 			private:
 #pragma warning(push)
 #pragma warning(disable : 4251)


### PR DESCRIPTION
- Remove `HAL::RuntimeError` and call `error` callback

###### TEST CASE
```Javascript
var win = Ti.UI.createWindow({backgroundColor: 'gray'});

win.addEventListener('open', function () {
    var socket = Ti.Network.Socket.createTCP({
        host: '192.168.255.255',
        port: 6262,
        timeout: 3000,
        connected: function (e) {
            console.log('[TEST] connected');
        },
        error: function (e) {
            socket = null;
            alert('[TEST] error: ' + e.error);
        }
    });
    console.log('[TEST] connecting...');
    socket.connect();
});

win.open();
```