### PR TITLE
[6_3_X][TIMOB-24867] Fix panel component events when wrapped by border 

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
@@ -495,6 +495,8 @@ namespace TitaniumWindows
 			{
 				if (underlying_control__) {
 					return underlying_control__;
+				} else if (is_panel__ && border__) {
+					return border__;
 				}
 				return component__;
 			}

--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -907,7 +907,7 @@ namespace TitaniumWindows
 		{
 			if (underlying_control__) {
 				underlying_control__->Background = brush;
-			} else if ((is_grid__ || is_border__) && border__) {
+			} else if ((is_grid__ || is_panel__ || is_border__) && border__) {
 				border__->Background = brush;
 			} else if (is_panel__) {
 				dynamic_cast<Panel^>(component__)->Background = brush;


### PR DESCRIPTION
[TIMOB-24867] Fix panel components events when wrapped by border

Cherry-pick & squash #1103 for `6_3_X`.