### PR TITLE
[TIMOB-24873] Window.fullscreen doesn't work

### DIFF
--- a/Source/UI/src/Window.cpp
+++ b/Source/UI/src/Window.cpp
@@ -461,7 +461,16 @@ namespace TitaniumWindows
 			fullscreen ? statusBar->HideAsync() : statusBar->ShowAsync();
 #elif defined(IS_WINDOWS_10)
 			auto view = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
-			fullscreen ? view->TryEnterFullScreenMode() : view->ExitFullScreenMode();
+			if (fullscreen) {
+				if (view->TryEnterFullScreenMode()) {
+					Windows::UI::ViewManagement::ApplicationView::PreferredLaunchWindowingMode = Windows::UI::ViewManagement::ApplicationViewWindowingMode::FullScreen;
+				} else {
+					TITANIUM_LOG_WARN("Unable to enter fullscreen mode");
+				}
+			} else {
+				view->ExitFullScreenMode();
+				Windows::UI::ViewManagement::ApplicationView::PreferredLaunchWindowingMode = Windows::UI::ViewManagement::ApplicationViewWindowingMode::Auto;
+			}
 #endif
 		}
 


### PR DESCRIPTION
[TIMOB-24873](https://jira.appcelerator.org/browse/TIMOB-24873)

```js
var window = Ti.UI.createWindow({ backgroundColor: 'gray', fullscreen:true }),
    btn = Ti.UI.createButton({ title: 'CLOSE THIS WINDOW', bottom: 0, left: 0, width: '50%' });

btn.addEventListener('click', function () {
    window.close();
});

window.add(btn);
window.open();
```

I was referring to the sample code in [ Application​View Class](https://docs.microsoft.com/en-us/uwp/api/windows.ui.viewmanagement.applicationview#Windows_UI_ViewManagement_ApplicationView_PreferredLaunchWindowingMode).