### PR TITLE
[TIMOB-24644] Decouple Hyperloop logic and Ti SDK

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/WebView.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/WebView.hpp
@@ -47,7 +47,7 @@ namespace TitaniumWindows
 			static std::string InjectLocalScript(const std::string& content);
 
 			virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;
-			virtual std::string evalJS(const std::string& code, JSObject& callback) override TITANIUM_NOEXCEPT;
+			virtual std::string evalJS(const std::string& code, JSObject& callback) TITANIUM_NOEXCEPT override;
 
 			virtual void _executeListener(const std::string& name, const std::string& data) TITANIUM_NOEXCEPT override;
 

--- a/Source/UI/src/ImageView.cpp
+++ b/Source/UI/src/ImageView.cpp
@@ -354,7 +354,7 @@ namespace TitaniumWindows
 			return true;
 		}
 
-		void ImageView::set_imageAsBlob(const std::shared_ptr<Titanium::Blob>& blob)
+		void ImageView::set_imageAsBlob(const std::shared_ptr<Titanium::Blob>& blob) TITANIUM_NOEXCEPT
 		{
 			Titanium::UI::ImageView::set_imageAsBlob(blob);
 
@@ -367,7 +367,7 @@ namespace TitaniumWindows
 			});
 		}
 
-		void ImageView::set_imageAsFile(const std::shared_ptr<Titanium::Filesystem::File>& file)
+		void ImageView::set_imageAsFile(const std::shared_ptr<Titanium::Filesystem::File>& file) TITANIUM_NOEXCEPT
 		{
 			Titanium::UI::ImageView::set_imageAsFile(file);
 

--- a/Source/UI/src/ScrollView.cpp
+++ b/Source/UI/src/ScrollView.cpp
@@ -23,7 +23,7 @@ namespace TitaniumWindows
 		{
 		}
 
-		JSFunction ScrollViewLayoutDelegate::CreateClickCallback(const JSObject& contentView)
+		JSFunction ScrollViewLayoutDelegate::CreateClickCallback(const JSObject& contentView) TITANIUM_NOEXCEPT
 		{
 			const std::string script = R"JS(
                  this._ti_scrollview_click_event_source_ = e.source;

--- a/Source/UI/src/TableView.cpp
+++ b/Source/UI/src/TableView.cpp
@@ -594,7 +594,7 @@ namespace TitaniumWindows
 			collectionViewSource__->Source = ref new Vector<Platform::Object^>();
 		}
 
-		std::uint32_t TableView::getRowIndexInCollectionView(const std::shared_ptr<Titanium::UI::TableViewSection>& section, const std::uint32_t& rowIndex)
+		std::uint32_t TableView::getRowIndexInCollectionView(const std::shared_ptr<Titanium::UI::TableViewSection>& section, const std::uint32_t& rowIndex) TITANIUM_NOEXCEPT
 		{
 			return rowIndex + /* +1 to skip section header */ (section->hasHeader() ? 1 : 0);
 		}

--- a/cli/lib/stub.js
+++ b/cli/lib/stub.js
@@ -288,36 +288,62 @@ exports.generate = function generate(builder, finished) {
 		}
 	}
 
-	async.parallel([
-		function(callback) {
-			// generate native types only when hyperloop is used
-			if (Object.keys(native_types).length === 0) {
-				return callback();
-			}
-			async.series([
-				function(next) {
-					generateNativeTypeHelper(dest_Hyperloop, native_types, native_events, next);
+	if (builder.useHyperloopBuilder) {
+		//
+		// Let Hyperloop module generate code (>= Hyperloop 2.2.0)
+		//
+		builder.cli.createHook('build.windows.stub.generate', builder, function (builder, done) {
+			async.parallel([
+				function(cb) {
+					builder.cli.createHook('build.windows.stub.generateCmakeList', builder, function (builder, cb) {
+						generateCmakeList(dest_Native, builder.modules, cb);
+					})(builder, cb);
 				},
-				function(next) {
-					generateNativeProject(dest_Hyperloop, platform, builder, 
-						{
-							sdkVersion: sdkVersion,
-							sdkMinVersion: sdkMinVersion
-						}, next);
-				},
-				function(next) {
-					buildNativeTypeHelper(dest_Hyperloop, platform, 'Debug', next);
-				},
-				function(next) {
-					buildNativeTypeHelper(dest_Hyperloop, platform, 'Release', next);
+				function(cb) {
+					builder.cli.createHook('build.windows.stub.generateRequireHook', builder, function (builder, cb) {
+						generateRequireHook(dest_Native, builder.modules, builder.native_types, cb);
+					})(builder, cb);
 				}
-			], callback);
-		},
-		function(callback) {
-			generateCmakeList(dest_Native, modules, callback);
-		},
-		function(callback) {
-			generateRequireHook(dest_Native, modules, native_types, callback);
-		}
-	], finished);
+			], function() {
+				done();
+			});
+		})(builder, finished);
+	} else {
+		//
+		// Compatibility Mode
+		// Use 'built-in' code generation for older version of Hyperloop module (< Hyperloop 2.2.0)
+		//
+		async.parallel([
+			function(callback) {
+				// generate native types only when hyperloop is used
+				if (Object.keys(native_types).length === 0) {
+					return callback();
+				}
+				async.series([
+					function(next) {
+						generateNativeTypeHelper(dest_Hyperloop, native_types, native_events, next);
+					},
+					function(next) {
+						generateNativeProject(dest_Hyperloop, platform, builder, 
+							{
+								sdkVersion: sdkVersion,
+								sdkMinVersion: sdkMinVersion
+							}, next);
+					},
+					function(next) {
+						buildNativeTypeHelper(dest_Hyperloop, platform, 'Debug', next);
+					},
+					function(next) {
+						buildNativeTypeHelper(dest_Hyperloop, platform, 'Release', next);
+					}
+				], callback);
+			},
+			function(callback) {
+				generateCmakeList(dest_Native, modules, callback);
+			},
+			function(callback) {
+				generateRequireHook(dest_Native, modules, native_types, callback);
+			}
+		], finished);
+	}
 };


### PR DESCRIPTION
[TIMOB-24644](https://jira.appcelerator.org/browse/TIMOB-24644)

Move Hyperloop-related code & logic to hyperloop plugin.

This PR doesn't actually remove existing Hyperloop logic and template files, but provides "compatibility mode" so we can run older version of Hyperloop module (< 2.2.0) in the newer version of Titanium SDK (>= 6.2.X).
