### PR TITLE
[TIMOB-24942] Fix scrolling of ListView with height set to auto

### DIFF
--- a/Source/UI/src/ListView.cpp
+++ b/Source/UI/src/ListView.cpp
@@ -73,6 +73,8 @@ namespace TitaniumWindows
 			Titanium::UI::ListView::setLayoutDelegate<WindowsViewLayoutDelegate>();
 			layoutDelegate__->set_defaultWidth(Titanium::UI::LAYOUT::FILL);
 			layoutDelegate__->set_defaultHeight(Titanium::UI::LAYOUT::FILL);
+			layoutDelegate__->set_autoLayoutForHeight(Titanium::UI::LAYOUT::FILL);
+			layoutDelegate__->set_autoLayoutForWidth(Titanium::UI::LAYOUT::FILL);
 
 			getViewLayoutDelegate<WindowsViewLayoutDelegate>()->setComponent(parent__, listview__);
 		}


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-24942

Same as #1032 but for ListView, setting height/width to auto will act as Ti.UI.FILL
````js

var win = Ti.UI.createWindow(),
    list = Ti.UI.createListView({
        templates: {
            template: {
                childTemplates: [
                    {
                        type: 'Ti.UI.Label',
                        bindId: 'title',
                        properties: {
                            left: '5dp'
                        }
                    }
                ]
            }
        },
        defaultItemTemplate: 'template',
		height: 'auto'
    }),
    section = Ti.UI.createListSection(),
    items = [];

for(var i = 0; i <100; i++) {
	items.push({
	    title: { text: 'TEXT' }
	});
}
section.setItems(items);
list.setSections([section]);
win.add(list);
win.open();

````


## Verification

1. Add the above to an app.js and build for Windows
    - Should be able to scroll the ListView