### PR TITLE
[TIMOB-24134] TableView.data should return TableViewSection[]

### DIFF
--- a/Source/TitaniumKit/include/Titanium/UI/TableView.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/TableView.hpp
@@ -56,7 +56,7 @@ namespace Titanium
 			  @abstract data
 			  @discussion Rows of the table view.
 			*/
-  			TITANIUM_PROPERTY_IMPL_DEF(std::vector<JSObject>, data);
+			virtual void set_data(const std::vector<JSObject>& data) TITANIUM_NOEXCEPT;
 
 			/*!
 			  @method

--- a/Source/TitaniumKit/src/UI/TableView.cpp
+++ b/Source/TitaniumKit/src/UI/TableView.cpp
@@ -58,25 +58,6 @@ namespace Titanium
 			model__->set_sections(sections);
 		}
 
-		std::vector<JSObject> TableView::get_data() const TITANIUM_NOEXCEPT
-		{
-			std::vector<JSObject> data;
-			const auto sections = get_sections();
-			for (const auto section : sections) {
-				// this indicates data is constructed from array of rows without header
-				if (sections.size() == 1 && !section->hasHeader())
-				{
-					for (const auto row : section->get_rows())
-					{
-						data.push_back(row->get_data());
-					}
-				} else {
-					data.push_back(section->get_object());
-				}
-			}
-			return data;
-		}
-
 		void TableView::set_data(const std::vector<JSObject>& data) TITANIUM_NOEXCEPT
 		{
 			model__->clear();
@@ -421,12 +402,7 @@ namespace Titanium
 
 		TITANIUM_PROPERTY_GETTER(TableView, data)
 		{
-			std::vector<JSValue> data_array;
-			const auto rows = get_data();
-			for (auto row : rows) {
-				data_array.push_back(row);
-			}
-			return get_context().CreateArray(data_array);
+			return js_get_sections();
 		}
 
 		TITANIUM_PROPERTY_SETTER(TableView, data)


### PR DESCRIPTION
[TIMOB-24134](https://jira.appcelerator.org/browse/TIMOB-24134)

`TableView.data` should return `TableViewSection[]`. As far as I can see from the source, `data` always returns `TableViewSection[]` on [iOS](https://github.com/appcelerator/titanium_mobile/blob/master/iphone/Classes/TiUITableViewProxy.m#L782) and [Android](https://github.com/appcelerator/titanium_mobile/blob/master/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewProxy.java#L697). The reason why type of `Ti.UI.TableView.data` is marked both `Titanium.UI.TableViewRow[]/Titanium.UI.TableViewSection[]` in [API doc](http://docs.appcelerator.com/platform/latest/#!/api/Titanium.UI.TableView-property-data) I think is that it _accepts_ `Titanium.UI.TableViewRow[]` as well as `Titanium.UI.TableViewSection[]` whereas `data` _always returns_ `Titanium.UI.TableViewSection[]`. So Windows implementation was wrong in this case.



```js
var _window = Ti.UI.createWindow();
var table = Ti.UI.createTableView({
    top: 0,
    bottom: 0
});

var tableData = [];

for (var i = 0; i < 10; i++) {
    tableData.push(Ti.UI.createTableViewRow({
        title: "Row " + (i + 1)
    }));
}

table.setData(tableData);

_window.add(table);

table.addEventListener("click", function (e) {
    alert(table.data[0].rows[e.index].title);
});
_window.open();
```