### PR TITLE
[6_1_X] [TIMOB-24714] ListView's scroll breaks if search bar added

### DIFF
--- a/Source/UI/src/ListView.cpp
+++ b/Source/UI/src/ListView.cpp
@@ -181,7 +181,7 @@ namespace TitaniumWindows
 				const auto row2 = ref new Windows::UI::Xaml::Controls::RowDefinition();
 
 				row1->Height = GridLengthHelper::Auto;
-				row2->Height = GridLengthHelper::Auto;
+				row2->Height = GridLengthHelper::FromValueAndType(1.0, GridUnitType::Star); // <RowDefinition Height="*"/>
 
 				parent__->RowDefinitions->Append(row1);
 				parent__->RowDefinitions->Append(row2);


### PR DESCRIPTION
Cherry-pick #1002 for 6_1_X.

I would like to backport this into `6.1.x` if QA time permits.