### PR TITLE
[TIMOB-24856] Implement bubbleParent functionality

### DIFF
--- a/Source/Media/src/Media.cpp
+++ b/Source/Media/src/Media.cpp
@@ -120,7 +120,10 @@ namespace TitaniumWindows
 #if defined(IS_WINDOWS_PHONE)
 		// Start listening to "windows.fileOpenFromPicker" event
 		GET_TITANIUM_APP(App);
-		App->addEventListener("windows.fileOpenFromPicker", fileOpenForMusicLibraryCallback__, fileOpenForMusicLibraryCallback__);
+		auto callback = get_context().CreateObject();
+		callback.SetProperty("callback", fileOpenForMusicLibraryCallback__);
+		callback.SetProperty("this_object", fileOpenForMusicLibraryCallback__);
+		App->addEventListener("windows.fileOpenFromPicker", callback);
 		if (options.allowMultipleSelections) {
 			picker->PickMultipleFilesAndContinue();
 		} else {
@@ -267,7 +270,10 @@ namespace TitaniumWindows
 #if defined(IS_WINDOWS_PHONE)
 		// Start listening to "windows.fileOpenFromPicker" event
 		GET_TITANIUM_APP(App);
-		App->addEventListener("windows.fileOpenFromPicker", fileOpenForPhotoGalleryCallback__, fileOpenForPhotoGalleryCallback__);
+		auto callback = get_context().CreateObject();
+		callback.SetProperty("callback", fileOpenForPhotoGalleryCallback__);
+		callback.SetProperty("this_object", fileOpenForPhotoGalleryCallback__);
+		App->addEventListener("windows.fileOpenFromPicker", callback);
 		picker->PickSingleFileAndContinue();
 #else
 		task<StorageFile^>(picker->PickSingleFileAsync()).then([this](task<StorageFile^> task) {

--- a/Source/TitaniumKit/include/Titanium/Module.hpp
+++ b/Source/TitaniumKit/include/Titanium/Module.hpp
@@ -63,7 +63,7 @@ namespace Titanium
 
 		  @result void
 		*/
-		virtual void addEventListener(const std::string& name, JSObject& callback, JSObject& this_object) TITANIUM_NOEXCEPT final;
+		virtual void addEventListener(const std::string& name, JSObject& callback, bool bubble = false) TITANIUM_NOEXCEPT final;
 
 		/*!
 		  @method
@@ -86,7 +86,7 @@ namespace Titanium
 
 		  @result void
 		*/
-		virtual void removeEventListener(const std::string& name, JSObject& callback, JSObject& this_object) TITANIUM_NOEXCEPT final;
+		virtual void removeEventListener(const std::string& name, JSObject& callback, bool bubble = false) TITANIUM_NOEXCEPT final;
 
 		/*!
 		  @method
@@ -234,13 +234,14 @@ namespace Titanium
 		std::shared_ptr<Titanium::UI::TabGroup> lifecycleContainerTabGroup__;
 
 		std::unordered_map<std::string, std::vector<JSObject>> event_listener_map__;
+		std::unordered_map<std::string, std::vector<JSObject>> event_bubble_map__;
 		bool enableEvents__ { true };
 
 		// Save constructor arguments so module can make copy of itself later on
 		JSObject ctorProperties__;
 #pragma warning(pop)
 	private:
-		static unsigned eventListenerIndex(const std::vector<JSObject>& event_listener_list, const std::string& name, JSObject& callback) TITANIUM_NOEXCEPT;
+		static int eventListenerIndex(const std::vector<JSObject>& event_listener_list, const std::string& name, JSObject& callback) TITANIUM_NOEXCEPT;
 	};
 }  // namespace Titanium
 

--- a/Source/TitaniumKit/include/Titanium/UI/View.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/View.hpp
@@ -148,6 +148,9 @@ namespace Titanium
 			*/
 			virtual void add(const JSObject&) TITANIUM_NOEXCEPT;
 
+			virtual void remove(const JSObject&) TITANIUM_NOEXCEPT;
+			virtual void removeAllChildren() TITANIUM_NOEXCEPT;
+
 			/*!
 			  @method
 			  @abstract get_children
@@ -342,6 +345,9 @@ namespace Titanium
 			{
 				return getViewLayoutDelegate<ViewLayoutDelegate>();
 			}
+
+			virtual void View::addBubbleEvents(View& bubbleParent) TITANIUM_NOEXCEPT;
+			virtual void View::removeBubbleEvents(View& bubbleParent) TITANIUM_NOEXCEPT;
 
 		protected:
 			template<typename T, typename U, typename... Us>

--- a/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
@@ -534,6 +534,7 @@ namespace TitaniumWindows
 			virtual void fireSimplePositionEvent(const std::string& event_name, Windows::Foundation::Point position);
 			virtual void firePostLayoutEvent();
 			virtual std::shared_ptr<Titanium::UI::View> getHierarchyEventSource(Windows::Foundation::Point position, const std::shared_ptr<Titanium::UI::View>& root = nullptr) const TITANIUM_NOEXCEPT;
+			template<typename EventArgs> bool isEventOnChild(EventArgs^ e);
 
 			static Windows::UI::Xaml::Media::ImageBrush^ CreateImageBrushFromPath(const std::string& path);
 			static Windows::UI::Xaml::Media::ImageBrush^ CreateImageBrushFromBitmapImage(Windows::UI::Xaml::Media::Imaging::BitmapImage^ image);

--- a/Source/UI/src/ScrollView.cpp
+++ b/Source/UI/src/ScrollView.cpp
@@ -46,7 +46,10 @@ namespace TitaniumWindows
 			Titanium::UI::ViewLayoutDelegate::add(view);
 			contentView__.GetPrivate<View>()->getViewLayoutDelegate()->add(view);
 
-			view->addEventListener("click", clickCallback__, contentView__);
+			auto callback_obj = contentView__.get_context().CreateObject();
+			callback_obj.SetProperty("callback", clickCallback__);
+			callback_obj.SetProperty("this_object", contentView__);
+			view->addEventListener("click", callback_obj);
 		}
 
 		void ScrollViewLayoutDelegate::set_layout(const std::string& layout) TITANIUM_NOEXCEPT

--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -1389,30 +1389,40 @@ namespace TitaniumWindows
 				} else {
 					click_event__ = component->Tapped += ref new TappedEventHandler([this](Platform::Object^ sender, TappedRoutedEventArgs^ e) {
 						const auto component = safe_cast<FrameworkElement^>(sender);
-						fireSimplePositionEvent("click", e->GetPosition(component));
+						if (!isEventOnChild<TappedRoutedEventArgs>(e)) {
+							fireSimplePositionEvent("click", e->GetPosition(component));
+						}
 					});
 				}
 			} else if (event_name == "dblclick") {
 				dblclick_event__ = component->DoubleTapped += ref new DoubleTappedEventHandler([this](Platform::Object^ sender, DoubleTappedRoutedEventArgs^ e) {
 					const auto component = safe_cast<FrameworkElement^>(sender);
-					fireSimplePositionEvent("dblclick", e->GetPosition(component));
+					if (!isEventOnChild<DoubleTappedRoutedEventArgs>(e)) {
+						fireSimplePositionEvent("dblclick", e->GetPosition(component));
+					}
 				});
 			} else if (event_name == "singletap") {
 				singletap_event__ = component->Tapped += ref new TappedEventHandler([this](Platform::Object^ sender, TappedRoutedEventArgs^ e) {
 					const auto component = safe_cast<FrameworkElement^>(sender);
-					fireSimplePositionEvent("singletap", e->GetPosition(component));
+					if (!isEventOnChild<TappedRoutedEventArgs>(e)) {
+						fireSimplePositionEvent("singletap", e->GetPosition(component));
+					}
 				});
 			} else if (event_name == "doubletap") {
 				doubletap_event__ = component->DoubleTapped += ref new DoubleTappedEventHandler([this](Platform::Object^ sender, DoubleTappedRoutedEventArgs^ e) {
 					const auto component = safe_cast<FrameworkElement^>(sender);
-					fireSimplePositionEvent("doubletap", e->GetPosition(component));
+					if (!isEventOnChild<DoubleTappedRoutedEventArgs>(e)) {
+						fireSimplePositionEvent("doubletap", e->GetPosition(component));
+					}
 				});
 			} else if (event_name == "longpress") {
 				longpress_event__ = component->Holding += ref new HoldingEventHandler([this](Platform::Object^ sender, HoldingRoutedEventArgs^ e) {
 					// fires event only when it started
 					if (e->HoldingState == Windows::UI::Input::HoldingState::Started) {
 						const auto component = safe_cast<FrameworkElement^>(sender);
-						fireSimplePositionEvent("longpress", e->GetPosition(component));
+						if (!isEventOnChild<HoldingRoutedEventArgs>(e)) {
+							fireSimplePositionEvent("longpress", e->GetPosition(component));
+						}
 					}
 				});
 			} else if (event_name == "focus") {
@@ -1453,6 +1463,19 @@ namespace TitaniumWindows
 					}
 				});
 			}
+		}
+
+		template<typename EventArgs> bool WindowsViewLayoutDelegate::isEventOnChild(EventArgs^ e) TITANIUM_NOEXCEPT
+		{
+			FrameworkElement^ component = getComponent();
+			for (auto child : get_children()) {
+				auto childComponent = child.get()->getViewLayoutDelegate<WindowsViewLayoutDelegate>()->getComponent();
+				auto position = e->GetPosition(childComponent);
+				if (position.X > 0 && position.Y > 0 && position.X < childComponent->Width && position.Y < childComponent->Height) {
+					return true;
+				}
+			}
+			return false;
 		}
 
 		static void onLayoutCallback(Titanium::LayoutEngine::Node* node)


### PR DESCRIPTION
- Implement `Titanium.Proxy.bubbleParent` functionality

###### TEST CASE
- Clicking the purple button should not fire the `click` event when `bubbleParent` is `false`
- Clicking the blue view should still fire the `click` event
```JS
var win = Ti.UI.createWindow(),
    view_a = Ti.UI.createView({ width: 300, height: 300, backgroundColor: 'red' }),
    view_b = Ti.UI.createView({ width: 200, height: 200, backgroundColor: 'blue' }),
    btn = Ti.UI.createButton({ title: 'TEST' , backgroundColor: 'purple', bubbleParent: false}),
    cb = function (e) {
        alert('click: ' + JSON.stringify(e, null, 2));
    };

view_a.addEventListener('click', cb);
// view_a.removeEventListener('click', cb);

view_b.add(btn);
view_a.add(view_b);

win.add(view_a);
win.open();
```

##### NOTE: it looks like the _diff_ also includes code that hasn't really changed, making it hard to review. Mostly in `WindowsViewLayoutDelegate.cpp`

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24856)