### PR TITLE
[TIMOB-24840] Calling setData on a tableview that already has data errors out

### DIFF
--- a/Source/UI/src/TableView.cpp
+++ b/Source/UI/src/TableView.cpp
@@ -144,6 +144,7 @@ namespace TitaniumWindows
 			for (const auto section : model__->get_sections()) {
 				unregisterSectionLayoutNode(section);
 			}
+			collectionViewItems__->Clear();
 		}
 
 		void TableView::setTableHeader()


### PR DESCRIPTION
- Clear `collectionViewItems__` when unregistering sections

###### TEST CASE
```JS
var win = Ti.UI.createWindow({layout: 'vertical'}),
    btn = Ti.UI.createButton({title: 'setData()'}),
    data = [
        [{ title: 'A' }, { title: 'B' }, { title: 'C' }, { title: 'D' }],
        [{ title: 'E' }, { title: 'F' }, { title: 'G' }, { title: 'H' }]
    ],
    table = Ti.UI.createTableView({
        data: data[0]
    });

btn.addEventListener('click', function () {
    table.setData(data[1]);
});

win.add(btn);
win.add(table);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24840)