### PR TITLE
[TIMOB-24656] Skip installing dependencies on deployment

### DIFF
--- a/cli/hooks/wp-run.js
+++ b/cli/hooks/wp-run.js
@@ -268,28 +268,30 @@ exports.init = function (logger, config, cli) {
 						});
 				}
 
-				// Install dependencies
-				var possibleDependencies = fs.readdirSync(dependenciesDir);
-				possibleDependencies = possibleDependencies.filter(function(file) {
-					return appxExtensions.indexOf(path.extname(file)) !== -1;
-				});
-				possibleDependencies.forEach(function(file) {
-					installs.push(function (next) {
-						logger.info(__('Installing dependency: %s', file));
-						windowslib.install(builder.deviceId, path.resolve(dependenciesDir, file), installOnlyOpts)
-						.on('installed', function (handle) {
-							next();
-						})
-						.on('timeout', function (err) {
-							logRelay && logRelay.stop();
-							next(err.message);
-						})
-						.on('error', function (err) {
-							logRelay && logRelay.stop();
-							next(err.message);
+				if (!cli.argv.hasOwnProperty('skipInstallDependencies')) {
+					// Install dependencies
+					var possibleDependencies = fs.readdirSync(dependenciesDir);
+					possibleDependencies = possibleDependencies.filter(function(file) {
+						return appxExtensions.indexOf(path.extname(file)) !== -1;
+					});
+					possibleDependencies.forEach(function(file) {
+						installs.push(function (next) {
+							logger.info(__('Installing dependency: %s', file));
+							windowslib.install(builder.deviceId, path.resolve(dependenciesDir, file), installOnlyOpts)
+							.on('installed', function (handle) {
+								next();
+							})
+							.on('timeout', function (err) {
+								logRelay && logRelay.stop();
+								next(err.message);
+							})
+							.on('error', function (err) {
+								logRelay && logRelay.stop();
+								next(err.message);
+							});
 						});
 					});
-				});
+				}
 
 				// Install actual app(s)
 				var possibleApps = fs.readdirSync(appxDir);


### PR DESCRIPTION
[TIMOB-24656](https://jira.appcelerator.org/browse/TIMOB-24656)

App deployment failed while installing dependencies. I found that we can actually skip the step. I suspect deployment behavior has been changed at some point of SDK update. I would add new command line option `--skipInstallDependencies` to keep backward compatibility.

```
appc run -p windows --wp-sdk 10.0 --target wp-device -l trace --skipInstallDependencies
```

Expected: App deployment and launch should not fail.

I would like to push this to 6.1.x because it's critical.
