### PR TITLE
[TIMOB-24907] Use Logo.png for mimetype test

### DIFF
--- a/Examples/NMocha/src/Assets/ti.blob.test.js
+++ b/Examples/NMocha/src/Assets/ti.blob.test.js
@@ -66,10 +66,10 @@ describe('Titanium.Blob', function () {
 	});
 
 	it('mimeType', function () {
-		var blob = Ti.Filesystem.getFile('app.js').read();
+		var blob = Ti.Filesystem.getFile('Logo.png').read();
 		should(blob.mimeType).be.a.String;
 		should(blob.mimeType.length).be.above(0);
-		should(blob.mimeType).be.eql('text/javascript');
+		should(blob.mimeType).be.eql('image/png');
 	});
 
 	it('length', function () {


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-24907
Failures have been observed when using app.js, it appears that ContentType for js files can be null on Desktop device families, this was reproduced using a native C# app also.

I rolled back to 5.5.1.GA and the test would fail for me there also, I am not sure why it appears intermittent on jenkins.

I guess this raises the question of what to do if the content type is null? I am yet to investigate what Android or iOS do here