### PR TITLE
[TIMOB-24749] Implement ListView.marker event

### DIFF
--- a/Source/TitaniumKit/include/Titanium/UI/ListModel.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/ListModel.hpp
@@ -25,6 +25,8 @@ namespace Titanium
 			bool found { false };
 			std::uint32_t sectionIndex { 0 };
 			std::uint32_t rowIndex { 0 };
+			bool header { false };
+			bool footer { false };
 		};
 
 		/*!
@@ -72,25 +74,35 @@ namespace Titanium
 					const auto itemCount = section->get_itemCount();
 					const auto rowCountIncludingHeader = itemCount + (section->hasHeader() ? 1 : 0) + (section->hasFooter() ? 1 : 0);
 					totalItemCount += rowCountIncludingHeader;
+					const int32_t rowIndex = selectedIndex - (totalItemCount - rowCountIncludingHeader) - (section->hasHeader() ? 1 : 0);
 					if (totalItemCount <= selectedIndex) {
 						// we just count the total item
 						continue;
 					} else if (section->hasHeader() && selectedIndex == 0) {
 						// that's a first header
+						result.header = true;
 						break;
 					} else if (section->hasHeader() && totalItemCount == selectedIndex) {
 						// this indicates header is selected
+						result.header = true;
 						sectionIndex++;
 						break;
 					} else {
 						// this indicates selected index is in this section
-						result.rowIndex = selectedIndex - (totalItemCount - rowCountIncludingHeader) - (section->hasHeader() ? 1 : 0);
-						if (result.rowIndex >= itemCount) {
+						if (rowIndex < 0) {
+							// this indicates header is selected
+							result.header = true;
+							break;
+						} else if (rowIndex >= itemCount) {
 							if (section->hasFooter()) {
 								// this indicates footer is selected
+								result.footer = true;
+								result.rowIndex = itemCount - 1; // Last item in this section
 								break;
 							}
 						} else {
+							// we finally found the index
+							result.rowIndex = rowIndex;
 							result.found = true;
 							break;
 						}

--- a/Source/TitaniumKit/include/Titanium/UI/ListView.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/ListView.hpp
@@ -198,6 +198,13 @@ namespace Titanium
 			*/
 			virtual void setMarker(const ListViewMarkerProps& marker) TITANIUM_NOEXCEPT;
 
+			/*!
+			  @method
+			  @abstract addMarker
+			  @discussion Adds a reference item in the list view.
+			*/
+			virtual void addMarker(const ListViewMarkerProps& marker) TITANIUM_NOEXCEPT;
+
 			ListView(const JSContext&) TITANIUM_NOEXCEPT;
 
 			virtual ~ListView() = default;
@@ -228,6 +235,7 @@ namespace Titanium
 			TITANIUM_FUNCTION_DEF(deleteSectionAt);
 			TITANIUM_FUNCTION_DEF(insertSectionAt);
 			TITANIUM_FUNCTION_DEF(replaceSectionAt);
+			TITANIUM_FUNCTION_DEF(addMarker);
 			TITANIUM_FUNCTION_DEF(setMarker);
 			TITANIUM_FUNCTION_DEF(getTemplates);
 			TITANIUM_FUNCTION_DEF(setTemplates);
@@ -289,7 +297,7 @@ namespace Titanium
 			bool showVerticalScrollIndicator__;
 			std::string separatorColor__;
 			std::string defaultItemTemplate__;
-			ListViewMarkerProps marker__;
+			std::vector<ListViewMarkerProps> markers__;
 
 			JSObject ti_listview_exports__;
 			JSObject sectionViewCreateFunction__;

--- a/Source/TitaniumKit/include/Titanium/UI/ListViewMarkerProps.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/ListViewMarkerProps.hpp
@@ -26,6 +26,10 @@ namespace Titanium
 		{
 			int32_t itemIndex {0};
 			int32_t sectionIndex {0};
+			//
+			// This indicates marker event is fired for this marker
+			//
+			bool fired { false };
 		};
 		
 		TITANIUMKIT_EXPORT ListViewMarkerProps js_to_ListViewMarkerProps(const JSObject& object);

--- a/Source/TitaniumKit/src/UI/ListView.cpp
+++ b/Source/TitaniumKit/src/UI/ListView.cpp
@@ -196,9 +196,15 @@ namespace Titanium
 			model__->replaceSectionAt(index, sections);
 		}
 
