### PR TITLE
[TIMOB-24455] Allow Package Extensions

### DIFF
--- a/cli/commands/_build/generate.js
+++ b/cli/commands/_build/generate.js
@@ -472,6 +472,7 @@ function generateAppxManifestForPlatform(target, properties) {
 	properties.Prerequisites = properties.Prerequisites || [];
 	properties.Resources = properties.Resources || [];
 	properties.Extensions = properties.Extensions || [];
+	properties.PackageExtensions = properties.PackageExtensions || [];
 
 	var applications = {};
 	if (properties.Applications) {

--- a/templates/build/Package.phone.appxmanifest.in.ejs
+++ b/templates/build/Package.phone.appxmanifest.in.ejs
@@ -66,6 +66,14 @@
     </Application>
   </Applications>
 
+<% if (manifest.PackageExtensions.length > 0) { -%>
+  <Extensions>
+<% for(var i = 0; i < manifest.PackageExtensions.length; i++) { -%>
+    <%- manifest.PackageExtensions[i] %>
+<% } -%>
+  </Extensions>
+<% } -%>
+
   <Capabilities>
 <% for(var i = 0; i < manifest.Capabilities.length; i++) { -%>
     <%- manifest.Capabilities[i].toString() %>

--- a/templates/build/Package.store.appxmanifest.in.ejs
+++ b/templates/build/Package.store.appxmanifest.in.ejs
@@ -64,6 +64,14 @@
     </Application>
   </Applications>
 
+<% if (manifest.PackageExtensions.length > 0) { -%>
+  <Extensions>
+<% for(var i = 0; i < manifest.PackageExtensions.length; i++) { -%>
+    <%- manifest.PackageExtensions[i] %>
+<% } -%>
+  </Extensions>
+<% } -%>
+
   <Capabilities>
 <% for(var i = 0; i < manifest.Capabilities.length; i++) { -%>
     <%- manifest.Capabilities[i].toString() %>

--- a/templates/build/Package.win10.appxmanifest.in.ejs
+++ b/templates/build/Package.win10.appxmanifest.in.ejs
@@ -61,6 +61,14 @@
     </Application>
   </Applications>
 
+<% if (manifest.PackageExtensions.length > 0) { -%>
+  <Extensions>
+<% for(var i = 0; i < manifest.PackageExtensions.length; i++) { -%>
+    <%- manifest.PackageExtensions[i] %>
+<% } -%>
+  </Extensions>
+<% } -%>
+
   <Capabilities>
 <% for(var i = 0; i < manifest.Capabilities.length; i++) { -%>
     <%- manifest.Capabilities[i].toString() %>


### PR DESCRIPTION
[TIMOB-24455](https://jira.appcelerator.org/browse/TIMOB-24455)

Allow [Package/Extensions](https://msdn.microsoft.com/en-us/library/windows/apps/dn934749.aspx) for package manifest.

**tiapp.xml**

```xml
  <windows>
    <manifest>
      <PackageExtensions>
        <Extension Category="windows.publisherCacheFolders">
          <PublisherCacheFolders>
            <Folder Name="Folder1"/>
            <Folder Name="Folder2"/>
          </PublisherCacheFolders>
        </Extension>
      </PackageExtensions>
    </manifest>
  </windows>
```

`appc run -p windows --wp-sdk 10.0 --target ws-local -l trace --build-only` and then check if Extentions are there on your `YOUR_PROJECT_ROOT\build\windows\win10.x86\Package.appxmanifest`.

