### PR TITLE
[TIMOB-24239] Implement zIndex

### DIFF
--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -1172,7 +1172,20 @@ namespace TitaniumWindows
 		void WindowsViewLayoutDelegate::set_zIndex(const int32_t& zIndex) TITANIUM_NOEXCEPT
 		{
 			Titanium::UI::ViewLayoutDelegate::set_zIndex(zIndex);
-			Controls::Canvas::SetZIndex(component__, zIndex);
+			if (is_grid__) {
+				if (dynamic_cast<Windows::UI::Xaml::Controls::ListView^>(underlying_control__)) {
+					// For Ti.UI.TableView and Ti.UI.ListView
+					Controls::Canvas::SetZIndex(border__, zIndex);
+				} else {
+					Controls::Canvas::SetZIndex(component__, zIndex);
+				}
+			} else if (border__) {
+				Controls::Canvas::SetZIndex(border__, zIndex);
+			} else if (underlying_control__) {
+				Controls::Canvas::SetZIndex(underlying_control__, zIndex);
+			} else {
+				Controls::Canvas::SetZIndex(component__, zIndex);
+			}
 		}
 
 		void WindowsViewLayoutDelegate::disableEvent(const std::string& event_name) TITANIUM_NOEXCEPT


### PR DESCRIPTION
[TIMOB-24239](https://jira.appcelerator.org/browse/TIMOB-24239)

`zIndex` did not work well with Xaml `Border` and `Grid`.

```js
var win = Ti.UI.createWindow({
    backgroundColor: 'green'
});

var view1 = Ti.UI.createView({
    backgroundColor: 'blue',
    width: 100, height: 100,
    top: 100, left: 100,
    zIndex: 140
}),
view2 = Ti.UI.createButton({
    backgroundColor: 'red',
    width: 100, height: 100,
    top: 110, left: 110,
    zIndex: 130
}),
view3 = Ti.UI.createLabel({
    backgroundColor: 'yellow',
    width: 100, height: 100,
    top: 120, left: 120,
    zIndex: 120
}),
view4 = Ti.UI.createImageView({
    backgroundColor: 'gray',
    width: 100, height: 100,
    top: 130, left: 130,
    zIndex: 110
}),
view5 = Ti.UI.createTextArea({
    backgroundColor: 'blue',
    width: 100, height: 100,
    top: 140, left: 140,
    zIndex: 100
}),
view6 = Ti.UI.createListView({
    backgroundColor: 'red',
    width: 100, height: 100,
    top: 150, left: 150,
    zIndex: 90
}),
view7 = Ti.UI.createTextField({
    backgroundColor: 'yellow',
    width: 100, height: 100,
    top: 160, left: 160,
    zIndex: 80
}),
view8 = Ti.UI.createPicker({
    backgroundColor: 'pink',
    width: 100, height: 100,
    top: 170, left: 170,
    zIndex: 70
}),
view9 = Ti.UI.createView({
    backgroundColor: 'blue',
    width: 100, height: 100,
    top: 180, left: 180,
    zIndex: 60
}),
view10 = Ti.UI.createScrollableView({
    backgroundColor: 'red',
    width: 100, height: 100,
    top: 190, left: 190,
    zIndex: 50
}),
view11 = Ti.UI.createScrollView({
    backgroundColor: 'gray',
    width: 100, height: 100,
    top: 200, left: 200,
    zIndex: 40
}),
view12 = Ti.UI.createSlider({
    backgroundColor: 'yellow',
    width: 100, height: 100,
    top: 210, left: 210,
    zIndex: 30
}),
view13 = Ti.UI.createSwitch({
    backgroundColor: 'gray',
    width: 100, height: 100,
    top: 220, left: 220,
    zIndex: 20
}),
view14 = Ti.UI.createTableView({
    backgroundColor: 'blue',
    width: 100, height: 100,
    top: 230, left: 230,
    zIndex: 10
});

win.addEventListener('click', function () {
    view1.zIndex = 10;
    view2.zIndex = 20;
    view3.zIndex = 30;
    view4.zIndex = 40;
    view5.zIndex = 50;
    view6.zIndex = 60;
    view7.zIndex = 70;
    view8.zIndex = 80;
    view9.zIndex = 90;
    view10.zIndex = 100;
    view11.zIndex = 110;
    view12.zIndex = 120;
    view13.zIndex = 130;
    view14.zIndex = 140;
});

win.add(view1);
win.add(view2);
win.add(view3);
win.add(view4);
win.add(view5);
win.add(view6);
win.add(view7);
win.add(view8);
win.add(view9);
win.add(view10);
win.add(view11);
win.add(view12);
win.add(view13);
win.add(view14);

win.open();
```