### PR TITLE
[TIMOB-24101] Ability to use 3rd-party native classes

### DIFF
--- a/cli/commands/_build/copy.js
+++ b/cli/commands/_build/copy.js
@@ -501,7 +501,13 @@ function copyResources(next) {
 			copyFile.call(this, path.join(templateDir, 'appicon.png'), destIcon);
 		}
 
+		var thirdpartyLibraries = this.hyperloopConfig.windows.thirdparty && Object.keys(this.hyperloopConfig.windows.thirdparty) || [];
 		function hasWindowsAPI(node_value) {
+			for (var i = 0; i < thirdpartyLibraries.length; i++) {
+				if (node_value.indexOf(thirdpartyLibraries[i] + '.') === 0) {
+					return true;
+				}
+			}
 			return (node_value.indexOf('Windows.') === 0 || node_value.indexOf('System.') === 0);
 		}
 

--- a/cli/commands/_build/copy.js
+++ b/cli/commands/_build/copy.js
@@ -405,6 +405,15 @@ function copyResources(next) {
 			}, cb);
 		},
 
+		// Copy all external libraries into lib folder
+		function (cb) {
+			var src = path.join(this.projectDir, 'lib', 'windows');
+			copyDir.call(this, {
+				src: src,
+				dest: path.join(this.buildDir, 'lib')
+			}, cb);
+		},
+
 		// Copy TitaniumKit and HAL dlls over into src folder
 		function (cb) {
 			var src = path.join(this.platformPath, 'lib', 'TitaniumKit', this.cmakePlatformAbbrev, this.arch, 'TitaniumKit.dll');

--- a/cli/commands/_build/generate.js
+++ b/cli/commands/_build/generate.js
@@ -109,8 +109,7 @@ function generateNativeTypes(next) {
 	this.targetPlatformSdkVersion    = this.targetPlatformSdkVersion || this.tiapp.windows['TargetPlatformVersion'] || this.wpsdk;
 	this.targetPlatformSdkMinVersion = this.targetPlatformSdkMinVersion || this.tiapp.windows['TargetPlatformMinVersion'] || this.targetPlatformSdkVersion;
 
-	nativeModuleGenerator.init(this);
-	nativeModuleGenerator.generate(this.buildDir, this.modules, this.native_types, this.native_events, next);
+	nativeModuleGenerator.generate(this, next);
 };
 
 /**

--- a/cli/commands/_build/initialize.js
+++ b/cli/commands/_build/initialize.js
@@ -85,5 +85,10 @@ function initialize(next) {
 	this.cmakeListFile = path.join(this.buildDir, 'CMakeLists.txt'); // lives above the buildSrcDir
 	this.cmakeFinderDir = path.join(this.buildDir, 'cmake');
 
+	// Hyperloop configuration
+	var hyperloopAppcJs = path.join(this.projectDir, 'appc.js');
+	this.hyperloopConfig = fs.existsSync(hyperloopAppcJs) && require(hyperloopAppcJs).hyperloop || {};
+	this.hyperloopConfig.windows || (this.hyperloopConfig.windows = {});
+
 	next();
 }

--- a/cli/commands/_build/initialize.js
+++ b/cli/commands/_build/initialize.js
@@ -86,7 +86,7 @@ function initialize(next) {
 	this.cmakeFinderDir = path.join(this.buildDir, 'cmake');
 
 	// Hyperloop configuration
-	var hyperloopAppcJs = path.join(this.projectDir, 'appc.js');
+	var hyperloopAppcJs = path.join(this.projectDir, 'appc.windows.js');
 	this.hyperloopConfig = fs.existsSync(hyperloopAppcJs) && require(hyperloopAppcJs).hyperloop || {};
 	this.hyperloopConfig.windows || (this.hyperloopConfig.windows = {});
 

--- a/cli/commands/_build/run.js
+++ b/cli/commands/_build/run.js
@@ -54,6 +54,7 @@ function run(logger, config, cli, finished) {
 		'generateCmakeList',
 		'runCmake',
 		'fixCSharpConfiguration',
+		'copyModuleOverride',
 		'compileApp',
 		'writeBuildManifest',
 		'copyResultsToProject',

--- a/cli/lib/stub.js
+++ b/cli/lib/stub.js
@@ -170,7 +170,7 @@ function generateNativeProject(dest, platform, builder, options, callback) {
 	for (var i = 0; i < thirdpartyLibraries.length; i++) {
 		externalReferences.push({
 			Include: thirdpartyLibraries[i],
-			HintPath: '..\\..\\lib\\' + platform + '\\' + builder.arch + '\\' + thirdpartyLibraries[i] + '.winmd'
+			HintPath: path.join('..', '..', 'lib', platform, builder.arch, thirdpartyLibraries[i] + '.winmd')
 		});
 	}
 

--- a/cli/lib/stub.js
+++ b/cli/lib/stub.js
@@ -15,17 +15,7 @@ var fs = require('fs'),
 	path = require('path'),
 	async = require('async'),
 	spawn = require('child_process').spawn,
-	logger, windowsInfo,
-	targetPlatformSdkVersion, targetPlatformSdkMinVersion,
-	cmakePlatform;
-
-exports.init = function(thiz) {
-	logger = thiz.logger;
-	windowsInfo = thiz.windowsInfo;
-	targetPlatformSdkVersion    = thiz.targetPlatformSdkVersion === '10.0' ? windowsInfo.windows['10.0'].sdks[0] : thiz.targetPlatformSdkVersion;
-	targetPlatformSdkMinVersion = thiz.targetPlatformSdkMinVersion === '10.0' ? targetPlatformSdkVersion : thiz.targetPlatformSdkMinVersion;
-	cmakePlatform = thiz.cmakePlatform;
-};
+	logger, windowsInfo;
 
 function generateCmakeList(dest, modules, next) {
 	var cmakelist_template = path.join(dest, 'CMakeLists.txt.ejs'),
@@ -171,17 +161,25 @@ function buildNativeTypeHelper(dest, platform, buildConfiguration, callback) {
 	});
 }
 
-function generateTargetVersion(dest, platform, callback) {
+function generateNativeProject(dest, platform, builder, options, callback) {
 	var template = path.join(dest, platform, 'TitaniumWindows_Hyperloop.csproj.ejs'),
-		csproj   = path.join(dest, platform, 'TitaniumWindows_Hyperloop.csproj');
+		csproj   = path.join(dest, platform, 'TitaniumWindows_Hyperloop.csproj'),
+		externalReferences = [];
+		thirdpartyLibraries = builder.hyperloopConfig.windows.thirdparty && Object.keys(builder.hyperloopConfig.windows.thirdparty) || [];
 
-	logger.trace("Updating target version for " + platform);
+	for (var i = 0; i < thirdpartyLibraries.length; i++) {
+		externalReferences.push({
+			Include: thirdpartyLibraries[i],
+			HintPath: '..\\..\\lib\\' + platform + '\\' + builder.arch + '\\' + thirdpartyLibraries[i] + '.winmd'
+		});
+	}
 
 	fs.readFile(template, 'utf8', function (err, data) {
 		if (err) throw err;
 		data = ejs.render(data, { 
-			targetPlatformSdkVersion:    targetPlatformSdkVersion,
-			targetPlatformSdkMinVersion: targetPlatformSdkMinVersion
+			externalReferences:          externalReferences,
+			targetPlatformSdkVersion:    options.sdkVersion,
+			targetPlatformSdkMinVersion: options.sdkMinVersion
 		}, {});
 
 		fs.writeFile(csproj, data, function(err) {
@@ -263,24 +261,29 @@ function runMSBuild(slnFile, buildConfiguration, callback) {
 
 /**
  * Generates the set of native type wrappers.
- * @param {String} dest - the location on disk where to place the generate types.
- * @param {Array[map]} modules - List of native modules
- * @param {Array[map]} native_types - List of native types
- * @param {Array[map]} native_events - List of native events
+ * @param {Object} builder - Builder
  * @param {Function} finished - Callback when detection is finished
  */
-exports.generate = function generate(dest, modules, native_types, native_events, finished) {
-	var dest_Native    = path.join(dest, 'Native'),
+exports.generate = function generate(builder, finished) {
+
+	var dest = builder.buildDir,
+		modules = builder.modules,
+		native_types   = builder.native_types || {},
+		native_events  = builder.native_events || {},	
+		dest_Native    = path.join(dest, 'Native'),
 		dest_Hyperloop = path.join(dest, 'TitaniumWindows_Hyperloop');
 
-	native_types  = native_types  || {};
-	native_events = native_events || {};
+	logger = builder.logger;
+	windowsInfo = builder.windowsInfo;
+
+	var sdkVersion = builder.targetPlatformSdkVersion === '10.0' ? windowsInfo.windows['10.0'].sdks[0] : builder.targetPlatformSdkVersion,
+	 	sdkMinVersion = builder.targetPlatformSdkMinVersion === '10.0' ? sdkVersion : builder.targetPlatformSdkMinVersion;
 
 	var platform = 'win10';
-	if (targetPlatformSdkVersion === '8.1') {
-		if (cmakePlatform === 'WindowsStore') {
+	if (sdkVersion === '8.1') {
+		if (builder.cmakePlatform === 'WindowsStore') {
 			platform = 'store';
-		} else if (cmakePlatform === 'WindowsPhone') {
+		} else if (builder.cmakePlatform === 'WindowsPhone') {
 			platform = 'phone';
 		}
 	}
@@ -296,7 +299,11 @@ exports.generate = function generate(dest, modules, native_types, native_events,
 					generateNativeTypeHelper(dest_Hyperloop, native_types, native_events, next);
 				},
 				function(next) {
-					generateTargetVersion(dest_Hyperloop, 'win10', next);
+					generateNativeProject(dest_Hyperloop, platform, builder, 
+						{
+							sdkVersion: sdkVersion,
+							sdkMinVersion: sdkMinVersion
+						}, next);
 				},
 				function(next) {
 					buildNativeTypeHelper(dest_Hyperloop, platform, 'Debug', next);

--- a/templates/build/CMakeLists.txt.ejs
+++ b/templates/build/CMakeLists.txt.ejs
@@ -177,6 +177,12 @@ set_property(TARGET ${EXE_NAME}
   "<%= targetPlatformSdkMinVersion %>")
 <% } -%>
 
+<% for(var i = 0; i < native_modules.length; i++) { -%>
+file(GLOB MODULE_WINRT_REFERENCES_<%= i %> <%= native_modules[i].path %>/${PLATFORM}/${Ti_ARCH}/*.winmd)
+<% } -%>
+
+file(GLOB THIRD_WINRT_REFERENCES ${PROJECT_SOURCE_DIR}/lib/${PLATFORM}/${Ti_ARCH}/*.winmd)
+
 set_property(TARGET ${EXE_NAME}
   PROPERTY VS_WINRT_REFERENCES
   "${WINDOWS_SOURCE_DIR}/lib/TitaniumWindows_Filesystem/${PLATFORM}/${Ti_ARCH}/TitaniumWindows_Filesystem.winmd"
@@ -189,8 +195,9 @@ set_property(TARGET ${EXE_NAME}
   "${WINDOWS_SOURCE_DIR}/lib/TitaniumWindows/${PLATFORM}/${Ti_ARCH}/TitaniumWindows.winmd"
   "${WINDOWS_SOURCE_DIR}/lib/TitaniumWindows_UI/${PLATFORM}/${Ti_ARCH}/TitaniumWindows_UI.winmd"
   "${WINDOWS_SOURCE_DIR}/lib/TitaniumWindows_Utility/${PLATFORM}/${Ti_ARCH}/TitaniumWindows_Utility.winmd"
+  ${THIRD_WINRT_REFERENCES}
 <% for(var i = 0; i < native_modules.length; i++) { -%>
-  "<%= native_modules[i].path %>/${PLATFORM}/${Ti_ARCH}/<%= native_modules[i].projectname %>.winmd"
+  ${MODULE_WINRT_REFERENCES_<%= i %>}
 <% if (native_modules[i].projectname == 'Hyperloop') { -%>
   "${PROJECT_SOURCE_DIR}/TitaniumWindows_Hyperloop/bin/${PLATFORM}/Release/TitaniumWindows_Hyperloop.winmd"
   "<%= native_modules[i].path %>/${PLATFORM}/${Ti_ARCH}/HyperloopInvocation.winmd"

--- a/templates/build/TitaniumWindows_Hyperloop/phone/TitaniumWindows_Hyperloop.csproj.ejs
+++ b/templates/build/TitaniumWindows_Hyperloop/phone/TitaniumWindows_Hyperloop.csproj.ejs
@@ -44,6 +44,15 @@
     <Compile Include="..\src\TypeHelper.cs" />
     <Compile Include="..\src\Properties\AssemblyInfo.cs" />
   </ItemGroup>
+<% if (externalReferences.length > 0) { -%>
+  <ItemGroup>
+<% for(var i = 0; i < externalReferences.length; i++) { -%>
+    <Reference Include="<%= externalReferences[i].Include %>">
+      <HintPath><%= externalReferences[i].HintPath %></HintPath>
+    </Reference>
+<% } -%>
+  </ItemGroup>
+<% } -%>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/templates/build/TitaniumWindows_Hyperloop/store/TitaniumWindows_Hyperloop.csproj.ejs
+++ b/templates/build/TitaniumWindows_Hyperloop/store/TitaniumWindows_Hyperloop.csproj.ejs
@@ -44,6 +44,15 @@
     <Compile Include="..\src\TypeHelper.cs" />
     <Compile Include="..\src\Properties\AssemblyInfo.cs" />
   </ItemGroup>
+<% if (externalReferences.length > 0) { -%>
+  <ItemGroup>
+<% for(var i = 0; i < externalReferences.length; i++) { -%>
+    <Reference Include="<%= externalReferences[i].Include %>">
+      <HintPath><%= externalReferences[i].HintPath %></HintPath>
+    </Reference>
+<% } -%>
+  </ItemGroup>
+<% } -%>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/templates/build/TitaniumWindows_Hyperloop/win10/TitaniumWindows_Hyperloop.csproj.ejs
+++ b/templates/build/TitaniumWindows_Hyperloop/win10/TitaniumWindows_Hyperloop.csproj.ejs
@@ -111,6 +111,15 @@
     <Compile Include="..\src\TypeHelper.cs" />
     <Compile Include="..\src\Properties\AssemblyInfo.cs" />
   </ItemGroup>
+<% if (externalReferences.length > 0) { -%>
+  <ItemGroup>
+<% for(var i = 0; i < externalReferences.length; i++) { -%>
+    <Reference Include="<%= externalReferences[i].Include %>">
+      <HintPath><%= externalReferences[i].HintPath %></HintPath>
+    </Reference>
+<% } -%>
+  </ItemGroup>
+<% } -%>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>

--- a/templates/module/default/template/windows/CMakeLists.txt.ejs
+++ b/templates/module/default/template/windows/CMakeLists.txt.ejs
@@ -29,6 +29,11 @@ SET(CMAKE_FIND_LIBRARY_SUFFIXES ".lib" ".dll")
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_INCLUDE_CURRENT_DIR_IN_INTERFACE ON)
 
+set(<%= moduleIdAsIdentifier %>_ARCH "x86")
+if(CMAKE_GENERATOR MATCHES "^Visual Studio .+ ARM$")
+  set(<%= moduleIdAsIdentifier %>_ARCH "ARM")
+endif()
+
 option(<%- moduleIdAsIdentifier %>_DISABLE_TESTS "Disable compiling the tests" OFF)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
@@ -67,10 +72,13 @@ target_include_directories(<%- moduleIdAsIdentifier %> PUBLIC
   $<TARGET_PROPERTY:TitaniumWindows_Utility,INTERFACE_INCLUDE_DIRECTORIES>
   )
 
+file(GLOB MODULE_TARGET_LIBS ${PROJECT_SOURCE_DIR}/lib/${PLATFORM}/${<%- moduleIdAsIdentifier %>_ARCH}/*.lib)
+
 target_link_libraries(<%- moduleIdAsIdentifier %>
   HAL
   TitaniumKit
   TitaniumWindows_Utility
+  ${MODULE_TARGET_LIBS}
   )
 
 set_target_properties(<%- moduleIdAsIdentifier %> PROPERTIES VS_WINRT_COMPONENT TRUE)
@@ -87,6 +95,13 @@ set_property(TARGET <%- moduleIdAsIdentifier %> PROPERTY INTERFACE_<%- moduleIdA
 set_property(TARGET <%- moduleIdAsIdentifier %> APPEND PROPERTY
   COMPATIBLE_INTERFACE_STRING <%- moduleIdAsIdentifier %>_MAJOR_VERSION
   )
+
+
+file(GLOB MODULE_WINRT_REFERENCES ${PROJECT_SOURCE_DIR}/lib/${PLATFORM}/${<%- moduleIdAsIdentifier %>_ARCH}/*.winmd)
+set_property(TARGET <%- moduleIdAsIdentifier %>
+  PROPERTY VS_WINRT_REFERENCES
+  ${MODULE_WINRT_REFERENCES}
+)
 
 install(TARGETS <%- moduleIdAsIdentifier %> EXPORT <%- moduleIdAsIdentifier %>_Targets
   LIBRARY DESTINATION lib

--- a/templates/module/default/template/windows/lib/README.md
+++ b/templates/module/default/template/windows/lib/README.md
@@ -1,0 +1,2 @@
+You can place any DLL/WinMD dependencies in this directory and they will be included
+when your module is being compiled.

--- a/templates/module/default/template/windows/platform/README.md
+++ b/templates/module/default/template/windows/platform/README.md
@@ -1,0 +1,10 @@
+Files in this folder are copied directory into the Windows build directory
+when the Windows app is compiled:
+
+    <project-dir>/build/windows
+
+You can place files such as res strings or drawable files.
+
+Files in this directory are copied directly on top of whatever files are already
+in the build directory, so please be careful that your files don't clobber
+essential project files or files from other modules.

--- a/templates/module/default/template/windows/plugins/hooks/windows.js
+++ b/templates/module/default/template/windows/plugins/hooks/windows.js
@@ -3,7 +3,8 @@ var spawn = require('child_process').spawn,
     path = require('path'),
     fs   = require('fs'),
     ejs  = require('ejs'),
-    appc = require('node-appc');
+    appc = require('node-appc'),
+    wrench = require('wrench');
 
 exports.cliVersion = ">=3.2";
 exports.init = function(logger, config, cli, nodeappc) {
@@ -40,17 +41,33 @@ exports.init = function(logger, config, cli, nodeappc) {
     
 };
 
+function selectVisualStudio(data) {
+    if (data.windowsInfo && data.selectedVisualStudio) {
+        var version = data.selectedVisualStudio.version;
+        if (version == '12.0') {
+            return 'Visual Studio 12 2013';
+        } else if (version == '14.0') {
+            return 'Visual Studio 14 2015';
+        } else if (/^Visual Studio \w+ 2017/.test(version)) {
+            return 'Visual Studio 15 2017';
+        }
+    }
+    return 'Visual Studio 14 2015';
+}
+
 function runCmake(data, platform, arch, sdkVersion, next) {
     var logger = data.logger,
-        generatorName = 'Visual Studio 14 2015' + (arch==='ARM' ? ' ARM' : ''),
+        generatorName = selectVisualStudio(data) + (arch==='ARM' ? ' ARM' : ''),
         cmakeProjectName = (sdkVersion === '10.0' ? 'Windows10' : platform) + '.' + arch,
         cmakeWorkDir = path.resolve(__dirname,'..','..',cmakeProjectName);
 
     logger.debug('Run CMake on ' + cmakeWorkDir);
 
-    if (!fs.existsSync(cmakeWorkDir)) {
-        fs.mkdirSync(cmakeWorkDir);
+    if (fs.existsSync(cmakeWorkDir)) {
+        wrench.rmdirSyncRecursive(cmakeWorkDir);
     }
+
+    fs.mkdirSync(cmakeWorkDir);
 
     var p = spawn(path.join(data.titaniumSdkPath,'windows','cli','vendor','cmake','bin','cmake.exe'),
         [


### PR DESCRIPTION
[TIMOB-24101](https://jira.appcelerator.org/browse/TIMOB-24101)

Ability to use 3rd-party Windows Runtime component with hyperloop.

**This requires #961 to be merged.** This PR is actually created on top of #961 so this includes these changes too. Checkout individual commit https://github.com/appcelerator/titanium_mobile_windows/commit/404f3a4355f43308af2508400284ecda9b0e768b for code review. This requires latest Hyperloop module.

**Steps to test**

1. Create Windows Runtime Component

Create Windows Runtime Component named `WindowsRuntimeComponent1` from Visual Studio. Compile it and you should get `WindowsRuntimeComponent1.winmd` somewhere under in your Visual Studio project folder. You can skip this step by using prebuilt [WindowsRuntimeComponent1.winmd](https://jira.appcelerator.org/secure/attachment/61987/61987_WindowsRuntimeComponent1.winmd).

```csharp
using System;

namespace WindowsRuntimeComponent1
{
    public sealed class Test
    {
        public int SampleNumber { get; set; }

        public static string SayHello(string str)
        {
            return String.Format("Hello, {0}!", str);
        }

        public string sayNumber()
        {
            return String.Format("SampleNumber is {0}.", SampleNumber);
        }
    }
}
```

2. Copy your `WindowsRuntimeComponent1.winmd` file into `lib/windows/win10/x86/` under  your Titanium app project folder.

**app.js**

```javascript
var win = Ti.UI.createWindow({ backgroundColor: 'green' }),
    Test = require('WindowsRuntimeComponent1.Test'),
    test = new Test();

win.addEventListener('open', function() {
    alert(test.SayHello('World!'));
});

win.open();
```

3. Place `appc.windows.js` directly under your Titanium project folder. Make sure it contains names of your Windows Runtime component under `hyperloop.windows.thirdparty` key. It should look like below.

**appc.windows.js**

```js
/**
 * Hyperloop configuration
 */
module.exports = {
	type: 'app',
	group: 'titanium',
	dependencies: {},
	hyperloop: {
		windows:
		{
			/**
			 * Optionally, you can bring in third-party or first-party Windows Runtime components.
			 * The 'key' is the root namespace of the component that will be used in the require.
			 * There's no values for now but we reserve them for future release.
			 *
			 * Place the library files into the lib/windows/(phone|store|win10)/(x86|ARM)/ folder under your app project.
			 * Hyperloop will pick up the winmd files and will generate necessary bindings and include the winmd in your app. 
			 */
			thirdparty: {
				'WindowsRuntimeComponent1': {}
			}
		}
	}
};
```
4. Make sure to enable hyperloop, and then run it using `appc run -p windows --wp-sdk 10.0 --target ws-local -l trace`.
5. Then you should see "Hello, World!!" dialog box in your Titanium app.