### PR TITLE
[TIMOB-24946] Ability to use 3rd party types as module member

### DIFF
--- a/Examples/NMocha/src/Assets/ti.ui.webview.test.js
+++ b/Examples/NMocha/src/Assets/ti.ui.webview.test.js
@@ -10,8 +10,8 @@ var should = require('should'),
 
 describe('Titanium.UI.WebView', function () {
 
-	// Skip this on desktop Windows 10 apps because it crashes the app now.
-	((utilities.isWindows10() && utilities.isWindowsDesktop()) ? it.skip : it)('url', function (finish) {
+	// Skip this on Windows 10 apps because internal network is unstable.
+	(utilities.isWindows10() ? it.skip : it)('url', function (finish) {
 		this.timeout(10000);
 		var w = Ti.UI.createWindow({
 			backgroundColor: 'blue'

--- a/templates/build/Native/CMakeLists.txt.ejs
+++ b/templates/build/Native/CMakeLists.txt.ejs
@@ -98,13 +98,17 @@ target_include_directories(TitaniumWindows_Native PUBLIC
 
 set_target_properties(TitaniumWindows_Native PROPERTIES VS_WINRT_COMPONENT TRUE)
 
+<% for(var i = 0; i < native_modules.length; i++) { -%>
+file(GLOB MODULE_WINRT_REFERENCES_<%= i %> <%= native_modules[i].path %>/${PLATFORM}/${Ti_ARCH}/*.winmd)
+<% } -%>
+
 set_property(TARGET TitaniumWindows_Native
   PROPERTY VS_WINRT_REFERENCES
   "${WINDOWS_SOURCE_DIR}/lib/TitaniumWindows/${PLATFORM}/${Ti_ARCH}/TitaniumWindows.winmd"
   "${WINDOWS_SOURCE_DIR}/lib/TitaniumWindows_UI/${PLATFORM}/${Ti_ARCH}/TitaniumWindows_UI.winmd"
   "${WINDOWS_SOURCE_DIR}/lib/TitaniumWindows_Utility/${PLATFORM}/${Ti_ARCH}/TitaniumWindows_Utility.winmd"
 <% for(var i = 0; i < native_modules.length; i++) { -%>
-  "<%= native_modules[i].path %>/${PLATFORM}/${Ti_ARCH}/<%= native_modules[i].projectname %>.winmd"
+  ${MODULE_WINRT_REFERENCES_<%= i %>}
   <% if (native_modules[i].projectname == 'Hyperloop') { -%>
   "${PROJECT_SOURCE_DIR}/../TitaniumWindows_Hyperloop/bin/${PLATFORM}/Release/TitaniumWindows_Hyperloop.winmd"
   "<%= native_modules[i].path %>/${PLATFORM}/${Ti_ARCH}/HyperloopInvocation.winmd"


### PR DESCRIPTION
[TIMOB-24946](https://jira.appcelerator.org/browse/TIMOB-24946)

Ability to use 3rd party types in module header.

**Verification**

```js
var win = Ti.UI.createWindow({ backgroundColor: 'green' });

var SAP = require('com.appc.module.test3'),
    sap = new SAP();

win.addEventListener('open', function() {
    alert(sap.testUsageInfo());
});

win.open();
```

* Download [com.appc.module.test3](https://jira.appcelerator.org/secure/attachment/62865/com.appc.module.test3-windows-1.0.0.zip) module zip and install in your Titanium SDK modules directory
* Create new app with `com.appc.module.test3` module enabled in your tiapp.xml (    `<module platform="windows">com.appc.module.test3</module>`) 
* Update app.js with the code described above
* `appc run -p windows --wp-sdk 10.0 --target ws-local -l trace`
* You should see alert dialog that shows `SAP.Usage.UsageInfo` string.

![msg](https://user-images.githubusercontent.com/1661068/28105858-5b00a97a-671c-11e7-8528-610ff33b64f5.png)


com.appc.module.test3 module source: [com.appc.module.test3-windows-1.0.0-src.zip](https://jira.appcelerator.org/secure/attachment/62866/com.appc.module.test3-windows-1.0.0-src.zip)