### PR TITLE
[TIMOB-24554] Ti.UI.FILL resizes Label incorrectly

### DIFF
--- a/Source/UI/src/Label.cpp
+++ b/Source/UI/src/Label.cpp
@@ -162,11 +162,13 @@ namespace TitaniumWindows
 			label__->Measure(desiredSize);
 
 			const auto layout = getViewLayoutDelegate<WindowsViewLayoutDelegate>();
-
-			if (layout->get_width().empty() || layout->get_right().empty()) {
+			const auto width = layout->get_width();
+			const auto height = layout->get_height();
+			const auto TI_UI_SIZE = Titanium::UI::Constants::to_string(Titanium::UI::LAYOUT::SIZE);
+			if (width.empty() || width == TI_UI_SIZE) {
 				border__->Width = label__->DesiredSize.Width;
 			}
-			if (layout->get_height().empty() || layout->get_bottom().empty()) {
+			if (height.empty() || height == TI_UI_SIZE) {
 				border__->Height = label__->DesiredSize.Height;
 			}
 		}


### PR DESCRIPTION
[TIMOB-24554](https://jira.appcelerator.org/browse/TIMOB-24554)

Label size should not be resized on Ti.UI.FILL.

```js
var win = Ti.UI.createWindow({
        backgroundColor: 'green'
    }),
    width_fill_label = Ti.UI.createLabel({
        text: 'I have a width of Ti.UI.FILL',
        textAlign: Titanium.UI.TEXT_ALIGNMENT_CENTER,
        width: Ti.UI.FILL,
        color: 'white',
        backgroundColor: 'purple',
        height: Ti.UI.SIZE,
    });

win.add(width_fill_label);
win.open();
```

![expected](https://cloud.githubusercontent.com/assets/1661068/24638826/b04f0582-1926-11e7-834b-8dacbced05c4.png)
