### PR TITLE
[TIMOB-25291] Fix upgrade of GET with data to POST

### DIFF
--- a/Source/Network/src/HTTPClient.cpp
+++ b/Source/Network/src/HTTPClient.cpp
@@ -130,12 +130,6 @@ namespace TitaniumWindows
 
 		void HTTPClient::send(const std::map<std::string, JSValue>& postDataPairs, const bool& useMultipartForm) TITANIUM_NOEXCEPT
 		{
-			if (method__ == Titanium::Network::RequestMethod::Get) {
-				TITANIUM_MODULE_LOG_WARN("HTTPClient::send: Data found during a GET request. Method will be changed to POST.");
-				method__ = Titanium::Network::RequestMethod::Post;
-			}
-
-
 			Windows::Web::Http::IHttpContent^ postData;
 			if (useMultipartForm) {
 				postData = ref new Windows::Web::Http::HttpMultipartFormDataContent();


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-25291

When performing a GET request and calling send with data the request used to be upgraded to a POST, this doesn't occur with other platforms.
<details>
<summary>Demo code</summary>

```js
var win = Ti.UI.createWindow({
    title: 'stuff',
    backgroundColor: '#fff'
});

var label = Ti.UI.createLabel({
    text: 'click me',
    color: "#333",
    font: {
        fontSize: 20
    }
});

label.addEventListener('click', function() {
    var url = 'https://httpbin.org/anything';
    var client = Ti.Network.createHTTPClient({
        onload : function(e) {
            alert("method was: " + JSON.parse(this.responseText).method);
            Ti.API.info(this.responseText);
        },
        onerror : function(e) {
            Ti.API.debug(e.error);
            alert('error');
        },
        timeout : 5000
    });
    client.open("GET", url);
    client.send({foo:'bar'});
})

win.add(label);
win.open()
```
</details>


### Verification

1. Add the code above to existing app.js and build
2. Tap the `click me` label
3. Method should be GET