### PR TITLE
[TIMOB-24402] Ability to limit target platform for module

### DIFF
--- a/cli/commands/_buildModule.js
+++ b/cli/commands/_buildModule.js
@@ -238,6 +238,9 @@ WindowsModuleBuilder.prototype.compileModule = function compileModule(next) {
 							// Remove Windows10 target only when it targets to 8.1 explicitly
 							if (sdk_version == '8.1') {
 								types = defaultTypes.slice(0, 2);
+							} else if (sdk_version == '10.0') {
+								types    = ['Windows10'];
+								typesMin = ['win10'];
 							}
 						}
 					});


### PR DESCRIPTION
[TIMOB-24402](https://jira.appcelerator.org/browse/TIMOB-24402)

There was no way to limit target platform for module. You should have a way to limit them by updating configuration files now.

Steps:

1. Create your module project

```
appc new -n test --id com.example.test
### when prompted for the project type, select "Titanium Module" 
```

2. Limit for "Windows 10 only"

Edit **YOUR_MODULE_PROJECT/windows/timodule.xml**

```xml
  <windows>
    <manifest>
      <uses-sdk targetSdkVersion="10.0"/>
    </manifest>
  </windows>
```

3. Limit for"ARM only"

Edit **YOUR_MODULE_PROJECT/windows/manifest**

BEFORE
```
architectures: ARM x86
```

AFTER (Remove **ARM**)
```
architectures: x86
```

4. Build it

```
appc ti build -p windows --build-only
```

This should create module zip that targets Windows 10 only. You can see there is `win10` folder and there's no `phone` and `store` folder. Also there should be no `win10/ARM` folder.
