### PR TITLE
[TIMOB-24618] Windows: Replace uglify usage in build process

### DIFF
--- a/cli/commands/_build/copy.js
+++ b/cli/commands/_build/copy.js
@@ -4,11 +4,9 @@ var appc = require('node-appc'),
 	fs = require('fs'),
 	crypto = require('crypto'),
 	jsanalyze = require('node-titanium-sdk/lib/jsanalyze'),
-	os = require('os'),
 	path = require('path'),
 	ti = require('node-titanium-sdk'),
 	wrench = require('wrench'),
-	babel = require('babel-core'),
 	babylon = require('babylon'),
 	types = require('babel-types'),
 	traverse = require('babel-traverse').default,
@@ -46,7 +44,7 @@ function copyResultsToProject(next) {
 		});
 	}
 	next();
-};
+}
 
 /**
  * Copies files from the project's "Resources", "Resources\windows", and "platform\windows"
@@ -333,10 +331,10 @@ function copyResources(next) {
 			// TODO: Generate SplashScreen.scale-100.png?
 		],
 		md5 = function (file) {
-		    return crypto
-		        .createHash('md5')
-		        .update(fs.readFileSync(file), 'binary')
-		        .digest('hex')
+			return crypto
+				.createHash('md5')
+				.update(fs.readFileSync(file), 'binary')
+				.digest('hex')
 		};
 
 		// if the app icon does not exist then check if it exists in the project root
@@ -463,9 +461,9 @@ function copyResources(next) {
 		});
 	});
 
-	this.modules.forEach(function (module) {
+	// this.modules.forEach(function (module) {
 		// TODO: copy any module specific resources here
-	}, this);
+	// }, this);
 
 	var platformPaths = [];
 	// WARNING! This is pretty dangerous, but yes, we're intentionally copying
@@ -528,7 +526,7 @@ function copyResources(next) {
 				var fromContent = fs.readFileSync(from, {encoding: 'utf8'}),
 					ast;
 				try {
-					ast = babylon.parse(fromContent, { filename: from }););
+					ast = babylon.parse(fromContent, { filename: from });
 				} catch (E) {
 					t_.logger.error(reportJSErrors(from, fromContent, E));
 					return next('Failed to parse JavaScript files.');

--- a/cli/commands/_build/encrypt.js
+++ b/cli/commands/_build/encrypt.js
@@ -7,7 +7,6 @@ var appc = require('node-appc'),
 	path = require('path'),
 	ti = require('node-titanium-sdk'),
 	wrench = require('wrench'),
-	UglifyJS = require('uglify-js'),
 	__ = appc.i18n(__dirname).__;
 
 /*


### PR DESCRIPTION
**JIRA**: https://jira.appcelerator.org/browse/TIMOB-24618

**Description**
uglify-js **still** does not support ES6/7+, which has the effect of breaking our CLI handling non-ES5 JS code. We want to be able to support users writing JS code in ES6+ because our JS engines often support newer features.

To do so, we're trying to move away from using uglify-js for any parsing/walking AST/transforming of JS code; and moving to the babel ecosystem. This PR attempts to replace usage of uglify-js with the babel equivalents in the Windows CLI code.

This code appears to be very specific to Windows hyperloop where we're detecting use of native requires/types. As such, I think the real test here is:

1. Can the user make use of ES6 syntax in their app.js (or elsewhere in their app) and the CLI won't barf on it?
2. Does this still handle hyperloop usage and properly detect reference native types?


