### PR TITLE
[TIMOB-25216] Docs do not show ti.cloud as supported

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,8 +74,12 @@ timestamps {
 			echo 'copying generated docs to dist folder'
 			if (isUnix()) {
 				sh 'mv apidoc/Titanium dist/windows/doc/Titanium'
+				sh 'mv apidoc/Modules dist/windows/doc/Modules'
+				sh 'mv apidoc/WindowsOnly dist/windows/doc/Windowsonly'
 			} else {
 				bat '(robocopy apidoc\\\\Titanium dist\\\\windows\\\\doc\\\\Titanium /e) ^& IF %ERRORLEVEL% LEQ 3 cmd /c exit 0'
+				bat '(robocopy apidoc\\\\Modules dist\\\\windows\\\\doc\\\\Modules /e) ^& IF %ERRORLEVEL% LEQ 3 cmd /c exit 0'
+				bat '(robocopy apidoc\\\\WindowsOnly dist\\\\windows\\\\doc\\\\WindowsOnly /e) ^& IF %ERRORLEVEL% LEQ 3 cmd /c exit 0'
 			}
 			archiveArtifacts artifacts: 'dist/**/*'
 		} // node

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,7 +75,7 @@ timestamps {
 			if (isUnix()) {
 				sh 'mv apidoc/Titanium dist/windows/doc/Titanium'
 				sh 'mv apidoc/Modules dist/windows/doc/Modules'
-				sh 'mv apidoc/WindowsOnly dist/windows/doc/Windowsonly'
+				sh 'mv apidoc/WindowsOnly dist/windows/doc/WindowsOnly'
 			} else {
 				bat '(robocopy apidoc\\\\Titanium dist\\\\windows\\\\doc\\\\Titanium /e) ^& IF %ERRORLEVEL% LEQ 3 cmd /c exit 0'
 				bat '(robocopy apidoc\\\\Modules dist\\\\windows\\\\doc\\\\Modules /e) ^& IF %ERRORLEVEL% LEQ 3 cmd /c exit 0'

--- a/apidoc/Modules/Cloud/ACLs/ACLs.yml
+++ b/apidoc/Modules/Cloud/ACLs/ACLs.yml
@@ -1,0 +1,42 @@
+---
+name: Modules.Cloud.ACLs
+methods:
+  - name: create
+    platforms:
+      - windowsphone
+  - name: update
+    platforms:
+      - windowsphone
+  - name: show
+    platforms:
+      - windowsphone
+  - name: remove
+    platforms:
+      - windowsphone
+  - name: addUser
+    platforms:
+      - windowsphone
+  - name: removeUser
+    platforms:
+      - windowsphone
+  - name: checkUser
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone
+---
+name: CloudACLsResponse
+properties:
+  - name: acls
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone
+---
+name: CloudACLsCheckResponse
+properties:
+  - name: permission
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone

--- a/apidoc/Modules/Cloud/Chats/Chats.yml
+++ b/apidoc/Modules/Cloud/Chats/Chats.yml
@@ -1,0 +1,36 @@
+---
+name: Modules.Cloud.Chats
+methods:
+  - name: create
+    platforms:
+      - windowsphone
+  - name: remove
+    platforms:
+      - windowsphone
+  - name: getChatGroups
+    platforms:
+      - windowsphone
+  - name: queryChatGroups
+    platforms:
+      - windowsphone
+  - name: query
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone
+---
+name: CloudChatsResponse
+properties:
+  - name: chats
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone
+---
+name: CloudChatGroupsResponse
+properties:
+  - name: chat_groups
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone

--- a/apidoc/Modules/Cloud/Checkins/Checkins.yml
+++ b/apidoc/Modules/Cloud/Checkins/Checkins.yml
@@ -1,0 +1,25 @@
+---
+name: Modules.Cloud.Checkins
+methods:
+  - name: create
+    platforms:
+      - windowsphone
+  - name: query
+    platforms:
+      - windowsphone
+  - name: remove
+    platforms:
+      - windowsphone
+  - name: show
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone
+---
+name: CloudCheckinsResponse
+properties:
+  - name: checkins
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone

--- a/apidoc/Modules/Cloud/Clients/Clients.yml
+++ b/apidoc/Modules/Cloud/Clients/Clients.yml
@@ -1,0 +1,19 @@
+---
+name: Modules.Cloud.Clients
+methods:
+  - name: geolocate
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone
+---
+name: CloudClientsResponse
+properties:
+  - name: ip_address
+    platforms:
+      - windowsphone
+  - name: location
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone

--- a/apidoc/Modules/Cloud/Cloud.yml
+++ b/apidoc/Modules/Cloud/Cloud.yml
@@ -1,0 +1,50 @@
+---
+name: Modules.Cloud
+methods:
+  - name: hasStoredSession
+    platforms:
+      - windowsphone
+  - name: retrieveStoredSession
+    platforms:
+      - windowsphone
+  - name: sendRequest
+    platforms:
+      - windowsphone
+  - name: createX509CertificatePinningSecurityManager
+    platforms:
+      - windowsphone
+properties:
+  - name: debug
+    platforms:
+      - windowsphone
+  - name: ondatastream
+    platforms:
+      - windowsphone
+  - name: onsendstream
+    platforms:
+      - windowsphone
+  - name: useSecure
+    platforms:
+      - windowsphone
+  - name: sessionId
+    platforms:
+      - windowsphone
+  - name: accessToken
+    platforms:
+      - windowsphone
+  - name: expiresIn
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone
+---
+name: CloudStreamProgress
+properties:
+  - name: progress
+    platforms:
+      - windowsphone
+  - name: url
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone

--- a/apidoc/Modules/Cloud/CloudResponse.yml
+++ b/apidoc/Modules/Cloud/CloudResponse.yml
@@ -1,0 +1,20 @@
+---
+name: CloudResponse
+properties:
+  - name: success
+    platforms:
+      - windowsphone
+  - name: error
+    platforms:
+      - windowsphone
+  - name: meta
+    platforms:
+      - windowsphone
+  - name: code
+    platforms:
+      - windowsphone
+  - name: message
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone

--- a/apidoc/Modules/Cloud/Emails/Emails.yml
+++ b/apidoc/Modules/Cloud/Emails/Emails.yml
@@ -1,0 +1,12 @@
+---
+name: Modules.Cloud.Emails
+methods:
+  - name: send
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone
+---
+name: CloudEmailsResponse
+platforms:
+  - windowsphone

--- a/apidoc/Modules/Cloud/Events/Events.yml
+++ b/apidoc/Modules/Cloud/Events/Events.yml
@@ -1,0 +1,48 @@
+---
+name: Modules.Cloud.Events
+methods:
+  - name: create
+    platforms:
+      - windowsphone
+  - name: show
+    platforms:
+      - windowsphone
+  - name: showOccurrences
+    platforms:
+      - windowsphone
+  - name: query
+    platforms:
+      - windowsphone
+  - name: queryOccurrences
+    platforms:
+      - windowsphone
+  - name: search
+    platforms:
+      - windowsphone
+  - name: searchOccurrences
+    platforms:
+      - windowsphone
+  - name: remove
+    platforms:
+      - windowsphone
+  - name: update
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone
+---
+name: CloudEventsResponse
+properties:
+  - name: events
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone
+---
+name: CloudEventOccurrencesResponse
+properties:
+  - name: event_occurrences
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone

--- a/apidoc/Modules/Cloud/Files/Files.yml
+++ b/apidoc/Modules/Cloud/Files/Files.yml
@@ -1,0 +1,28 @@
+---
+name: Modules.Cloud.Files
+methods:
+  - name: create
+    platforms:
+      - windowsphone
+  - name: query
+    platforms:
+      - windowsphone
+  - name: remove
+    platforms:
+      - windowsphone
+  - name: show
+    platforms:
+      - windowsphone
+  - name: update
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone
+---
+name: CloudFilesResponse
+properties:
+  - name: files
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone

--- a/apidoc/Modules/Cloud/Friends/Friends.yml
+++ b/apidoc/Modules/Cloud/Friends/Friends.yml
@@ -1,0 +1,36 @@
+---
+name: Modules.Cloud.Friends
+methods:
+  - name: add
+    platforms:
+      - windowsphone
+  - name: requests
+    platforms:
+      - windowsphone
+  - name: approve
+    platforms:
+      - windowsphone
+  - name: remove
+    platforms:
+      - windowsphone
+  - name: search
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone
+---
+name: CloudFriendsResponse
+properties:
+  - name: users
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone
+---
+name: CloudFriendRequestsResponse
+properties:
+  - name: friend_requests
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone

--- a/apidoc/Modules/Cloud/GeoFences/GeoFences.yml
+++ b/apidoc/Modules/Cloud/GeoFences/GeoFences.yml
@@ -1,0 +1,25 @@
+---
+name: Modules.Cloud.GeoFences
+methods:
+  - name: create
+    platforms:
+      - windowsphone
+  - name: query
+    platforms:
+      - windowsphone
+  - name: remove
+    platforms:
+      - windowsphone
+  - name: update
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone
+---
+name: CloudGeoFenceResponse
+properties:
+  - name: geo_fences
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone

--- a/apidoc/Modules/Cloud/KeyValues/KeyValues.yml
+++ b/apidoc/Modules/Cloud/KeyValues/KeyValues.yml
@@ -1,0 +1,28 @@
+---
+name: Modules.Cloud.KeyValues
+methods:
+  - name: append
+    platforms:
+      - windowsphone
+  - name: get
+    platforms:
+      - windowsphone
+  - name: increment
+    platforms:
+      - windowsphone
+  - name: remove
+    platforms:
+      - windowsphone
+  - name: set
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone
+---
+name: CloudKeyValuesResponse
+properties:
+  - name: keyvalues
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone

--- a/apidoc/Modules/Cloud/Likes/Likes.yml
+++ b/apidoc/Modules/Cloud/Likes/Likes.yml
@@ -1,0 +1,19 @@
+---
+name: Modules.Cloud.Likes
+methods:
+  - name: create
+    platforms:
+      - windowsphone
+  - name: remove
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone
+---
+name: CloudLikesResponse
+properties:
+  - name: likes
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone

--- a/apidoc/Modules/Cloud/Messages/Messages.yml
+++ b/apidoc/Modules/Cloud/Messages/Messages.yml
@@ -1,0 +1,40 @@
+---
+name: Modules.Cloud.Messages
+methods:
+  - name: create
+    platforms:
+      - windowsphone
+  - name: reply
+    platforms:
+      - windowsphone
+  - name: show
+    platforms:
+      - windowsphone
+  - name: showInbox
+    platforms:
+      - windowsphone
+  - name: showSent
+    platforms:
+      - windowsphone
+  - name: showThreads
+    platforms:
+      - windowsphone
+  - name: showThread
+    platforms:
+      - windowsphone
+  - name: remove
+    platforms:
+      - windowsphone
+  - name: removeThread
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone
+---
+name: CloudMessagesResponse
+properties:
+  - name: messages
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone

--- a/apidoc/Modules/Cloud/Objects/Objects.yml
+++ b/apidoc/Modules/Cloud/Objects/Objects.yml
@@ -1,0 +1,28 @@
+---
+name: Modules.Cloud.Objects
+methods:
+  - name: create
+    platforms:
+      - windowsphone
+  - name: query
+    platforms:
+      - windowsphone
+  - name: remove
+    platforms:
+      - windowsphone
+  - name: show
+    platforms:
+      - windowsphone
+  - name: update
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone
+---
+name: CloudObjectsResponse
+properties:
+  - name: classname
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone

--- a/apidoc/Modules/Cloud/PhotoCollections/PhotoCollections.yml
+++ b/apidoc/Modules/Cloud/PhotoCollections/PhotoCollections.yml
@@ -1,0 +1,42 @@
+---
+name: Modules.Cloud.PhotoCollections
+methods:
+  - name: create
+    platforms:
+      - windowsphone
+  - name: remove
+    platforms:
+      - windowsphone
+  - name: search
+    platforms:
+      - windowsphone
+  - name: show
+    platforms:
+      - windowsphone
+  - name: showPhotos
+    platforms:
+      - windowsphone
+  - name: showSubCollections
+    platforms:
+      - windowsphone
+  - name: update
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone
+---
+name: CloudPhotoCollectionsResponse
+properties:
+  - name: collections
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone
+---
+name: CloudPhotoCollectionsPhotosResponse
+properties:
+  - name: photos
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone

--- a/apidoc/Modules/Cloud/Photos/Photos.yml
+++ b/apidoc/Modules/Cloud/Photos/Photos.yml
@@ -1,0 +1,31 @@
+---
+name: Modules.Cloud.Photos
+methods:
+  - name: create
+    platforms:
+      - windowsphone
+  - name: query
+    platforms:
+      - windowsphone
+  - name: remove
+    platforms:
+      - windowsphone
+  - name: search
+    platforms:
+      - windowsphone
+  - name: show
+    platforms:
+      - windowsphone
+  - name: update
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone
+---
+name: CloudPhotosResponse
+properties:
+  - name: photos
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone

--- a/apidoc/Modules/Cloud/Places/Places.yml
+++ b/apidoc/Modules/Cloud/Places/Places.yml
@@ -1,0 +1,31 @@
+---
+name: Modules.Cloud.Places
+methods:
+  - name: create
+    platforms:
+      - windowsphone
+  - name: query
+    platforms:
+      - windowsphone
+  - name: remove
+    platforms:
+      - windowsphone
+  - name: search
+    platforms:
+      - windowsphone
+  - name: show
+    platforms:
+      - windowsphone
+  - name: update
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone
+---
+name: CloudPlacesResponse
+properties:
+  - name: places
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone

--- a/apidoc/Modules/Cloud/Posts/Posts.yml
+++ b/apidoc/Modules/Cloud/Posts/Posts.yml
@@ -1,0 +1,28 @@
+---
+name: Modules.Cloud.Posts
+methods:
+  - name: create
+    platforms:
+      - windowsphone
+  - name: query
+    platforms:
+      - windowsphone
+  - name: remove
+    platforms:
+      - windowsphone
+  - name: show
+    platforms:
+      - windowsphone
+  - name: update
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone
+---
+name: CloudPostsResponse
+properties:
+  - name: posts
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone

--- a/apidoc/Modules/Cloud/PushNotifications/PushNotifications.yml
+++ b/apidoc/Modules/Cloud/PushNotifications/PushNotifications.yml
@@ -1,0 +1,69 @@
+---
+name: Modules.Cloud.PushNotifications
+methods:
+  - name: notify
+    platforms:
+      - windowsphone
+  - name: notifyTokens
+    platforms:
+      - windowsphone
+  - name: resetBadge
+    platforms:
+      - windowsphone
+  - name: setBadge
+    platforms:
+      - windowsphone
+  - name: subscribe
+    platforms:
+      - windowsphone
+  - name: subscribeToken
+    platforms:
+      - windowsphone
+  - name: unsubscribe
+    platforms:
+      - windowsphone
+  - name: unsubscribeToken
+    platforms:
+      - windowsphone
+  - name: updateSubscription
+    platforms:
+      - windowsphone
+  - name: queryChannels
+    platforms:
+      - windowsphone
+  - name: showChannels
+    platforms:
+      - windowsphone
+  - name: query
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone
+---
+name: CloudPushNotificationsResponse
+platforms:
+  - windowsphone
+---
+name: CloudPushNotificationsQueryChannelResponse
+properties:
+  - name: push_channels
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone
+---
+name: CloudPushNotificationsShowChannelResponse
+properties:
+  - name: devices
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone
+---
+name: CloudPushNotificationsQueryResponse
+properties:
+  - name: subscriptions
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone

--- a/apidoc/Modules/Cloud/PushSchedules/PushSchedules.yml
+++ b/apidoc/Modules/Cloud/PushSchedules/PushSchedules.yml
@@ -1,0 +1,22 @@
+---
+name: Modules.Cloud.PushSchedules
+methods:
+  - name: create
+    platforms:
+      - windowsphone
+  - name: remove
+    platforms:
+      - windowsphone
+  - name: query
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone
+---
+name: CloudPushSchedulesResponse
+properties:
+  - name: push_schedules
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone

--- a/apidoc/Modules/Cloud/Reviews/Reviews.yml
+++ b/apidoc/Modules/Cloud/Reviews/Reviews.yml
@@ -1,0 +1,28 @@
+---
+name: Modules.Cloud.Reviews
+methods:
+  - name: create
+    platforms:
+      - windowsphone
+  - name: query
+    platforms:
+      - windowsphone
+  - name: remove
+    platforms:
+      - windowsphone
+  - name: show
+    platforms:
+      - windowsphone
+  - name: update
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone
+---
+name: CloudReviewsResponse
+properties:
+  - name: reviews
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone

--- a/apidoc/Modules/Cloud/SocialIntegrations/SocialIntegrations.yml
+++ b/apidoc/Modules/Cloud/SocialIntegrations/SocialIntegrations.yml
@@ -1,0 +1,25 @@
+---
+name: Modules.Cloud.SocialIntegrations
+methods:
+  - name: externalAccountLink
+    platforms:
+      - windowsphone
+  - name: externalAccountLogin
+    platforms:
+      - windowsphone
+  - name: externalAccountUnlink
+    platforms:
+      - windowsphone
+  - name: searchFacebookFriends
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone
+---
+name: CloudSocialIntegrationsResponse
+properties:
+  - name: users
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone

--- a/apidoc/Modules/Cloud/Statuses/Statuses.yml
+++ b/apidoc/Modules/Cloud/Statuses/Statuses.yml
@@ -1,0 +1,31 @@
+---
+name: Modules.Cloud.Statuses
+methods:
+  - name: create
+    platforms:
+      - windowsphone
+  - name: update
+    platforms:
+      - windowsphone
+  - name: show
+    platforms:
+      - windowsphone
+  - name: delete
+    platforms:
+      - windowsphone
+  - name: query
+    platforms:
+      - windowsphone
+  - name: search
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone
+---
+name: CloudStatusesResponse
+properties:
+  - name: statuses
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone

--- a/apidoc/Modules/Cloud/Users/Users.yml
+++ b/apidoc/Modules/Cloud/Users/Users.yml
@@ -1,0 +1,74 @@
+---
+name: Modules.Cloud.Users
+methods:
+  - name: create
+    platforms:
+      - windowsphone
+  - name: login
+    platforms:
+      - windowsphone
+  - name: logout
+    platforms:
+      - windowsphone
+  - name: query
+    platforms:
+      - windowsphone
+  - name: search
+    platforms:
+      - windowsphone
+  - name: show
+    platforms:
+      - windowsphone
+  - name: showMe
+    platforms:
+      - windowsphone
+  - name: update
+    platforms:
+      - windowsphone
+  - name: remove
+    platforms:
+      - windowsphone
+  - name: requestResetPassword
+    platforms:
+      - windowsphone
+  - name: resendConfirmation
+    platforms:
+      - windowsphone
+  - name: secureCreate
+    platforms:
+      - windowsphone
+  - name: secureLogin
+    platforms:
+      - windowsphone
+  - name: secureStatus
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone
+---
+name: CloudUsersSecureDialog
+properties:
+  - name: title
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone
+---
+name: CloudUsersResponse
+properties:
+  - name: users
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone
+---
+name: CloudUsersSecureResponse
+properties:
+  - name: accessToken
+    platforms:
+      - windowsphone
+  - name: expiresIn
+    platforms:
+      - windowsphone
+platforms:
+  - windowsphone

--- a/apidoc/Titanium/UI/ListView.yml
+++ b/apidoc/Titanium/UI/ListView.yml
@@ -32,6 +32,10 @@ methods:
     platforms: [windowsphone]
   - name: replaceSectionAt
     platforms: [windowsphone]
+  - name: addMarker
+    platforms: [windowsphone]
+  - name: setMarker
+    platforms: [windowsphone]
   - name: getTemplates
     platforms: [windowsphone]
   - name: setTemplates

--- a/apidoc/Titanium/UI/SearchBar.yml
+++ b/apidoc/Titanium/UI/SearchBar.yml
@@ -1,13 +1,21 @@
 name: Titanium.UI.SearchBar
 platforms: [windowsphone]
 properties:
+  - name: barColor
+    platforms: [windowsphone]
   - name: hintText
     platforms: [windowsphone]
   - name: hinttextid
     platforms: [windowsphone]
+  - name: showCancel
+    platforms: [windowsphone]
   - name: value
     platforms: [windowsphone]
 methods:
+  - name: getBarColor
+    platforms: [windowsphone]
+  - name: setBarColor
+    platforms: [windowsphone]
   - name: getHintText
     platforms: [windowsphone]
   - name: setHintText
@@ -15,6 +23,10 @@ methods:
   - name: getHinttextid
     platforms: [windowsphone]
   - name: setHinttextid
+    platforms: [windowsphone]
+  - name: getShowCancel
+    platforms: [windowsphone]
+  - name: setShowCancel
     platforms: [windowsphone]
   - name: getValue
     platforms: [windowsphone]


### PR DESCRIPTION
- Add the skeleton of the ti.cloud module docs
- Archive both the Modules and WindowsOnly folders in the Jenkins jobs
- Update latest docs

Couple of questions that this has made me think of

1. Can we class `createX509CertificatePinningSecurityManager`, as supported on Windows given that we don't have a https module?
2. Our docs state that lifecycleContainer is supported on Windows, it looks to be implemented in https://github.com/appcelerator/titanium_mobile_windows/blob/3f1967e80db8a70f363f78661ce6665558709245/Source/TitaniumKit/src/Module.cpp#L276-L299, but it's an Android specific API? Does it provide any value on Windows? Should it be marked as unimplemented?