### PR TITLE
[TIMOB-24382] Adding same component should not cause error

### DIFF
--- a/Source/TitaniumKit/src/UI/ViewLayoutDelegate.cpp
+++ b/Source/TitaniumKit/src/UI/ViewLayoutDelegate.cpp
@@ -35,7 +35,10 @@ namespace Titanium
 
 		void ViewLayoutDelegate::add(const std::shared_ptr<Titanium::UI::View>& view) TITANIUM_NOEXCEPT
 		{
-			children__.push_back(view);
+			auto it = std::find(children__.begin(), children__.end(), view);
+			if (it == children__.end()) {
+				children__.push_back(view);
+			}
 		}
 
 		void ViewLayoutDelegate::remove(const std::shared_ptr<Titanium::UI::View>& view) TITANIUM_NOEXCEPT

--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -164,14 +164,19 @@ namespace TitaniumWindows
 			TITANIUM_ASSERT(newView != nullptr);
 			auto nativeChildView = newView->getComponent();
 			if (nativeChildView != nullptr) {
-				Titanium::LayoutEngine::nodeAddChild(layout_node__, newView->getLayoutNode());
-				if (isLoaded()) {
-					requestLayout();
-				}
 				try {
 					auto nativeView = dynamic_cast<Controls::Panel^>(component__);
+					uint32_t index = 0;
+					if (nativeView->Children->IndexOf(nativeChildView, &index)) {
+						TITANIUM_LOG_DEBUG("This UI element is already added");
+						return;
+					}
 					nativeView->Children->Append(nativeChildView);
 					newView->set_touchEnabled(get_touchEnabled() && newView->get_touchEnabled());
+					Titanium::LayoutEngine::nodeAddChild(layout_node__, newView->getLayoutNode());
+					if (isLoaded()) {
+						requestLayout();
+					}
 				} catch (Platform::Exception^ e) {
 					detail::ThrowRuntimeError("add", Utility::ConvertString(e->Message));
 				}


### PR DESCRIPTION
[TIMOB-24382](https://jira.appcelerator.org/browse/TIMOB-24382)

Adding same component multiple times should not cause error to align with iOS behavior.

```js
var win = Ti.UI.createWindow({ backgroundColor: 'green' });

var label = Ti.UI.createLabel({ text: 'Test' });

win.add(label);
win.add(label);

win.open();
```

