### PR TITLE
[TIMOB-24615] HTTPClient.responseText is not cleared

### DIFF
--- a/Source/Network/src/HTTPClient.cpp
+++ b/Source/Network/src/HTTPClient.cpp
@@ -92,6 +92,9 @@ namespace TitaniumWindows
 				method__ = Titanium::Network::RequestMethod::Options;
 			}
 
+			responseData__.clear();
+			responseDataLen__ = 0;
+
 			location__ = location;
 			filter__ = ref new Windows::Web::Http::Filters::HttpBaseProtocolFilter();
 			httpClient__ = ref new Windows::Web::Http::HttpClient(filter__);


### PR DESCRIPTION
[TIMOB-24615](https://jira.appcelerator.org/browse/TIMOB-24615)

Test Case

```js
var responseText = '';

var count = 0;
var client = Ti.Network.createHTTPClient();
client.onerror = function (e) {

};
client.onload = function (e) {
    count = count + 1;
    Ti.API.info((client.responseText == responseText) + ' should be false');
    responseText = client.responseText;
    if (count < 2) {
        setTimeout(function () {
            client.setRequestHeader('X-Request-Date', new Date().toString());
            client.open("GET", "https://httpbin.org/get");
            client.send();
        }, 1000);
    }
};
client.setTimeout(60000);
client.validatesSecureCertificate = false;
client.setRequestHeader('X-Request-Date', new Date().toString());
client.open("GET", "https://httpbin.org/get");
client.send();
```

should print

```
[INFO] false should be false
[INFO] false should be false
```