### PR TITLE
[TIMOB-24252] touchEnabled with border/panel components

### DIFF
--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -1104,13 +1104,50 @@ namespace TitaniumWindows
 		void WindowsViewLayoutDelegate::set_touchEnabled(const bool& enabled) TITANIUM_NOEXCEPT
 		{
 			Titanium::UI::ViewLayoutDelegate::set_touchEnabled(enabled);
-			if (is_control__ || underlying_control__) {
-				if (underlying_control__) {
-					underlying_control__->IsEnabled = enabled;
-				} else {
-					dynamic_cast<Control^>(component__)->IsEnabled = enabled;
+
+			component__->IsTapEnabled = enabled;
+			component__->IsDoubleTapEnabled = enabled;
+			component__->IsHoldingEnabled = enabled;
+			component__->IsRightTapEnabled = enabled;
+
+			if (is_control__) {
+				dynamic_cast<Control^>(component__)->IsEnabled = enabled;
+			}
+
+			if (is_panel__) {
+				for (const auto child : dynamic_cast<Panel^>(component__)->Children) {
+					child->IsTapEnabled = enabled;
+					child->IsDoubleTapEnabled = enabled;
+					child->IsHoldingEnabled = enabled;
+					child->IsRightTapEnabled = enabled;
 				}
 			}
+
+			if (underlying_control__) {
+				underlying_control__->IsEnabled = enabled;
+				underlying_control__->IsTapEnabled = enabled;
+				underlying_control__->IsDoubleTapEnabled = enabled;
+				underlying_control__->IsHoldingEnabled = enabled;
+				underlying_control__->IsRightTapEnabled = enabled;
+			}
+			
+			if (border__) {
+				border__->IsTapEnabled = enabled;
+				border__->IsDoubleTapEnabled = enabled;
+				border__->IsHoldingEnabled = enabled;
+				border__->IsRightTapEnabled = enabled;
+				if (border__->Child) {
+					border__->Child->IsTapEnabled = enabled;
+					border__->Child->IsDoubleTapEnabled = enabled;
+					border__->Child->IsHoldingEnabled = enabled;
+					border__->Child->IsRightTapEnabled = enabled;
+					const auto control = dynamic_cast<Control^>(border__->Child);
+					if (control) {
+						control->IsEnabled = enabled;
+					}
+				}
+			}
+
 			updateDisabledBackground();
 
 			for (auto child : get_children()) {


### PR DESCRIPTION
[TIMOB-24252](https://jira.appcelerator.org/browse/TIMOB-24252)

Similar to #944, `touchEnabled` did not work well with Xaml `Border` and `Grid` etc. We should have propagated enabled status onto child components too. 

```js
var win = Ti.UI.createWindow({
    backgroundColor: 'green'
});

var view1 = Ti.UI.createView({
    backgroundColor: 'blue',
    width: 100, height: 100,
    top: 100, left: 100,
    touchEnabled: false
}),
view2 = Ti.UI.createButton({
    backgroundColor: 'red',
    width: 100, height: 100,
    top: 110, left: 110,
    touchEnabled: false
}),
view3 = Ti.UI.createLabel({
    backgroundColor: 'yellow',
    width: 100, height: 100,
    top: 120, left: 120,
    touchEnabled: false
}),
view4 = Ti.UI.createImageView({
    backgroundColor: 'pink',
    width: 100, height: 100,
    top: 130, left: 130,
    touchEnabled: false
}),
view5 = Ti.UI.createTextArea({
    backgroundColor: 'blue',
    width: 100, height: 100,
    top: 140, left: 140,
    touchEnabled: false
}),
view6 = Ti.UI.createListView({
    backgroundColor: 'red',
    width: 100, height: 100,
    top: 150, left: 150,
    touchEnabled: false
}),
view7 = Ti.UI.createTextField({
    backgroundColor: 'yellow',
    width: 100, height: 100,
    top: 160, left: 160,
    touchEnabled: false
}),
view8 = Ti.UI.createPicker({
    backgroundColor: 'pink',
    width: 100, height: 100,
    top: 170, left: 170,
    touchEnabled: false
}),
view9 = Ti.UI.createView({
    backgroundColor: 'blue',
    width: 100, height: 100,
    top: 180, left: 180,
    touchEnabled: false
}),
view10 = Ti.UI.createScrollableView({
    backgroundColor: 'red',
    width: 100, height: 100,
    top: 190, left: 190,
    touchEnabled: false
}),
view11 = Ti.UI.createScrollView({
    backgroundColor: 'pink',
    width: 100, height: 100,
    top: 200, left: 200,
    touchEnabled: false
}),
view12 = Ti.UI.createSlider({
    backgroundColor: 'yellow',
    width: 100, height: 100,
    top: 210, left: 210,
    touchEnabled: false
}),
view13 = Ti.UI.createSwitch({
    backgroundColor: 'pink',
    width: 100, height: 100,
    top: 220, left: 220,
    touchEnabled: false
});

var onClick = function (e) {
    alert('click from ' + e.source.apiName)
};

view1.addEventListener('click', onClick);
view2.addEventListener('click', onClick);
view3.addEventListener('click', onClick);
view4.addEventListener('click', onClick);
view5.addEventListener('click', onClick);
view6.addEventListener('click', onClick);
view7.addEventListener('click', onClick);
view8.addEventListener('click', onClick);
view9.addEventListener('click', onClick);
view10.addEventListener('click', onClick);
view11.addEventListener('click', onClick);
view12.addEventListener('click', onClick);
view13.addEventListener('click', onClick);

var btn = Ti.UI.createButton({
    title: 'Toggle touchEnabled -> ' + (!view1.touchEnabled),
    bottom: 0, left: 0,
    backgroundColor:'red'
});

btn.addEventListener('click', function () {
    view1.touchEnabled = !view1.touchEnabled;
    view2.touchEnabled = !view2.touchEnabled;
    view3.touchEnabled = !view3.touchEnabled;
    view4.touchEnabled = !view4.touchEnabled;
    view5.touchEnabled = !view5.touchEnabled;
    view6.touchEnabled = !view6.touchEnabled;
    view7.touchEnabled = !view7.touchEnabled;
    view8.touchEnabled = !view8.touchEnabled;
    view9.touchEnabled = !view9.touchEnabled;
    view10.touchEnabled = !view10.touchEnabled;
    view11.touchEnabled = !view11.touchEnabled;
    view12.touchEnabled = !view12.touchEnabled;
    view13.touchEnabled = !view13.touchEnabled;
    btn.title = 'Toggle touchEnabled -> ' + (!view1.touchEnabled);
});

win.add(view1);
win.add(view2);
win.add(view3);
win.add(view4);
win.add(view5);
win.add(view6);
win.add(view7);
win.add(view8);
win.add(view9);
win.add(view10);
win.add(view11);
win.add(view12);
win.add(view13);
win.add(btn);

win.open();
```