### PR TITLE
[TIMOB-24125] TableView should create new row on inserting existing row

### DIFF
--- a/Source/TitaniumKit/include/Titanium/Module.hpp
+++ b/Source/TitaniumKit/include/Titanium/Module.hpp
@@ -133,6 +133,11 @@ namespace Titanium
 		virtual void fireEvent(const std::string& name) TITANIUM_NOEXCEPT final;
 		virtual void fireEvent(const std::string& name, const JSObject& event) TITANIUM_NOEXCEPT final;
 
+		virtual JSObject getCtorProperties() const TITANIUM_NOEXCEPT final
+		{
+			return ctorProperties__;
+		}
+
 		Module(const JSContext&, const std::string& apiName = "Titanium.Proxy") TITANIUM_NOEXCEPT;
 		virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;
 
@@ -230,6 +235,9 @@ namespace Titanium
 
 		std::unordered_map<std::string, std::vector<JSObject>> event_listener_map__;
 		bool enableEvents__ { true };
+
+		// Save constructor arguments so module can make copy of itself later on
+		JSObject ctorProperties__;
 #pragma warning(pop)
 	private:
 		static unsigned eventListenerIndex(const std::vector<JSObject>& event_listener_list, const std::string& name, JSObject& callback) TITANIUM_NOEXCEPT;

--- a/Source/TitaniumKit/include/Titanium/UI/TableViewRow.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/TableViewRow.hpp
@@ -104,6 +104,15 @@ namespace Titanium
 
 			bool contains(const std::string& query);
 
+			bool get_added()
+			{
+				return added__;
+			}
+
+			void set_added(const bool& added) 
+			{
+				added__ = added;
+			}
 			protected:
 #pragma warning(push)
 #pragma warning(disable : 4251)
@@ -113,6 +122,8 @@ namespace Titanium
 				bool hasChild__;
 				std::string title__;
 				JSObject data__;
+				// This indicates this row is already added to section.
+				bool added__;
 #pragma warning(pop)
 		};
 	} // namespace UI

--- a/Source/TitaniumKit/include/Titanium/UI/TableViewSection.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/TableViewSection.hpp
@@ -130,6 +130,9 @@ namespace Titanium
 
 			static void JSExportInitialize();
 
+			// Check if given row is already added, create new row then.
+			static std::shared_ptr<TableViewRow> MakeSafeRowCopy(const JSContext&, const std::shared_ptr<TableViewRow>& row) TITANIUM_NOEXCEPT;
+
 			TITANIUM_PROPERTY_DEF(footerTitle);
 			TITANIUM_PROPERTY_DEF(footerView);
 			TITANIUM_PROPERTY_DEF(headerTitle);

--- a/Source/TitaniumKit/src/Module.cpp
+++ b/Source/TitaniumKit/src/Module.cpp
@@ -17,6 +17,7 @@ namespace Titanium
 	Module::Module(const JSContext& js_context, const std::string& apiName) TITANIUM_NOEXCEPT
 	    : JSExportObject(js_context)
 	    , apiName__(apiName)
+	    , ctorProperties__(js_context.CreateObject())
 	{
 	}
 
@@ -125,6 +126,7 @@ namespace Titanium
 
 		const auto module = this_object.GetPrivate<Titanium::Module>();
 		if (module) {
+			module->ctorProperties__ = props;
 			module->propertiesSet__ = true;
 			module->afterPropertiesSet();
 		}

--- a/Source/TitaniumKit/src/UI/TableViewSection.cpp
+++ b/Source/TitaniumKit/src/UI/TableViewSection.cpp
@@ -46,11 +46,7 @@ namespace Titanium
 			JSObject TableViewRow_obj = static_cast<JSObject>(TableViewRow_property);
 			auto js_row = TableViewRow_obj.CallAsConstructor();
 
-			const auto props = row->getCtorProperties().GetProperties();
-			for (const auto prop : props) {
-				const auto prop_name = prop.first;
-				js_row.SetProperty(prop.first, prop.second);
-			}
+			Module::applyProperties(row->getCtorProperties(), js_row);
 
 			return js_row.GetPrivate<TableViewRow>();
 		}

--- a/Source/TitaniumKit/src/UI/TableViewSection.cpp
+++ b/Source/TitaniumKit/src/UI/TableViewSection.cpp
@@ -30,13 +30,42 @@ namespace Titanium
 		TITANIUM_PROPERTY_READWRITE(TableViewSection, std::shared_ptr<View>, headerView)
 		TITANIUM_PROPERTY_READ(TableViewSection, std::vector<std::shared_ptr<TableViewRow>>, rows)
 
