### PR TITLE
[TIMOB-24867] Fix panel component events when wrapped by border

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
@@ -495,6 +495,8 @@ namespace TitaniumWindows
 			{
 				if (underlying_control__) {
 					return underlying_control__;
+				} else if (is_panel__ && border__) {
+					return border__;
 				}
 				return component__;
 			}

--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -907,9 +907,7 @@ namespace TitaniumWindows
 		{
 			if (underlying_control__) {
 				underlying_control__->Background = brush;
-			} else if ((is_grid__ || is_border__) && border__) {
-				border__->Background = brush;
-			} else if (is_panel__ && border__) {
+			} else if ((is_grid__ || is_panel__ || is_border__) && border__) {
 				border__->Background = brush;
 			} else if (is_panel__) {
 				dynamic_cast<Panel^>(component__)->Background = brush;

--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -909,6 +909,8 @@ namespace TitaniumWindows
 				underlying_control__->Background = brush;
 			} else if ((is_grid__ || is_border__) && border__) {
 				border__->Background = brush;
+			} else if (is_panel__ && border__) {
+				border__->Background = brush;
 			} else if (is_panel__) {
 				dynamic_cast<Panel^>(component__)->Background = brush;
 			} else if (is_control__) {


### PR DESCRIPTION
- Use border wrapper component when listening for panel component events

```JS
var win = Ti.UI.createWindow({backgroundColor: 'green'}),
    view = Ti.UI.createView({
        backgroundColor: 'blue',
        borderRadius: 50,
        borderColor: 'red',
        borderWidth: 3,
        width: '30%',
        height: '30%'
    });

view.addEventListener('dblclick', function (e) {
    console.log('dblclick');
});
view.addEventListener('click', function (e) {
    console.log('click');
});

win.add(view);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-25261) and [TIMOB-24867](https://jira.appcelerator.org/browse/TIMOB-24867)