### PR TITLE
Ensure we select the SDK after installing it

### DIFF
--- a/Tools/Scripts/build/test.js
+++ b/Tools/Scripts/build/test.js
@@ -64,7 +64,21 @@ function installSDK(branch, next) {
 		if (code != 0) {
 			next("Failed to install SDK. Exit code: " + code);
 		} else {
-			next(null, sdkVersion);
+			console.log("Making sure " + sdkVersion + " is selected");
+			var selectPrc = spawn('node', [titanium, 'sdk', 'select', sdkVersion]);
+			selectPrc.stdout.on('data', function (data) {
+				console.log(data.toString());
+			});
+			selectPrc.stderr.on('data', function (data) {
+				console.error(data.toString().trim());
+			});
+			selectPrc.on('close', function (code) {
+				if (code != 0) {
+					next("Failed to select SDK. Exit code: " + code);
+				} else {
+					next(null, sdkVersion);
+				}
+			});
 		}
 	});
 }


### PR DESCRIPTION
So I was checking out the failure for #1077 and was like huh it's using 6.2.0 `Error: ENOENT: no such file or directory, open 'C:\ProgramData\Titanium\mobilesdk\win32\6.2.0.v20170816173122\windows\lib\TitaniumKit\phone\x86\TitaniumKit.dll'` and was intrigued as to why, it's because if an SDK is already installed the `-d` flag in the sdk install command isn't respected 😱, that's a bug in titanium cli but for now we need to workaround it and this is how we do that