+		void ListView::addMarker(const ListViewMarkerProps& marker) TITANIUM_NOEXCEPT
+		{
+			markers__.push_back(marker);
+		}
+
 		void ListView::setMarker(const ListViewMarkerProps& marker) TITANIUM_NOEXCEPT
 		{
-			marker__ = marker;
+			markers__.clear();
+			markers__.push_back(marker);
 		}
 
 		void ListView::fireListSectionEvent(const std::string& name, const std::shared_ptr<ListSection>& section, const std::uint32_t& itemIndex, const std::uint32_t& itemCount, const std::uint32_t& affectedRows)
@@ -238,6 +244,7 @@ namespace Titanium
 			TITANIUM_ADD_FUNCTION(ListView, deleteSectionAt);
 			TITANIUM_ADD_FUNCTION(ListView, insertSectionAt);
 			TITANIUM_ADD_FUNCTION(ListView, replaceSectionAt);
+			TITANIUM_ADD_FUNCTION(ListView, addMarker);
 			TITANIUM_ADD_FUNCTION(ListView, setMarker);
 			TITANIUM_ADD_FUNCTION(ListView, getTemplates);
 			TITANIUM_ADD_FUNCTION(ListView, setTemplates);
@@ -571,6 +578,16 @@ namespace Titanium
 				}
 
 				replaceSectionAt(sectionIndex, sections, animation.GetPrivate<ListViewAnimationProperties>());
+			}
+			return this_object.get_context().CreateUndefined();
+		}
+
+		TITANIUM_FUNCTION(ListView, addMarker)
+		{
+			if (arguments.size() >= 1) {
+				const auto _0 = arguments.at(0);
+				TITANIUM_ASSERT(_0.IsObject());
+				addMarker(js_to_ListViewMarkerProps(static_cast<JSObject>(_0)));
 			}
 			return this_object.get_context().CreateUndefined();
 		}

--- a/Source/UI/include/TitaniumWindows/UI/ListView.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/ListView.hpp
@@ -75,6 +75,8 @@ namespace TitaniumWindows
 			void clearListViewData();
 
 		private:
+			static Windows::UI::Xaml::Controls::ScrollViewer^ GetScrollView(Windows::UI::Xaml::DependencyObject^ obj);
+
 			void unregisterSectionLayoutNode(const std::shared_ptr<Titanium::UI::ListSection>& section);
 			void registerListViewItemAsLayoutNode(const std::shared_ptr<Titanium::UI::View>& view);
 			void unregisterListViewItemAsLayoutNode(const std::shared_ptr<Titanium::UI::View>& view);
@@ -83,16 +85,30 @@ namespace TitaniumWindows
 			void bindCollectionViewSource();
 			void unbindCollectionViewSource();
 
+			void updateScrollParams(const JSContext& ctx, JSObject params);
+			void registerScrollstartEvent();
+			void registerScrollingEvent();
+			void registerScrollendEvent();
+
 			Windows::UI::Xaml::Controls::Grid^ parent__;
 			Windows::UI::Xaml::Controls::ListView^ listview__;
 			Windows::UI::Xaml::Data::CollectionViewSource^ collectionViewSource__;
+			Windows::UI::Xaml::Controls::ScrollViewer^ scrollview__;
 
 			// This is the "view" of the underlying list view items that is shown in the UI. It may be filtered from set_searchText
 			Windows::Foundation::Collections::IObservableVector<::Platform::Object^>^ collectionViewItems__;
 
+			double oldScrollPosX__{ -1 };
+			double oldScrollPosY__{ -1 };
+			bool scrollstop__ { true };
+
 #pragma warning(push)
 #pragma warning(disable : 4251)
 			Windows::Foundation::EventRegistrationToken itemclick_event__;
+			Windows::Foundation::EventRegistrationToken loaded_event__;
+			Windows::Foundation::EventRegistrationToken scrollstart_event__;
+			Windows::Foundation::EventRegistrationToken scrolling_event__;
+			Windows::Foundation::EventRegistrationToken scrollend_event__;
 #pragma warning(pop)
 
 		};

--- a/Source/UI/include/TitaniumWindows/UI/ListView.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/ListView.hpp
@@ -35,7 +35,6 @@ namespace TitaniumWindows
 
 			TITANIUM_PROPERTY_UNIMPLEMENTED(showVerticalScrollIndicator);
 			TITANIUM_PROPERTY_UNIMPLEMENTED(separatorColor);
-			TITANIUM_FUNCTION_UNIMPLEMENTED(setMarker);
 			TITANIUM_PROPERTY_UNIMPLEMENTED(borderColor);
 			TITANIUM_PROPERTY_UNIMPLEMENTED(borderWidth);
 			TITANIUM_PROPERTY_UNIMPLEMENTED(borderRadius);
