### PR TITLE
[TIMOB-24371] TextField/TextArea return event fired twice

### DIFF
--- a/Source/UI/src/TextField.cpp
+++ b/Source/UI/src/TextField.cpp
@@ -337,7 +337,8 @@ namespace TitaniumWindows
 				}
 			} else if (event_name == "return") {
 				const auto keydown = ref new KeyEventHandler([this, ctx](Platform::Object^ sender, KeyRoutedEventArgs^ e) {
-					if (e->Key == Windows::System::VirtualKey::Enter) {
+					// TIMOB-24371: Enter event fired twice due to a bug in Xaml KeyDown event, here's a workaround
+					if (e->Key == Windows::System::VirtualKey::Enter && e->KeyStatus.RepeatCount == 0) {
 						JSObject eventArgs = ctx.CreateObject();
 						eventArgs.SetProperty("value", ctx.CreateString(this->get_value()));
 


### PR DESCRIPTION
[TIMOB-24371](https://jira.appcelerator.org/browse/TIMOB-24371)

Xaml `TextBox` fires `Enter` event twice. Microsoft is still ["investigating" this since 2012](https://social.msdn.microsoft.com/Forums/en-US/734d6c7a-8da2-48c6-9b3d-fa868b4dfb1d/c-textbox-keydown-triggered-twice-in-metro-applications?forum=winappswithcsharp). :|

```js
var win = Ti.UI.createWindow({
    backgroundColor: 'green',
    layout:'vertical'
});

var textField = Ti.UI.createTextField({
    width: 250, height: 60
});

textField.addEventListener('return', function () {
    alert('return event');
});

win.add(Ti.UI.createLabel({ text: 'type enter' }))
win.add(textField);
win.open();
```