### PR TITLE
[TIMOB-24936] Windows: Build errors out when selecting wp-emulator or wp-device after being prompted for a target

### DIFF
--- a/cli/commands/_build/config.js
+++ b/cli/commands/_build/config.js
@@ -46,7 +46,7 @@ function config(logger, config, cli) {
 		supportedVisualStudioVersions: windowsPackageJson.vendorDependencies['visual studio'],
 		supportedWindowsPhoneSDKVersions: windowsPackageJson.vendorDependencies['windows phone sdk'],
 		tasklist: config.get('windows.executables.tasklist'),
-		skipWpTool: cli.argv['build-only'] || (target !== 'wp-device' && target !== 'wp-emulator' && target !== undefined)
+		skipWpTool: cli.argv['build-only'] || (target !== 'wp-device' && target !== 'wp-emulator' && target !== undefined && this.targets.indexOf(target) !== -1)
 	};
 
 	this.ignoreDirs = new RegExp(config.get('cli.ignoreDirs'));
@@ -91,7 +91,7 @@ function config(logger, config, cli) {
 		if (shouldForceProduction(cli.argv)) {
 			cli.argv['deploy-type'] = 'production';
 		}
-	
+
 		callback();
 	}.bind(this));
 


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-24936

## Verification

1. Build an app with appc run -p windows -T notvalid
2. Select a target (exercise all possible targets, it does not have to build all the way through)
   - The CLI should not error out when selecting wp-emulator or wp-device, ws-local and dist-* should work as normal
