### PR TITLE
[TIMOB-24795] Add hintText to search bar

### DIFF
--- a/Examples/NMocha/src/Assets/ti.ui.searchbar.test.js
+++ b/Examples/NMocha/src/Assets/ti.ui.searchbar.test.js
@@ -95,4 +95,18 @@ describe('Ti.UI.SearchBar', function () {
 		});
 		win.open();
 	});
+
+	it('Should be able to set/set hintText', function (finish) {
+	    var search = Ti.UI.createSearchBar({
+	        hintText: 'Search'
+	    });
+	    should(search.hintText).eql('Search');
+	    should(search.getHintText()).eql('Search');
+	    should(function() {
+	        search.setHintText('Updated search');
+	    }).not.throw();
+	    should(search.hintText).eql('Updated search');
+	    should(search.getHintText()).eql('Updated search');
+	    finish();
+	})
 });

--- a/Source/UI/include/TitaniumWindows/UI/SearchBar.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/SearchBar.hpp
@@ -52,6 +52,10 @@ namespace TitaniumWindows
 			virtual std::string get_value() const TITANIUM_NOEXCEPT override;
 			virtual void set_value(const std::string&) TITANIUM_NOEXCEPT override;
 
+			virtual void set_hintText(const std::string&) TITANIUM_NOEXCEPT override;
+			virtual std::string get_hintText() const TITANIUM_NOEXCEPT override;
+
+
 		private:
 			Windows::UI::Xaml::Controls::Border^ border__;
 #if defined(IS_WINDOWS_PHONE) || defined(IS_WINDOWS_10)

--- a/Source/UI/src/SearchBar.cpp
+++ b/Source/UI/src/SearchBar.cpp
@@ -118,5 +118,15 @@ namespace TitaniumWindows
 #endif
 		}
 
+		void SearchBar::set_hintText(const std::string& hintText) TITANIUM_NOEXCEPT
+		{
+			Titanium::UI::SearchBar::set_hintText(hintText);
+			suggest_box__->PlaceholderText = TitaniumWindows::Utility::ConvertUTF8String(hintText);
+		}
+
+		std::string SearchBar::get_hintText() const TITANIUM_NOEXCEPT
+		{
+			return TitaniumWindows::Utility::ConvertUTF8String(suggest_box__->PlaceholderText);
+		}
 	}  // namespace UI
 }  // namespace TitaniumWindows


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-24795

Implement hintText for search bar

I had noticed that [in the docs](http://docs.appcelerator.com/platform/latest/#!/api/Titanium.UI.SearchBar) we show SearchBar as unimplemented on Windows, to fix this do I need to just add a SearchBar file [here](https://github.com/appcelerator/titanium_mobile_windows/tree/c6906ff2ecad57cc1942e6bec0c0a86e6912102a/apidoc/Titanium/UI)?

````
var win = Ti.UI.createWindow();
var searchWithHintText = Ti.UI.createSearchBar({
    hintText: 'Search...',
    color: "#333",
    top: 250,
    width: 300,
    backgroundColor: "#fff"
});
var searchWithoutHintText = Ti.UI.createSearchBar({
    color: "#333",
    top: 300,
    width: 300,
    backgroundColor: "#fff"
});
var setMethBtn = Ti.UI.createButton({
    title: 'Set the hintText via method',
    top: '15'
});
var setPropBtn = Ti.UI.createButton({
    title: 'Set the hintText via prop',
    top: 50
});
setMethBtn.addEventListener('click', function () {
    searchWithHintText.setHintText('Changed search text via method');
});
setPropBtn.addEventListener('click', function () {
    searchWithHintText.hintText = 'Changed search text via prop';
});
var getBtn = Ti.UI.createButton({
    title: 'Get the hintText',
    top:  150
 
});
getBtn.addEventListener('click', function () {
    console.log(searchWithHintText.hintText);
    console.log(searchWithHintText.getHintText());
});
win.add(setMethBtn);
win.add(setPropBtn);
win.add(getBtn);
win.add(searchWithHintText);
win.add(searchWithoutHintText);
win.open();
````