### PR TITLE
Prevent building to 8.1 targets, and stop producing 8.1 artifacts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,43 +93,6 @@ timestamps {
 		}
 
 		parallel(
-			'Windows 8.1 Store x86': {
-				node('msbuild-12 && (vs2013 || vs2015) && hyper-v && windows-sdk-8.1 && npm && node && cmake && jsc') {
-					build('8.1', '12.0', 'WindowsStore-x86', gitCommit)
-
-					unstash 'NMocha' // for tests
-					dir('Tools/Scripts/build') {
-						timeout(testTimeout) {
-							echo 'Running Tests on Windows 8.1 Desktop'
-							bat "node test.js -s 8.1 -T ws-local -p Windows8_1.Store -b ${targetBranch}"
-						}
-						// Kill the desktop app, so workspace cleanup works...
-						bat 'taskkill /IM Mocha.exe /F 2> nul'
-					}
-					junit 'dist/junit_report.xml'
-				}
-			},
-			'Windows 8.1 Phone x86': {
-				node('msbuild-12 && (vs2013 || vs2015) && hyper-v && windows-sdk-8.1 && npm && node && cmake && jsc') {
-					build('8.1', '12.0', 'WindowsPhone-x86', gitCommit)
-
-					unstash 'NMocha' // for tests
-					dir('Tools/Scripts/build') {
-						timeout(testTimeout) {
-							echo 'Running Tests on Windows 8.1 Phone Emulator'
-							bat "node test.js -s 8.1 -T wp-emulator -p Windows8_1.Phone -b ${targetBranch}"
-						}
-						// Kill the phone emulator, so workspace cleanup works...
-						bat 'taskkill /IM xde.exe 2> nul'
-					}
-					junit 'dist/junit_report.xml'
-				}
-			},
-			'Windows 8.1 Phone ARM': {
-				node('msbuild-12 && (vs2013 || vs2015) && windows-sdk-8.1 && npm && node && cmake && jsc') {
-					build('8.1', '12.0', 'WindowsPhone-ARM', gitCommit)
-				}
-			},
 			'Windows 10 x86': {
 				node('msbuild-14 && vs2015 && hyper-v && windows-sdk-10 && npm && node && cmake && jsc') {
 					build('10.0', '14.0', 'WindowsStore-x86', gitCommit)

--- a/cli/commands/_build/config/deviceID.js
+++ b/cli/commands/_build/config/deviceID.js
@@ -27,8 +27,11 @@ module.exports = function configOptionDeviceID(order) {
 			 (cli.argv.target === 'wp-device' && value === 'de')) && devices[0]) {
 
 			// if win-sdk is not specified, use wpsdk for device
-			if (devices[0].wpsdk && !this.isWindowsSDKTargetSpecified()) {
+			if (devices[0].wpsdk && !this.isWindowsSDKTargetSpecified() && appc.version.satisfies(devices[0].wpsdk, this.packageJson.vendorDependencies['windows phone sdk'], false)) {
 				cli.argv['win-sdk'] = devices[0].wpsdk;
+			} else {
+				this.logger.error(__('The connected device is running %s, which is unsupported by Titanium SDK %s', devices[0].wpsdk, this.cli.sdk.name));
+				process.exit(0)
 			}
 			return callback(null, devices[0].udid);
 		}
@@ -47,8 +50,11 @@ module.exports = function configOptionDeviceID(order) {
 		}
 
 		// if win-sdk is not specified, use wpsdk specified for device
-		if (dev.wpsdk && !this.isWindowsSDKTargetSpecified()) {
+		if (dev.wpsdk && !this.isWindowsSDKTargetSpecified() && appc.version.satisfies(dev.wpsdk, this.packageJson.vendorDependencies['windows phone sdk'], false)) {
 			cli.argv['win-sdk'] = dev.wpsdk;
+		} else {
+			this.logger.error(__('The connected device is running %s, which is unsupported by Titanium SDK %s', dev.wpsdk, this.cli.sdk.name));
+			process.exit(10)
 		}
 
 		// check the device

--- a/cli/commands/_build/config/deviceID.js
+++ b/cli/commands/_build/config/deviceID.js
@@ -27,11 +27,13 @@ module.exports = function configOptionDeviceID(order) {
 			 (cli.argv.target === 'wp-device' && value === 'de')) && devices[0]) {
 
 			// if win-sdk is not specified, use wpsdk for device
-			if (devices[0].wpsdk && !this.isWindowsSDKTargetSpecified() && appc.version.satisfies(devices[0].wpsdk, this.packageJson.vendorDependencies['windows phone sdk'], false)) {
-				cli.argv['win-sdk'] = devices[0].wpsdk;
-			} else {
-				this.logger.error(__('The connected device is running %s, which is unsupported by Titanium SDK %s', devices[0].wpsdk, this.cli.sdk.name));
-				process.exit(0)
+			if (dev.wpsdk && !this.isWindowsSDKTargetSpecified()) {
+				if (appc.version.satisfies(dev.wpsdk, this.packageJson.vendorDependencies['windows phone sdk'], false)) {
+					cli.argv['win-sdk'] = dev.wpsdk;
+				} else {
+					this.logger.error(__('The connected device is running %s, which is unsupported by Titanium SDK %s', dev.wpsdk, this.cli.sdk.name));
+					process.exit(10)
+				}
 			}
 			return callback(null, devices[0].udid);
 		}
@@ -50,11 +52,13 @@ module.exports = function configOptionDeviceID(order) {
 		}
 
 		// if win-sdk is not specified, use wpsdk specified for device
-		if (dev.wpsdk && !this.isWindowsSDKTargetSpecified() && appc.version.satisfies(dev.wpsdk, this.packageJson.vendorDependencies['windows phone sdk'], false)) {
-			cli.argv['win-sdk'] = dev.wpsdk;
-		} else {
-			this.logger.error(__('The connected device is running %s, which is unsupported by Titanium SDK %s', dev.wpsdk, this.cli.sdk.name));
-			process.exit(10)
+		if (dev.wpsdk && !this.isWindowsSDKTargetSpecified()) {
+			if (appc.version.satisfies(dev.wpsdk, this.packageJson.vendorDependencies['windows phone sdk'], false)) {
+				cli.argv['win-sdk'] = dev.wpsdk;
+			} else {
+				this.logger.error(__('The connected device is running %s, which is unsupported by Titanium SDK %s', dev.wpsdk, this.cli.sdk.name));
+				process.exit(10)
+			}
 		}
 
 		// check the device

--- a/cli/commands/_build/config/wpSDK.js
+++ b/cli/commands/_build/config/wpSDK.js
@@ -11,7 +11,7 @@ var appc = require('node-appc'),
  */
 module.exports = function configOptionSDK(order) {
 	var sdkTargets = [],
-		unsupportedTargets = ['8.0'];
+		unsupportedTargets = ['8.0', '8.1'];
 
 	if (this.windowsInfo) {
 		for (var version in this.windowsInfo.windowsphone) {

--- a/cli/commands/_buildModule.js
+++ b/cli/commands/_buildModule.js
@@ -153,7 +153,8 @@ WindowsModuleBuilder.prototype.initialize = function initialize(next) {
 								_t.logger.debug('targetSdkVersion: ' + sdk_version);
 								// Remove Windows10 target only when it targets to 8.1 explicitly
 								if (sdk_version == '8.1') {
-									types = defaultTypes.slice(0, 2);
+									_t.logger.error('The specified version of the Windows and Windows Phone SDK "%s" is no supported by Titanium %s', sdk_version, _t.titaniumSdkName)
+									process.exit(0)
 								}
 							}
 						}
@@ -217,19 +218,6 @@ WindowsModuleBuilder.prototype.generateModuleProject = function generateModulePr
                     runCmake(data, 'WindowsStore', 'ARM', '10.0', done);
                 }
             ];
-
-            // Visual Studio 2017 doesn't support Windows/Phone 8.1 project anymore
-            if (selectVisualStudio(data) != 'Visual Studio 15 2017') {
-                tasks.push(function(done) {
-                    runCmake(data, 'WindowsPhone', 'Win32', '8.1', done);
-                });
-                tasks.push(function(done) {
-                    runCmake(data, 'WindowsPhone', 'ARM', '8.1', done);
-                });
-                tasks.push(function(done) {
-                    runCmake(data, 'WindowsStore', 'Win32', '8.1', done);
-                });
-            }
 
             appc.async.series(this, tasks, function(err) {
                 next(err);
@@ -488,7 +476,7 @@ WindowsModuleBuilder.prototype.packageZip = function packageZip(next) {
 				_t.logger.debug('Packing: '+JSON.stringify(relative_path, null, 2));
 				archive.append(fs.createReadStream(file.path), {name: relative_path });
 			}
-		}	
+		}
 		archive.finalize();
 	});
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 	],
 	"vendorDependencies": {
 		"visual studio": ">=12.x <=14.x",
-		"windows phone sdk": "8.1 || 10.0",
+		"windows phone sdk": "10.0",
 		"windows 10 sdk": ">=10.0.10240.0 <=10.0.15063.0",
 		"msbuild": ">=4.0",
 		"node": ">=0.10.0 <=0.12.x",

--- a/templates/module/default/hooks/windows-module.js
+++ b/templates/module/default/hooks/windows-module.js
@@ -74,33 +74,6 @@ exports.init = function (logger, config, cli) {
 						next();
 					},
 					function(next) {
-						if (sdks.windowsphone.hasOwnProperty('8.1')) {
-							logger.info('Generating WindowsPhone ARM project');
-							runCMake(logger, cmake, projectDir, 'WindowsPhone', 'ARM', generator, next);
-						} else {
-							logger.info('Skipping WindowsPhone ARM project as Windows 8.1 SDK is not installed');
-							next()
-						}
-					},
-					function(next) {
-						if (sdks.windowsphone.hasOwnProperty('8.1')) {
-							logger.info('Generating WindowsPhone Win32 project');
-							runCMake(logger, cmake, projectDir, 'WindowsPhone', 'Win32', generator, next);
-						} else {
-							logger.info('Skipping WindowsPhone Win32 project as Windows 8.1 SDK is not installed');
-							next()
-						}
-					},
-					function(next) {
-						if (sdks.windowsphone.hasOwnProperty('8.1')) { // still uses windowsphone sdk
-							logger.info('Generating WindowsStore Win32 project');
-							runCMake(logger, cmake, projectDir, 'WindowsStore', 'Win32', generator, next);
-						} else {
-							logger.info('Skipping WindowsStore Win32 project as Windows 8.1 SDK is not installed');
-							next()
-						}
-					},
-					function(next) {
 						if (sdks.windows.hasOwnProperty('10.0')) {
 							logger.info('Generating Windows 10 Win32 project');
 							runCMake(logger, cmake, projectDir, 'Windows10', 'Win32', generator, next);


### PR DESCRIPTION
Apologies in advance for the wall of text 😅, I greatly appreciate any input on this PR whether it be around the wording, behaviour or any other parts of it.


### Summary
This PR does the following

- Prevents building app projects to 8.1 targets, or when specifying 8.1 as `--win-sdk` SDK
    - `--win-sdk 8.1` will error with `[ERROR] Invalid "--win-sdk" value "8.1"`, prompting the user to select another version
    - With an 8.1 device plugged in `-T wp-device` will error with `[ERROR] The connected device is running 8.1, which is unsupported by Titanium SDK 7.0.0.v20170828180637`
    - When specifying TargetPlatformVersion or TargetPlatformMinVersion to 8.1 will error out [TIMOB-24704](https://jira.appcelerator.org/browse/TIMOB-24704), is that even a supported config? Setting to 10.0 is too vague imo
	- I still need to test building to `-T ws-local` on an Windows 8.1 install

- Prevents building 8.1 artifacts for module projects
    - When creating a module only Windows 10 projects are generated
    - When building with `--run-cmake` only Windows 10 projects are created
    - When specifying `<uses-sdk targetSdkVersion="8.1" />` in the timodule.xml the build process will error with `[ERROR] The specified version of the Windows and Windows Phone SDK "8.1" is not supported by Titanium 7.0.0.v20170828180637`

- When used with appcelerator/windowslib/pull/78 and running ti info -t windows
	- 8.1 SDK will be shown, but listed as not supported `8.1 **Not supported by Titanium SDK 7.0.0.v20170828180637**`
	- 8.1 emulators will not be shown (and subsequently Studio does not show them)
	- 8.1 devices will be shown (and subsequently Studio will show them)

-	The above is based on my understanding and observation of how we behave on other platforms, any input is greatly appreciated on error messages, behaviour etc.

- Stops producing 8.1 artifacts during the build process

This PR does not do the following

- Remove any code under Source\, cli\ or Tools\ relevant to Windows 8.1 or Windows Phone 8.1 (other then necessary for the above)
	- This was deemed a cleanup task that is not required for removal
- Make any edits to documentation in this repo
    - Again, will be a cleanup task
- Drop support for anything else i.e. Visual Studio 2013
    - Although it kind of does as that version only supports 8.1, there is no explicit removal of support. Although in my opinion we should do it in the same release


Tickets:

https://jira.appcelerator.org/browse/TIMOB-25207
https://jira.appcelerator.org/browse/TIMOB-25203