@@ -89,6 +88,8 @@ namespace TitaniumWindows
 			void registerScrollstartEvent();
 			void registerScrollingEvent();
 			void registerScrollendEvent();
+			void registerMarkerEvent();
+			void checkMarkers();
 
 			Windows::UI::Xaml::Controls::Grid^ parent__;
 			Windows::UI::Xaml::Controls::ListView^ listview__;
@@ -109,6 +110,8 @@ namespace TitaniumWindows
 			Windows::Foundation::EventRegistrationToken scrollstart_event__;
 			Windows::Foundation::EventRegistrationToken scrolling_event__;
 			Windows::Foundation::EventRegistrationToken scrollend_event__;
+			Windows::Foundation::EventRegistrationToken marker_event__;
+
 #pragma warning(pop)
 
 		};

--- a/Source/UI/src/ListView.cpp
+++ b/Source/UI/src/ListView.cpp
@@ -43,6 +43,21 @@ namespace TitaniumWindows
 			listview__->IsItemClickEnabled = true;
 			listview__->SelectionMode = Controls::ListViewSelectionMode::None;
 
+			// Since VisualTreeHelper is only available after Loaded event is fired, we need to register scroll/scrollend event after that.
+			loaded_event__ = listview__->Loaded += ref new RoutedEventHandler([this](Platform::Object^ sender, RoutedEventArgs^ e) {
+				scrollview__ = GetScrollView(Media::VisualTreeHelper::GetChild(listview__, 0));
+				TITANIUM_ASSERT(scrollview__ != nullptr);
+				if (hasEventListener("scrollstart")) {
+					registerScrollstartEvent();
+				}
+				if (hasEventListener("scrolling")) {
+					registerScrollingEvent();
+				}
+				if (hasEventListener("scrollend")) {
+					registerScrollendEvent();
+				}
+			});
+
 			resetListViewDataBinding();
 
 			parent__ = ref new Controls::Grid();
@@ -55,6 +70,21 @@ namespace TitaniumWindows
 			layoutDelegate__->set_defaultHeight(Titanium::UI::LAYOUT::FILL);
 
 			getViewLayoutDelegate<WindowsViewLayoutDelegate>()->setComponent(parent__, listview__);
+		}
+
+		Controls::ScrollViewer^ ListView::GetScrollView(DependencyObject^ root)
+		{
+			const auto count = Media::VisualTreeHelper::GetChildrenCount(root);
+			for (int i = 0; i < count; i++) {
+				const auto child = Media::VisualTreeHelper::GetChild(root, i);
+				const auto scrollview = dynamic_cast<Controls::ScrollViewer^>(child);
+				if (scrollview) {
+					return scrollview;
+				} else {
+					return ListView::GetScrollView(child);
+				}
+			}
+			return nullptr;
 		}
 
 		void ListView::resetListViewDataBinding() 
