### PR TITLE
[TIMOB-24938] CLI errors when using a Windows specific app id and building for ws-local

### DIFF
--- a/cli/hooks/ws-run.js
+++ b/cli/hooks/ws-run.js
@@ -154,7 +154,7 @@ exports.init = function (logger, config, cli) {
 				}
 
 				var tiapp = builder.tiapp,
-					appId = tiapp.id,
+					appId = tiapp.windows.id || tiapp.id,
 					projectDir = path.resolve(builder.cmakeTargetDir, 'AppPackages'),
 					// Options for installing and launching app
 					opts = appc.util.mix({


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-24938

appId must be set to the windows specific id for usage in the commands

## Verification

1. Add the following to the windows section of your tiapp (creating if it doesnt exist) `<id>com.incrediblyuniqueappid</id>`
2. Build the app using appc run -p windows -T ws-local (windows local from Studio)
   - The CLI should not error and the app should run as normal