### PR TITLE
[TIMOB-24751] Cannot build for Android if Windows SDK is not installed

### DIFF
--- a/cli/commands/_build/config/wpSDK.js
+++ b/cli/commands/_build/config/wpSDK.js
@@ -19,9 +19,10 @@ module.exports = function configOptionSDK(order) {
 				sdkTargets.push(version);
 			}
 		}
+		if (this.windowsInfo.windowsphone && this.windowsInfo.windowsphone[version]) {
+			sdkTargets = sdkTargets.concat(this.windowsInfo.windowsphone[version].sdks);
+		}
 	}
-
-	sdkTargets = sdkTargets.concat(this.windowsInfo.windowsphone[version].sdks);
 
 	function isWindows10(wpsdk) {
 		return (wpsdk && wpsdk.startsWith && wpsdk.startsWith('10.0'));


### PR DESCRIPTION
- Fix `wpSDK` when selecting `sdkTargets`

###### TEST CASE
- When building without Windows SDK installed
```
appc run -p android --build-only
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24751)