+		std::shared_ptr<TableViewRow> TableViewSection::MakeSafeRowCopy(const JSContext& ctx, const std::shared_ptr<TableViewRow>& row) TITANIUM_NOEXCEPT
+		{
+			if (!row->get_added()) {
+				return row;
+			}
+			JSValue Titanium_property = ctx.get_global_object().GetProperty("Titanium");
+			TITANIUM_ASSERT(Titanium_property.IsObject());
+			JSObject Titanium = static_cast<JSObject>(Titanium_property);
+			JSValue UI_property = Titanium.GetProperty("UI");
+			TITANIUM_ASSERT(UI_property.IsObject());
+			JSObject UI = static_cast<JSObject>(UI_property);
+			JSValue TableViewRow_property = UI.GetProperty("TableViewRow");
+			TITANIUM_ASSERT(TableViewRow_property.IsObject());
+			JSObject TableViewRow_obj = static_cast<JSObject>(TableViewRow_property);
+			auto js_row = TableViewRow_obj.CallAsConstructor();
+
+			const auto props = row->getCtorProperties().GetProperties();
+			for (const auto prop : props) {
+				const auto prop_name = prop.first;
+				js_row.SetProperty(prop.first, prop.second);
+			}
+
+			return js_row.GetPrivate<TableViewRow>();
+		}
+
 		std::uint32_t TableViewSection::get_rowCount() const TITANIUM_NOEXCEPT
 		{
 			return static_cast<std::uint32_t>(rows__.size());
 		}
 
-		void TableViewSection::add(const std::shared_ptr<TableViewRow>& row, const bool& fireEvent) TITANIUM_NOEXCEPT
+		void TableViewSection::add(const std::shared_ptr<TableViewRow>& row_, const bool& fireEvent) TITANIUM_NOEXCEPT
 		{
+			// Check if row is already added, make new row then.
+			std::shared_ptr<TableViewRow> row = MakeSafeRowCopy(get_context(), row_);
+
+			row->set_added(true);
 			rows__.push_back(row);
 			if (fireEvent) {
 				const auto index = static_cast<std::uint32_t>(rows__.size() - 1);
@@ -44,8 +73,11 @@ namespace Titanium
 			}
 		}
 
-		void TableViewSection::add(const std::shared_ptr<TableViewRow>& row, const std::uint32_t& index) TITANIUM_NOEXCEPT
+		void TableViewSection::add(const std::shared_ptr<TableViewRow>& row_, const std::uint32_t& index) TITANIUM_NOEXCEPT
 		{
+			std::shared_ptr<TableViewRow> row = MakeSafeRowCopy(get_context(), row_);
+
+			row->set_added(true);
 			rows__.insert(rows__.begin() + index, row);
 			fireTableViewSectionEvent("append", rows__.at(index), index);
 		}
@@ -55,6 +87,7 @@ namespace Titanium
 			const auto it = find(rows__.begin(), rows__.end(), row);
 			if (it != rows__.end()) {
 				const auto index = static_cast<std::uint32_t>(std::distance(rows__.begin(), it));
+				row->set_added(false);
 				rows__.erase(it);
 				fireTableViewSectionEvent("remove", row, index);
 				return true;
@@ -67,6 +100,7 @@ namespace Titanium
 		{
 			if (rows__.size() > index) {
 				const auto row = rows__.at(index);
+				row->set_added(false);
 				rows__.erase(rows__.begin() + index);
 				fireTableViewSectionEvent("remove", row, index);
 				return true;


### PR DESCRIPTION
[TIMOB-24125](https://jira.appcelerator.org/browse/TIMOB-24125)

To keep parity with iOS, `TableView` should create new `TableViewRow` on inserting existing row.

```js
var _window = Ti.UI.createWindow();
var table = Ti.UI.createTableView({
    top: 0,
    bottom: 0
});

var tableData = [];

for (var i = 0; i < 10; i++) {
    tableData.push(Ti.UI.createTableViewRow({
        title: "Row " + (i + 1)
    }));
}

table.setData(tableData);

_window.add(table);

table.addEventListener("click", function (e) {
    var row = e.row;
    Ti.API.info('index');
    Ti.API.info(e.index);
    Ti.API.info(row.title);
    table.insertRowBefore(0, row);
});
_window.open();
```