### PR TITLE
[TIMOB-24132] Implement TableView.touchmove event

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/TableView.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/TableView.hpp
@@ -118,6 +118,7 @@ namespace TitaniumWindows
 			Windows::Foundation::EventRegistrationToken loaded_event__;
 			Windows::Foundation::EventRegistrationToken scroll_event__;
 			Windows::Foundation::EventRegistrationToken scrollend_event__;
+			Windows::Foundation::EventRegistrationToken touchmove_event__;
 			
 			double oldScrollPosX__ { -1 };
 			double oldScrollPosY__ { -1 };

--- a/Source/UI/src/TableView.cpp
+++ b/Source/UI/src/TableView.cpp
@@ -465,7 +465,7 @@ namespace TitaniumWindows
 
 		void TableView::enableEvent(const std::string& event_name) TITANIUM_NOEXCEPT
 		{
-			getViewLayoutDelegate<WindowsViewLayoutDelegate>()->filterEvents({ "click" });
+			getViewLayoutDelegate<WindowsViewLayoutDelegate>()->filterEvents({ "click", "touchmove" });
 
 			Titanium::UI::TableView::enableEvent(event_name);
 
@@ -512,6 +512,18 @@ namespace TitaniumWindows
 				if (scrollview__) {
 					registerScrollendEvent();
 				}
+			} else if (event_name == "touchmove") {
+				touchmove_event__ = tableview__->PointerMoved += ref new Input::PointerEventHandler([this](Platform::Object^, Input::PointerRoutedEventArgs^ e) {
+
+					const auto ctx = get_context();
+					JSObject  eventArgs = ctx.CreateObject();
+
+					const auto position = e->GetCurrentPoint(tableview__)->Position;
+					eventArgs.SetProperty("x", ctx.CreateNumber(position.X));
+					eventArgs.SetProperty("y", ctx.CreateNumber(position.Y));
+
+					fireEvent("touchmove", eventArgs);
+				});
 			}
 		}
 
@@ -529,6 +541,8 @@ namespace TitaniumWindows
 				if (scrollview__) {
 					scrollview__->ViewChanged -= scrollend_event__;
 				}
+			} else if (event_name == "touchmove") {
+				tableview__->PointerMoved -= touchmove_event__;
 			}
 		}
 


### PR DESCRIPTION
[TIMOB-24132](https://jira.appcelerator.org/browse/TIMOB-24132)

`touchmove` event for `TableView` did not work. We need to use Xaml `PointerMoved` event for TableView here because Xaml `ListView` doesn't fire `ManipulationDelta` event which is widely used in TitaniumKit, more lightweight version of `PointerMoved`.

```js
var _window = Ti.UI.createWindow();

var data = [];
for (var i = 1; i <= 10; i++) {
    data.push({
        title: 'Row ' + i
    });
}
var MyListbox = Ti.UI.createTableView({ data: data, top: 0, left: 0, width: Ti.UI.FILL, height: Ti.UI.FILL });

MyListbox.addEventListener('touchmove', TchMove);

function TchMove(evt) {
    Ti.API.info('TchMove');
}

_window.add(MyListbox);
_window.open();
```