### PR TITLE
[TIMOB-25044][TIMOB-25023] Fix around touchEnabled

### DIFF
--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -955,6 +955,8 @@ namespace TitaniumWindows
 					updateBackground(backgroundDisabledImageBrush__);
 				} else if (backgroundDisabledColorBrush__ != nullptr) {
 					updateBackground(backgroundDisabledColorBrush__);
+				} else {
+					updateBackground(previousBackgroundBrush__);
 				}
 			}
 		}
@@ -975,6 +977,8 @@ namespace TitaniumWindows
 			backgroundImageBrush__ = CreateImageBrushFromPath(backgroundImage);
 			if (get_touchEnabled()) {
 				updateBackground(backgroundImageBrush__);
+			} else {
+				updateDisabledBackground();
 			}
 		}
 
@@ -984,6 +988,8 @@ namespace TitaniumWindows
 			backgroundImageBrush__ = CreateImageBrushFromBlob(backgroundImage);
 			if (get_touchEnabled()) {
 				updateBackground(backgroundImageBrush__);
+			} else {
+				updateDisabledBackground();
 			}
 		}
 
@@ -994,6 +1000,8 @@ namespace TitaniumWindows
 			backgroundColorBrush__ = ref new Media::SolidColorBrush(ColorForName(backgroundColor));
 			if (get_touchEnabled()) {
 				updateBackground(backgroundColorBrush__);
+			} else {
+				updateDisabledBackground();
 			}
 		}
 
@@ -1479,6 +1487,8 @@ namespace TitaniumWindows
 				} else {
 					updateBackground(nullptr); // delete background
 				}
+			} else {
+				updateDisabledBackground();
 			}
 		}
 

--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -1303,7 +1303,8 @@ namespace TitaniumWindows
 			const auto children = root == nullptr ? get_children() : root->get_children();
 			// Let's find correct source
 			for (const auto child : children) {
-				const auto childView = child->getViewLayoutDelegate<WindowsViewLayoutDelegate>()->getEventComponent();
+				const auto childLayout = child->getViewLayoutDelegate<WindowsViewLayoutDelegate>();
+				const auto childView   = childLayout->getComponent();
 				const auto elements = Windows::UI::Xaml::Media::VisualTreeHelper::FindElementsInHostCoordinates(position, childView);
 				for (const auto e : elements) {
 					// Let's check its descendents so we can support nested views
@@ -1313,7 +1314,9 @@ namespace TitaniumWindows
 							return found;
 						}
 					}
-					return child;
+					if (childLayout->get_touchEnabled()) {
+						return child;
+					}
 				}
 			}
 			return nullptr;


### PR DESCRIPTION
[TIMOB-25044](https://jira.appcelerator.org/browse/TIMOB-25044)
[TIMOB-25023](https://jira.appcelerator.org/browse/TIMOB-25023)

## TIMOB-25044

 View event delegation to children should take child's `touchEnabled` into account.

```js
var win = Ti.UI.createWindow({
    backgroundColor: 'green',
    id: 'win',
    layout: 'vertical'
});

var view1 = Ti.UI.createView({
    backgroundColor: 'blue',
    width: '40%', height: '40%',
    id: 'view1',
    touchEnabled: false
});

var view2 = Ti.UI.createView({
    backgroundColor: 'red',
    width: '40%', height: '40%',
    id: 'view2'
});

win.addEventListener('click', function (e) {
    alert(e.source.id);
});

win.add(view1);
win.add(view2);
win.open();
```

Expected: 

- When you click on `view1`, it should show the Window id `win`.
- When you click on `view2`, it should show view id `view2`.

## TIMOB-25023

`View.backgroundColor` should work with `touchEnabled=false`

```js
var win = Ti.UI.createWindow({
    backgroundColor: 'blue'
});
var view = Ti.UI.createView({
    width: 50,
    height: 50,
    touchEnabled: false,
});

win.addEventListener('open', function () {
    view.backgroundColor = 'red';
});

win.add(view);
win.open();
```

Expected: you should see a view with `red` color.
