### PR TITLE
[TIMOB-25033] Picker.width is ignored

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/Picker.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/Picker.hpp
@@ -19,6 +19,14 @@ namespace TitaniumWindows
 	{
 		using namespace HAL;
 
+		class TITANIUMWINDOWS_UI_EXPORT WindowsPickerLayoutDelegate : public WindowsViewLayoutDelegate {
+		public:
+			WindowsPickerLayoutDelegate() TITANIUM_NOEXCEPT : WindowsViewLayoutDelegate() { };
+			virtual ~WindowsPickerLayoutDelegate() = default;
+
+			virtual void onComponentSizeChange(const Titanium::LayoutEngine::Rect&) override;
+		};
+
 		/*!
 		  @class Picker
 		  @ingroup Titanium.UI.Picker


### PR DESCRIPTION
[TIMOB-25033](https://jira.appcelerator.org/browse/TIMOB-25033)

Expected:

- `classicPicker` - Setting `Ti.UI.SIZE` does not stretch its size (because of internal component spec, it does not stretch its size based on its content texts)
- `classicPicker2` - Setting number value to`Ti.UI.Picker.width` should adjust its size.

```js
var words = ['Bananas', 'Strawberries', 'Mangos', 'Electrocardiographically',
'October', 'November', 'September', 'Wednesday', 'Trinitrophenylmethylnitramine',
'Humor', 'Weekday', 'Balloon', 'Ornament', 'Strange', 'Disestablishmentarianism',
'Aeroplane', 'Aeroplane', 'Chess board', 'Floodlight', 'Rocket', 'Space Shuttle',
'Thermometer', ' Umbrella', 'Water', 'Tunnel', 'Treadmill', 'Lips', 'Brush',
'Subconstellation', 'Typewriter', 'Room', 'Money', 'Hieroglyph', 'Flower', 'Monument',
'Egg', 'Explosive', 'Family', 'Festival', 'Gloves', 'Horoscope', 'Kaleidoscope',
'Microscope', 'Pendulum', 'Restaurant', 'Apples', 'Cycle', 'Miraculousness',
'Overprovocation', 'Kyphoscoliotic', 'Disillusionizing', 'Prince'];

var win = Ti.UI.createWindow({
    exitOnClose: true,
    layout: 'vertical'
});

// Add TiClassic picker - 1 column, width = Ti.UI.SIZE, height = Ti.UI.SIZE, backgroundColor = #d83636
var classicPicker = Ti.UI.createPicker({
    top: 20,
    left: 0,
    height: Ti.UI.SIZE,
    width: Ti.UI.SIZE,
    backgroundColor: '#554e4e'
});

var classicPickerRows = [];
for (var i = 0; i < words.length; i++) {
    var wordIndex = Math.round(Math.random() * 50);
    classicPickerRows[i] = Ti.UI.createPickerRow({
        title: words[wordIndex]
    });
}
classicPicker.add(classicPickerRows);

win.add(classicPicker);

// Add TiClassic picker - 1 column, width = 350, height = Ti.UI.SIZE, backgroundColor = #EDEDED
var classicPicker2 = Ti.UI.createPicker({
    top: 200,
    left: 0,
    height: Ti.UI.SIZE,
    width: 350,
    backgroundColor: '#554e4e'
});

var classicPickerRows2 = [];
for (var i = 0; i < words.length; i++) {
    var wordIndex = Math.round(Math.random() * 50);
    classicPickerRows2[i] = Ti.UI.createPickerRow({
        title: words[wordIndex]
    });
}
classicPicker2.add(classicPickerRows2);

win.add(classicPicker2);
win.open();
```