### PR TITLE
[TIMOB-25263] Remove back button when there's no window left

### DIFF
--- a/Source/UI/src/Window.cpp
+++ b/Source/UI/src/Window.cpp
@@ -53,8 +53,6 @@ namespace TitaniumWindows
 					if (!IS_WINDOWS_MOBILE) {
 						updateWindowSize();
 					}
-					// Update back button visibility. Note that back button is available on Store App too.
-					SystemNavigationManager::GetForCurrentView()->AppViewBackButtonVisibility = AppViewBackButtonVisibility::Visible;
 				} catch (...) {
 					TITANIUM_LOG_DEBUG("Error at root frame Navigated");
 				}
@@ -268,6 +266,9 @@ namespace TitaniumWindows
 						}
 					}
 
+#if defined(IS_WINDOWS_10)
+					SystemNavigationManager::GetForCurrentView()->AppViewBackButtonVisibility = window_stack__.size() > 1 ? AppViewBackButtonVisibility::Visible : AppViewBackButtonVisibility::Collapsed;
+#endif
 					// start accepting events for the new Window
 					next_window->enableEvents();
 					next_window->focus();
@@ -376,6 +377,10 @@ namespace TitaniumWindows
 			if (tab__ == nullptr) {
 				window_stack__.push_back(this->get_object().GetPrivate<Window>());
 			}
+
+#if defined(IS_WINDOWS_10)
+			SystemNavigationManager::GetForCurrentView()->AppViewBackButtonVisibility = window_stack__.size() > 1 ? AppViewBackButtonVisibility::Visible : AppViewBackButtonVisibility::Collapsed;
+#endif
 
 			// start accepting events
 			enableEvents();


### PR DESCRIPTION
[TIMOB-25263](https://jira.appcelerator.org/browse/TIMOB-25263)

```js
var win1 = Ti.UI.createWindow({ backgroundColor: 'green' }),
    win2 = Ti.UI.createWindow({ backgroundColor: 'lightblue'}),
    win3 = Ti.UI.createWindow({ backgroundColor: 'pink' }),
    button1 = Ti.UI.createButton({ title: 'open', borderWidth: 2, borderColor: 'red' }),
    button2 = Ti.UI.createButton({ title: 'open', borderWidth: 2, borderColor: 'red', top: 100 }),
    label2 = Ti.UI.createLabel({ text: '(Use back button to navigate back)', top: 150 }),
    label3 = Ti.UI.createLabel({ text: '(Use back button to navigate back)' });

button1.addEventListener('click', function (e) {
    win2.open();
});

button2.addEventListener('click', function (e) {
    win3.open();
});

win1.add(button1);
win2.add(button2);
win2.add(label2);
win3.add(label3);

win1.open();
```

Expected:
- When app is launched, back button should be hidden initially.
- When you click "open" button and then new Window is opened, back button should be visible.
- When you click the back button, current Window should be closed.
- When you are on the initial Window (green one), back button should be hidden.
