### PR TITLE
[TIMOB-25247] Picker.setSelectedRow doesn't work

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/PickerColumn.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/PickerColumn.hpp
@@ -48,6 +48,7 @@ namespace TitaniumWindows
 			virtual void addRow(const std::shared_ptr<Titanium::UI::PickerRow>& row) TITANIUM_NOEXCEPT override;
 			virtual void removeRow(const std::shared_ptr<Titanium::UI::PickerRow>& row) TITANIUM_NOEXCEPT override;
 			virtual std::shared_ptr<Titanium::UI::PickerRow> get_selectedRow() const TITANIUM_NOEXCEPT override;
+			virtual void set_selectedRow(const std::shared_ptr<Titanium::UI::PickerRow>&) TITANIUM_NOEXCEPT override;
 
 			Windows::UI::Xaml::Controls::ComboBox^ getComponent() const TITANIUM_NOEXCEPT
 			{

--- a/Source/UI/src/PickerColumn.cpp
+++ b/Source/UI/src/PickerColumn.cpp
@@ -46,6 +46,13 @@ namespace TitaniumWindows
 			}
 		}
 
+		void PickerColumn::set_selectedRow(const std::shared_ptr<Titanium::UI::PickerRow>& selectedRow) TITANIUM_NOEXCEPT
+		{
+			Titanium::UI::PickerColumn::set_selectedRow(selectedRow);
+			const auto row = std::dynamic_pointer_cast<TitaniumWindows::UI::PickerRow>(selectedRow);
+			picker__->SelectedItem = row->getComboBoxItem();
+		}
+
 		void PickerColumn::addRow(const std::shared_ptr<Titanium::UI::PickerRow>& r) TITANIUM_NOEXCEPT
 		{
 			Titanium::UI::PickerColumn::addRow(r);


### PR DESCRIPTION
[TIMOB-25247](https://jira.appcelerator.org/browse/TIMOB-25247)

Implement `Picker.setSelectedRow`.

```js
var _window = Ti.UI.createWindow();
var picker = Ti.UI.createPicker({
    type: Ti.UI.PICKER_TYPE_PLAIN,
    selectionIndicator: true
});
var data = [];
var answerLoop = 0;
// add answers
for (answerLoop = 0; answerLoop < 11; answerLoop++) {
    data.push(Ti.UI.createPickerRow({
        title: 'Answer ' + answerLoop,
        custom_item: answerLoop
    }));
}
picker.add(data);
picker.setSelectedRow(0, 5, true);
var selectedButton = Ti.UI.createButton({
    title: 'Select Answer 6',
    width: 300,
    height: 'auto',
    top: 50
});
selectedButton.addEventListener('click', function (e) {
    picker.setSelectedRow(0, 6, true);
    console.log(picker.getSelectedRow(0).title);
});
_window.add(picker);
_window.add(selectedButton);
_window.open()
```