### PR TITLE
[TIMOB-24561] Ti.Network change event crashes the app

### DIFF
--- a/Source/Network/src/Network.cpp
+++ b/Source/Network/src/Network.cpp
@@ -6,6 +6,7 @@
 
 #include "TitaniumWindows/Network.hpp"
 #include "Titanium/detail/TiLogger.hpp"
+#include "TitaniumWindows/Utility.hpp"
 
 namespace TitaniumWindows
 {
@@ -85,12 +86,14 @@ namespace TitaniumWindows
 		Titanium::Module::enableEvent(event_name);
 		if (event_name == "change") {
 			change_event__ = NetworkInformation::NetworkStatusChanged += ref new NetworkStatusChangedEventHandler([this](Platform::Object^ sender) {
-				const auto ctx = get_context();
-				auto object = ctx.CreateObject();
-				object.SetProperty("networkType", js_get_networkType());
-				object.SetProperty("networkTypeName", js_get_networkTypeName());
-				object.SetProperty("online", js_get_online());
-				fireEvent("change", object);
+				TitaniumWindows::Utility::RunOnUIThread([this]() {
+					const auto ctx = get_context();
+					auto object = ctx.CreateObject();
+					object.SetProperty("networkType", js_get_networkType());
+					object.SetProperty("networkTypeName", js_get_networkTypeName());
+					object.SetProperty("online", js_get_online());
+					fireEvent("change", object);
+				});
 			});
 		}
 	}


### PR DESCRIPTION
[TIMOB-24561](https://jira.appcelerator.org/browse/TIMOB-24561)

Using `Ti.Network.change` event crashes app for Windows Store app.

1. Launch sample app (make sure you're online)
2. Turn the internet connection off.
3. Alert dialog should be shown accordingly

```js
var win = Ti.UI.createWindow({
    backgroundColor: 'green'
});

win.addEventListener('open', function () {
    Ti.Network.addEventListener('change', function (_evt) {
        alert(JSON.stringify(_evt));
    });
});

win.open();
```