@@ -91,6 +121,77 @@ namespace TitaniumWindows
 		{
 			JSExport<ListView>::SetClassVersion(1);
 			JSExport<ListView>::SetParent(JSExport<Titanium::UI::ListView>::Class());
+		}
+
+		void ListView::updateScrollParams(const JSContext& ctx, JSObject params)
+		{
+			const auto itemsSize = listview__->Items->Size;
+			const auto itemHeight = scrollview__->ExtentHeight / itemsSize;
+			const auto visibleItemIndex = static_cast<std::size_t>(scrollview__->VerticalOffset / itemHeight);
+			const auto visibleItemCount = static_cast<std::size_t>(scrollview__->ViewportHeight / itemHeight);
+
+			const auto rowInfo = model__->searchRowBySelectedIndex(visibleItemIndex);
+
+			params.SetProperty("visibleItemCount", ctx.CreateNumber(visibleItemCount));
+			params.SetProperty("firstVisibleItemIndex", ctx.CreateNumber(rowInfo.rowIndex));
+			params.SetProperty("firstVisibleSectionIndex", ctx.CreateNumber(rowInfo.sectionIndex));
+
+			if (get_sectionCount() > rowInfo.sectionIndex) {
+				const auto section = get_sections().at(rowInfo.sectionIndex);
+				params.SetProperty("firstVisibleSection", section->get_object());
+				if (section->get_itemCount() > rowInfo.rowIndex) {
+					params.SetProperty("firstVisibleItem", ListDataItem_to_js(ctx, section->getItemAt(rowInfo.rowIndex)));
+				}
+			}
+		}
+
+		void ListView::registerScrollstartEvent()
+		{
+			scrollstart_event__ = scrollview__->ViewChanging += ref new Windows::Foundation::EventHandler<Controls::ScrollViewerViewChangingEventArgs ^>([this](Platform::Object^ sender, Controls::ScrollViewerViewChangingEventArgs^ e) {
+				if (scrollstop__) {
+					scrollstop__ = false;
+
+					const auto ctx = get_context();
+					auto eventArgs = ctx.CreateObject();
+
+					updateScrollParams(ctx, eventArgs);
+
+					fireEvent("scrollstart", eventArgs);
+				}
+			});
+		}
+
+		void ListView::registerScrollingEvent()
+		{
+			scrolling_event__ = scrollview__->ViewChanging += ref new Windows::Foundation::EventHandler<Controls::ScrollViewerViewChangingEventArgs ^>([this](Platform::Object^ sender, Controls::ScrollViewerViewChangingEventArgs^ e) {
+
+				const auto ctx = get_context();
+				auto eventArgs = ctx.CreateObject();
+
+				updateScrollParams(ctx, eventArgs);
+
+				fireEvent("scrolling", eventArgs);
+			});
+		}
+
+		void ListView::registerScrollendEvent()
+		{
+			scrollend_event__ = scrollview__->ViewChanged += ref new Windows::Foundation::EventHandler<Controls::ScrollViewerViewChangedEventArgs ^>([this](Platform::Object^ sender, Controls::ScrollViewerViewChangedEventArgs^ e) {
+				// Stop firing event when ScrollView didn't actually move
+				if (oldScrollPosX__ != scrollview__->VerticalOffset || oldScrollPosY__ != scrollview__->HorizontalOffset) {
+					scrollstop__ = true;
+
+					const auto ctx = get_context();
+					auto eventArgs = ctx.CreateObject();
+
+					updateScrollParams(ctx, eventArgs);
+
+					fireEvent("scrollend", eventArgs);
+
+					oldScrollPosX__ = scrollview__->VerticalOffset;
+					oldScrollPosY__ = scrollview__->HorizontalOffset;
+				}
+			});
 		}
 
 		void ListView::enableEvent(const std::string& event_name) TITANIUM_NOEXCEPT
@@ -160,6 +261,18 @@ namespace TitaniumWindows
 
 			if (event_name == "itemclick") {
 				listview__->ItemClick -= itemclick_event__;
+			} else if (event_name == "scrollstart") {
+				if (scrollview__) {
+					scrollview__->ViewChanging -= scrollstart_event__;
+				}
+			} else if (event_name == "scrolling") {
+				if (scrollview__) {
+					scrollview__->ViewChanged -= scrolling_event__;
+				}
+			} else if (event_name == "scrollend") {
+				if (scrollview__) {
+					scrollview__->ViewChanged -= scrollend_event__;
+				}
 			}
 		}
 


### PR DESCRIPTION
[TIMOB-24749](https://jira.appcelerator.org/browse/TIMOB-24749)

Implement [ListView.marker](https://docs.appcelerator.com/platform/latest/#!/api/Titanium.UI.ListView-event-marker) event.

- `{ sectionIndex: 0, itemIndex: 1 }` marker event should be fired when ListView is loaded
- `{ sectionIndex: 5, itemIndex: 1 }` marker event should be fired when it is visible (when you scroll down the list)
- Each markers should fire `marker` event only once.

Note that this PR is based on top of #1008. Please refer to commit https://github.com/appcelerator/titanium_mobile_windows/commit/10ca490b6a75c8e1ad1e246726d072db58aa94d8 for code review.
 
```js
var win = Ti.UI.createWindow({ backgroundColor: 'green', layout: 'vertical' });

var listView = Ti.UI.createListView({ width: Ti.UI.FILL, height: Ti.UI.FILL });
var sections = [];

for (var i = 0; i < 10; i++) {
    var fruitSection = Ti.UI.createListSection({ headerTitle: 'Fruits ' + i, footerTitle:' -- ' + i + ' -- ' });
    var items = [];
    for (var j = 0; j < 3; j++) {
        items.push({ properties: { title: 'Apple ' + i + '.' + j } });
    }
    fruitSection.setItems(items);
    sections.push(fruitSection);
}

listView.sections = sections;

// This should be fired immediately after ListView data is loaded
listView.addMarker({ sectionIndex: 0, itemIndex: 1 });

// This should be fired when you scroll down the list
listView.addMarker({ sectionIndex: 5, itemIndex: 1 });

listView.addEventListener('marker', function (e) {
    Ti.API.info(JSON.stringify(listView.sections[e.sectionIndex].items[e.itemIndex].properties));
});

win.add(listView);
win.open();
```
