### PR TITLE
[TIMOB-24925] Unable to build module with VS2017

### DIFF
--- a/Source/TitaniumKit/include/Titanium/detail/TiBase.hpp
+++ b/Source/TitaniumKit/include/Titanium/detail/TiBase.hpp
@@ -19,7 +19,7 @@
 // list of Visual C++ "Predefined Macros". Visual Studio 2013 Update 3
 // RTM ships with MSVC 18.0.30723.0
 
-#if defined(_MSC_VER) && _MSC_VER <= 1900
+#if defined(_MSC_VER)
 // According to Microsoft's "Visual C++ Team Blog":
 //
 // VS 2013 supported rvalue references, except for automatically
@@ -38,7 +38,7 @@
 #undef TITANIUM_NOEXCEPT_ENABLE
 #undef TITANIUM_MOVE_CTOR_AND_ASSIGN_DEFAULT_ENABLE
 
-#endif  // #defined(_MSC_VER) && _MSC_VER <= 1900
+#endif  // #defined(_MSC_VER)
 
 #ifdef TITANIUM_NOEXCEPT_ENABLE
 #define TITANIUM_NOEXCEPT noexcept


### PR DESCRIPTION
[TIMOB-24925](https://jira.appcelerator.org/browse/TIMOB-24925)

Steps to reproduce

1. appc new -t timodule --name myawesomemodule --id com.foo
2. appc run -p windows --build-only

Verification

- If you have both VS2015 and VS2017 installed, it should build module libraries for Phone/Store/Win10. (Check folders inside module zip)
- If you have only VS2017 installed, it should build module libraries for Win10 only.

Developer note:

We should keep disableing `TITANIUM_MOVE_CTOR_AND_ASSIGN_DEFAULT_ENABLE` even on VS2017 to keep modules' backward compatibility.
