### PR TITLE
[TIMOB-14410] Add hintTextid to all views

### DIFF
--- a/Examples/NMocha/src/Assets/ti.ui.searchbar.test.js
+++ b/Examples/NMocha/src/Assets/ti.ui.searchbar.test.js
@@ -102,11 +102,27 @@ describe('Ti.UI.SearchBar', function () {
 	    });
 	    should(search.hintText).eql('Search');
 	    should(search.getHintText()).eql('Search');
-	    should(function() {
+	    should(function () {
 	        search.setHintText('Updated search');
 	    }).not.throw();
 	    should(search.hintText).eql('Updated search');
 	    should(search.getHintText()).eql('Updated search');
 	    finish();
-	})
+	});
+
+	it("hinttextid", function (finish) {
+	    var search = Ti.UI.createSearchBar({
+	        hinttextid: "this is my key"
+	    });
+	    should(search.hinttextid).be.a.String;
+	    should(search.getHinttextid).be.a.Function;
+	    should(search.hinttextid).eql('this is my key');
+	    should(search.getHinttextid()).eql('this is my key');
+	    should(search.hintText).eql('this is my value');
+	    search.hinttextid = 'other text';
+	    should(search.hinttextid).eql('other text');
+	    should(search.getHinttextid()).eql('other text');
+	    should(search.hintText).eql('this is my value'); // should retain old value if can't find key
+	    finish();
+	});
 });

