### PR TITLE
[TIMOB-24583] Native view should use absolute position in Ti View

### DIFF
--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -88,11 +88,13 @@ namespace TitaniumWindows
 			const auto object_ptr = view.GetPrivate<TitaniumWindows::Platform_Object>();
 			if (object_ptr) {
 				auto elm_ctor  = ctx.CreateObject(JSExport<TitaniumWindows::UI::FrameworkElementWrapper>::Class());
-				const auto elm = elm_ctor.CallAsConstructor();
+				auto elm = elm_ctor.CallAsConstructor();
 				const auto elm_ptr = elm.GetPrivate<TitaniumWindows::UI::FrameworkElementWrapper>();
 				const auto element = safe_cast<FrameworkElement^>(object_ptr->get_native_object());
 				if (element) {
 					elm_ptr->setComponent(element);
+					elm.SetProperty("left", ctx.CreateNumber(Canvas::GetLeft(element)));
+					elm.SetProperty("top",  ctx.CreateNumber(Canvas::GetTop(element)));
 					return std::dynamic_pointer_cast<Titanium::UI::View>(elm_ptr);
 				}
 			}


### PR DESCRIPTION
[TIMOB-24583](https://jira.appcelerator.org/browse/TIMOB-24583)

```js
var win = Ti.UI.createWindow({
    backgroundColor: 'green'
});

var Canvas = require('Windows.UI.Xaml.Controls.Canvas'),
    SolidColorBrush = require('Windows.UI.Xaml.Media.SolidColorBrush'),
    Colors = require('Windows.UI.Colors'),
    TranslateTransform = require('Windows.UI.Xaml.Media.TranslateTransform');

var box = new Canvas();
box.Background = new SolidColorBrush(Colors.Red);
box.Width = 50;
box.Height = 50;

Canvas.SetLeft(box, 100);
Canvas.SetTop(box, 200);

win.add(box);
win.open();
```

**Expected**

Red box should be placed at position `left=100, top=200`

**Actual**

Red box is placed at center of the Window