### PR TITLE
[TIMOB-24833] Setting TableView.height to auto breaks scrolling

### DIFF
--- a/Source/UI/src/TableView.cpp
+++ b/Source/UI/src/TableView.cpp
@@ -110,6 +110,8 @@ namespace TitaniumWindows
 			Titanium::UI::TableView::setLayoutDelegate<WindowsViewLayoutDelegate>();
 			layoutDelegate__->set_defaultWidth(Titanium::UI::LAYOUT::FILL);
 			layoutDelegate__->set_defaultHeight(Titanium::UI::LAYOUT::FILL);
+			layoutDelegate__->set_autoLayoutForHeight(Titanium::UI::LAYOUT::FILL);
+			layoutDelegate__->set_autoLayoutForWidth(Titanium::UI::LAYOUT::FILL);
 
 			getViewLayoutDelegate<WindowsViewLayoutDelegate>()->setComponent(parent__, tableview__);
 		}


### PR DESCRIPTION
[TIMOB-24833](https://jira.appcelerator.org/browse/TIMOB-24833)

Setting `TableView.height` (and `width`) to `auto` should act as `Ti.UI.FILL`.

```js
var _window = Ti.UI.createWindow();
var tbl_data = [];
for (var i = 0; i < 50; i++) {
    var row = Ti.UI.createTableViewRow();
    var label = Ti.UI.createLabel({
        left: 10,
        text: 'Row ' + (i + 1)
    });
    row.add(label);
    tbl_data.push(row);
}
var table = Titanium.UI.createTableView({
    height: 'auto',
    data: tbl_data,
    borderWidth: 1,
    borderColor: 'blue'
});
_window.add(table);
_window.open();
```