--- a/Examples/NMocha/src/Assets/ti.ui.textfield.test.js
+++ b/Examples/NMocha/src/Assets/ti.ui.textfield.test.js
@@ -95,7 +95,7 @@ describe('Titanium.UI.TextField', function () {
 	// suppressReturn
 
 
-	it.only("hinttextid", function (finish) {
+	it("hinttextid", function (finish) {
 	    var tf = Ti.UI.createTextField({
 	        hinttextid: "this is my key"
 	    });

--- a/Examples/NMocha/src/Assets/ti.ui.textfield.test.js
+++ b/Examples/NMocha/src/Assets/ti.ui.textfield.test.js
@@ -94,6 +94,23 @@ describe('Titanium.UI.TextField', function () {
 	// selection
 	// suppressReturn
 
+
+	it.only("hinttextid", function (finish) {
+	    var tf = Ti.UI.createTextField({
+	        hinttextid: "this is my key"
+	    });
+	    should(tf.hinttextid).be.a.String;
+	    should(tf.getHinttextid).be.a.Function;
+	    should(tf.hinttextid).eql('this is my key');
+	    should(tf.getHinttextid()).eql('this is my key');
+	    should(tf.hintText).eql('this is my value');
+	    tf.hinttextid = 'other text';
+	    should(tf.hinttextid).eql('other text');
+	    should(tf.getHinttextid()).eql('other text');
+	    should(tf.hintText).eql('this is my value'); // should retain old value if can't find key
+	    finish();
+	});
+
 	it.skip('width', function (finish) {
 		this.timeout(5000);
 		var textfield = Ti.UI.createTextField({

--- a/Source/TitaniumKit/include/Titanium/UI/TextField.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/TextField.hpp
@@ -125,6 +125,16 @@ namespace Titanium
 			TITANIUM_PROPERTY_IMPL_DEF(Font, font);
 
 			/*!
+			@method
+
+			@abstract hinttextid : String
+
+			@discussion Key identifying a string from the locale file to use for the TextField hintText.
+
+			*/
+			TITANIUM_PROPERTY_IMPL_DEF(std::string, hinttextid);
+
+			/*!
 			  @method
 
 			  @abstract hintText : String
@@ -335,6 +345,10 @@ namespace Titanium
 			TITANIUM_FUNCTION_DEF(getFont);
 			TITANIUM_FUNCTION_DEF(setFont);
 
+			TITANIUM_PROPERTY_DEF(hinttextid);
+			TITANIUM_FUNCTION_DEF(getHinttextid);
+			TITANIUM_FUNCTION_DEF(setHinttextid);
+
 			TITANIUM_PROPERTY_DEF(hintText);
 			TITANIUM_FUNCTION_DEF(getHintText);
 			TITANIUM_FUNCTION_DEF(setHintText);
@@ -396,6 +410,7 @@ namespace Titanium
 			bool ellipsize__;
 			bool enableReturnKey__;
 			Font font__;
+			std::string hinttextid__;
 			std::string hintText__;
 			KEYBOARD keyboardType__;
 			INPUT_BUTTONMODE leftButtonMode__;

--- a/Source/TitaniumKit/src/UI/SearchBar.cpp
+++ b/Source/TitaniumKit/src/UI/SearchBar.cpp
@@ -8,6 +8,7 @@
 
 #include "Titanium/UI/SearchBar.hpp"
 #include "Titanium/UI/TableViewRow.hpp"
+#include "Titanium/Locale.hpp"
 
 namespace Titanium
 {
@@ -36,7 +37,6 @@ namespace Titanium
 		TITANIUM_PROPERTY_READWRITE(SearchBar, bool, autocorrect)
 		TITANIUM_PROPERTY_READWRITE(SearchBar, std::string, barColor)
 		TITANIUM_PROPERTY_READWRITE(SearchBar, std::string, hintText)
-		TITANIUM_PROPERTY_READWRITE(SearchBar, std::string, hinttextid)
 		TITANIUM_PROPERTY_READWRITE(SearchBar, KEYBOARD, keyboardType)
 		TITANIUM_PROPERTY_READWRITE(SearchBar, KEYBOARD_APPEARANCE, keyboardAppearance)
 		TITANIUM_PROPERTY_READWRITE(SearchBar, std::string, prompt)
@@ -46,6 +46,16 @@ namespace Titanium
 		TITANIUM_PROPERTY_READWRITE(SearchBar, std::string, value)
 		TITANIUM_PROPERTY_READWRITE(SearchBar, std::function<void(const std::string&)>, querySubmitted)
 		TITANIUM_PROPERTY_READWRITE(SearchBar, std::function<std::vector<std::string>(const std::string&)>, suggestionRequested)
+
+		TITANIUM_PROPERTY_READ(SearchBar, std::string, hinttextid)
+		void SearchBar::set_hinttextid(const std::string& hinttextid) TITANIUM_NOEXCEPT
+		{
+			hinttextid__ = hinttextid;
+			const auto value = Titanium::Locale::GetString(get_context(), hinttextid);
+			if (value) {
+				set_hintText(*value);
+			}
+		}
 
 		void SearchBar::JSExportInitialize()
 		{

--- a/Source/TitaniumKit/src/UI/TextField.cpp
+++ b/Source/TitaniumKit/src/UI/TextField.cpp
@@ -9,6 +9,7 @@
 #include "Titanium/UI/TextField.hpp"
 #include "Titanium/detail/TiImpl.hpp"
 #include "Titanium/UI/AttributedString.hpp"
+#include "Titanium/Locale.hpp"
 #include <type_traits>
 
 namespace Titanium
@@ -58,6 +59,16 @@ namespace Titanium
 		TITANIUM_PROPERTY_READWRITE(TextField, std::shared_ptr<AttributedString>, attributedHintString)
 		TITANIUM_PROPERTY_READWRITE(TextField, std::shared_ptr<AttributedString>, attributedString)
 
+		TITANIUM_PROPERTY_READ(TextField, std::string, hinttextid)
+		void TextField::set_hinttextid(const std::string& hinttextid) TITANIUM_NOEXCEPT
+		{
+			hinttextid__ = hinttextid;
+			const auto value = Titanium::Locale::GetString(get_context(), hinttextid);
+			if (value) {
+				set_hintText(*value);
+			}
+		}
+
 		void TextField::blur() TITANIUM_NOEXCEPT
 		{
 			TITANIUM_LOG_DEBUG("TextField::blur");
@@ -89,6 +100,7 @@ namespace Titanium
 			TITANIUM_ADD_PROPERTY(TextField, ellipsize);
 			TITANIUM_ADD_PROPERTY(TextField, enableReturnKey);
 			TITANIUM_ADD_PROPERTY(TextField, font);
+			TITANIUM_ADD_PROPERTY(TextField, hinttextid);
 			TITANIUM_ADD_PROPERTY(TextField, hintText);
 			TITANIUM_ADD_PROPERTY(TextField, keyboardType);
 			TITANIUM_ADD_PROPERTY(TextField, leftButtonMode);
@@ -125,6 +137,8 @@ namespace Titanium
 			TITANIUM_ADD_FUNCTION(TextField, setEnableReturnKey);
 			TITANIUM_ADD_FUNCTION(TextField, getFont);
 			TITANIUM_ADD_FUNCTION(TextField, setFont);
+			TITANIUM_ADD_FUNCTION(TextField, getHinttextid);
+			TITANIUM_ADD_FUNCTION(TextField, setHinttextid);
 			TITANIUM_ADD_FUNCTION(TextField, getHintText);
 			TITANIUM_ADD_FUNCTION(TextField, setHintText);
 			TITANIUM_ADD_FUNCTION(TextField, getKeyboardType);
@@ -246,6 +260,12 @@ namespace Titanium
 
 		TITANIUM_FUNCTION_AS_GETTER(TextField, getFont, font)
 		TITANIUM_FUNCTION_AS_SETTER(TextField, setFont, font)
+
+		TITANIUM_PROPERTY_GETTER_STRING(TextField, hinttextid)
+		TITANIUM_PROPERTY_SETTER_STRING(TextField, hinttextid)
+
+		TITANIUM_FUNCTION_AS_GETTER(TextField, getHinttextid, hinttextid)
+		TITANIUM_FUNCTION_AS_SETTER(TextField, setHinttextid, hinttextid)
 
 		TITANIUM_PROPERTY_GETTER_STRING(TextField, hintText)
 		TITANIUM_PROPERTY_SETTER_STRING(TextField, hintText)


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-14410

Implement hinttextid for TextField and SearchBar

Verification:

i18n/en/strings.xml
````
<?xml version="1.0" encoding="UTF-8"?>
<resources>
	<string name="enter_email">Enter E-Mail ...</string>
	<string name="enter_password">Enter Password ...</string>	
</resources>
````

app.js
````
var win = Ti.UI.createWindow({
	backgroundColor : "#ccc"
}); 
win.add(Ti.UI.createTextField({
	hinttextid: "enter_email",
	width: 300,
	height: 40,
	color: "#333",
	hintTextColor: "#f00",
	backgroundColor: "#fff",
	top: 50
}));
win.add(Ti.UI.createSearchBar({
   hinttextid: "enter_email",
   top: 100
}));
win.open();
````