### PR TITLE
Bump test timeout to 25 minutes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 #!groovy​
 
 def gitCommit = ''
-def testTimeout = 20
+def testTimeout = 25
 
 def build(sdkVersion, msBuildVersion, architecture, gitCommit) {
 	unstash 'sources' // for build


### PR DESCRIPTION
We've seen some failure where Jenkins has killed the builds because the tests ran over 20 minutes, this PR bumps that timeout from 20 to 25