### PR TITLE
[TIMOB-24223] Support event source for nested views

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
@@ -531,7 +531,7 @@ namespace TitaniumWindows
 			virtual std::shared_ptr<Titanium::UI::View> rescueGetView(const JSObject& view) TITANIUM_NOEXCEPT override;
 			virtual void fireSimplePositionEvent(const std::string& event_name, Windows::Foundation::Point position);
 			virtual void firePostLayoutEvent();
-			virtual std::shared_ptr<Titanium::UI::View> getHierarchyEventSource(Windows::Foundation::Point position) const TITANIUM_NOEXCEPT;
+			virtual std::shared_ptr<Titanium::UI::View> getHierarchyEventSource(Windows::Foundation::Point position, const std::shared_ptr<Titanium::UI::View>& root = nullptr) const TITANIUM_NOEXCEPT;
 
 			static Windows::UI::Xaml::Media::ImageBrush^ CreateImageBrushFromPath(const std::string& path);
 			static Windows::UI::Xaml::Media::ImageBrush^ CreateImageBrushFromBitmapImage(Windows::UI::Xaml::Media::Imaging::BitmapImage^ image);

--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -1212,13 +1212,21 @@ namespace TitaniumWindows
 			}
 		}
 
-		std::shared_ptr<Titanium::UI::View> WindowsViewLayoutDelegate::getHierarchyEventSource(Windows::Foundation::Point position) const TITANIUM_NOEXCEPT
+		std::shared_ptr<Titanium::UI::View> WindowsViewLayoutDelegate::getHierarchyEventSource(Windows::Foundation::Point position, const std::shared_ptr<Titanium::UI::View>& root) const TITANIUM_NOEXCEPT
 		{
+			const auto children = root == nullptr ? get_children() : root->get_children();
 			// Let's find correct source
-			for (const auto child : get_children()) {
+			for (const auto child : children) {
 				const auto childView = child->getViewLayoutDelegate<WindowsViewLayoutDelegate>()->getEventComponent();
 				const auto elements = Windows::UI::Xaml::Media::VisualTreeHelper::FindElementsInHostCoordinates(position, childView);
 				for (const auto e : elements) {
+					// Let's check its descendents so we can support nested views
+					if (child->get_children().size() > 0) {
+						const auto found = getHierarchyEventSource(position, child);
+						if (found) {
+							return found;
+						}
+					}
 					return child;
 				}
 			}


### PR DESCRIPTION
Revised PR for [TIMOB-24223](https://jira.appcelerator.org/browse/TIMOB-24223) because #924 does not support nested Views.

```js
var win = Ti.UI.createWindow({
    backgroundColor: 'green',
    id: 'win',
    layout: 'vertical'
});

var view = Ti.UI.createView({
    backgroundColor: 'white',
    width: '80%', height: '80%',
    id: 'view',
    layout: 'vertical'
});

var view1 = Ti.UI.createView({
    backgroundColor: 'red',
    width: '80%', height: 100,
    id: 'view1'
}),
view2 = Ti.UI.createView({
    backgroundColor: 'black',
    width: '80%', height: 100,
    id: 'view2'
}),
view3 = Ti.UI.createView({
    backgroundColor: 'blue',
    width: '80%', height: 100,
    id: 'view3'
}),
view4 = Ti.UI.createView({
    backgroundColor: 'yellow',
    width: '80%', height: 100,
    id: 'view4'
});

var view1_1 = Ti.UI.createView({
    backgroundColor: 'gray',
    width: '70%', height: '70%',
    id: 'view1_1'
}),
view2_1 = Ti.UI.createView({
    backgroundColor: 'gray',
    width: '70%', height: '70%',
    id: 'view2_1'
}),
view3_1 = Ti.UI.createView({
    backgroundColor: 'gray',
    width: '70%', height: '70%',
    id: 'view3_1'
}),
view4_1 = Ti.UI.createView({
    backgroundColor: 'gray',
    width: '70%', height: '70%',
    id: 'view4_1'
});

view1.add(view1_1);
view2.add(view2_1);
view3.add(view3_1);
view4.add(view4_1);

win.addEventListener('click', function (e) {
    alert(e.source.id);
});

view.add(view1);
view.add(view2);
view.add(view3);
view.add(view4);
win.add(view);
win.open();
```
