### PR TITLE
[TIMOB-24934] Skip installing dependencies when it is already installed

### DIFF
--- a/cli/hooks/wp-run.js
+++ b/cli/hooks/wp-run.js
@@ -286,8 +286,14 @@ exports.init = function (logger, config, cli) {
 								next(err.message);
 							})
 							.on('error', function (err) {
-								logRelay && logRelay.stop();
-								next(err.message);
+								// We should skip installing dependency when it is aready there
+								if (err.message && err.message.indexOf('A debug application is already installed') != -1) {
+									logger.info(__('Skipping installing dependency: %s', file));
+									next();
+								} else {
+									logRelay && logRelay.stop();
+									next(err.message);
+								}
 							});
 						});
 					});


### PR DESCRIPTION
[TIMOB-24934](https://jira.appcelerator.org/browse/TIMOB-24934)

Skip installing dependencies when it is already installed.

**Steps to Test**

Please refer to the ticket description [TIMOB-24934](https://jira.appcelerator.org/browse/TIMOB-24934)