### PR TITLE
[TIMOB-25344] New setTimeout implementation

### DIFF
--- a/Source/Global/include/TitaniumWindows/GlobalObject.hpp
+++ b/Source/Global/include/TitaniumWindows/GlobalObject.hpp
@@ -37,6 +37,11 @@ namespace TitaniumWindows
 		GlobalObject& operator=(GlobalObject&&) = default;
 #endif
 
+		virtual unsigned setTimeout(JSObject& function, const std::chrono::milliseconds& delay) TITANIUM_NOEXCEPT override;
+		virtual unsigned setInterval(JSObject& function, const std::chrono::milliseconds& delay) TITANIUM_NOEXCEPT override;
+		virtual void clearTimeout(const unsigned& timerId) TITANIUM_NOEXCEPT override;
+		virtual void clearInterval(const unsigned& timerId) TITANIUM_NOEXCEPT override;
+
 		static void JSExportInitialize();
 		void setSeed(::Platform::String^ seed);
 		virtual std::string readRequiredModule(const JSObject& parent, const std::string& path) const override final;
@@ -51,6 +56,11 @@ namespace TitaniumWindows
 		// cache for native module
 		std::unordered_map<std::string, JSValue> native_module_cache__;
 		std::function<JSValue(const JSContext& js_context, const std::string&)> native_module_requireHook__;
+
+		Windows::Foundation::Collections::IMap<unsigned, Windows::System::Threading::ThreadPoolTimer^>^ timer_dispatcher_map__;
+		std::unordered_map<unsigned, JSObject> timer_callback_map__;
+		static std::atomic<unsigned> timer_id_generator__;
+
 #pragma warning(pop)
 
 		// native module
@@ -58,7 +68,8 @@ namespace TitaniumWindows
 		virtual JSValue requireNativeModule(const JSContext& js_context, const std::string& moduleId) TITANIUM_NOEXCEPT override;
 
 		virtual bool requiredModuleExists(const std::string& path) const TITANIUM_NOEXCEPT override final;
-		virtual std::shared_ptr<Titanium::GlobalObject::Timer> CreateTimer(Callback_t callback, const std::chrono::milliseconds& interval) const TITANIUM_NOEXCEPT override final;
+
+		unsigned invokeTimerCallback(JSObject& function, const std::chrono::milliseconds& delay, const bool isSetTimeout) TITANIUM_NOEXCEPT;
 
 	private:
 		::Platform::String^ seed__;

--- a/Source/Global/src/GlobalObject.cpp
+++ b/Source/Global/src/GlobalObject.cpp
@@ -11,7 +11,6 @@
 #include "Titanium/Module.hpp"
 #include <ratio>
 #include <sstream>
-#include <concrt.h>
 #include <collection.h>
 #include <boost/algorithm/string.hpp>
 #include "TitaniumWindows/Utility.hpp"

--- a/Source/Global/src/GlobalObject.cpp
+++ b/Source/Global/src/GlobalObject.cpp
@@ -8,11 +8,14 @@
 
 #include "TitaniumWindows/GlobalObject.hpp"
 #include "Titanium/detail/TiImpl.hpp"
+#include "Titanium/Module.hpp"
 #include <ratio>
 #include <sstream>
 #include <concrt.h>
+#include <collection.h>
 #include <boost/algorithm/string.hpp>
 #include "TitaniumWindows/Utility.hpp"
+#include "TitaniumWindows/LogForwarder.hpp"
 
 using Windows::Security::Cryptography::Core::SymmetricAlgorithmNames;
 using Windows::Security::Cryptography::Core::SymmetricKeyAlgorithmProvider;
@@ -29,6 +32,99 @@ using concurrency::task_continuation_context;
 
 namespace TitaniumWindows
 {
+	std::atomic<std::uint32_t> GlobalObject::timer_id_generator__;
+
+	unsigned GlobalObject::setTimeout(JSObject& function, const std::chrono::milliseconds& delay) TITANIUM_NOEXCEPT
+	{
+		return invokeTimerCallback(function, delay, true);
+	}
+
+	unsigned GlobalObject::setInterval(JSObject& function, const std::chrono::milliseconds& delay) TITANIUM_NOEXCEPT
+	{
+		return invokeTimerCallback(function, delay, false);
+	}
+
+	void GlobalObject::clearTimeout(const unsigned& timerId) TITANIUM_NOEXCEPT
+	{
+		TITANIUM_LOG_DEBUG("clearTimeout: ", timerId);
+
+		const bool timer_found = timer_dispatcher_map__->HasKey(timerId);
+
+		// dispatcher won't be found when interval equals zero
+		if (timer_found) {
+			timer_dispatcher_map__->Lookup(timerId)->Cancel();
+			timer_dispatcher_map__->Remove(timerId);
+		}
+
+		if (timer_callback_map__.find(timerId) != timer_callback_map__.end()) {
+			timer_callback_map__.erase(timerId);
+		}
+	}
+
+	void GlobalObject::clearInterval(const unsigned& timerId) TITANIUM_NOEXCEPT
+	{
+		clearTimeout(timerId);
+	}
+
+	unsigned GlobalObject::invokeTimerCallback(JSObject& function, const std::chrono::milliseconds& delay, const bool isSetTimeout) TITANIUM_NOEXCEPT
+	{
+		const auto timerId = timer_id_generator__++;
+		timer_callback_map__.emplace(timerId, function);
+
+		std::function<void()> run = [this, timerId, delay, function, isSetTimeout]() {
+			TitaniumWindows::Utility::RunOnUIThread(Windows::UI::Core::CoreDispatcherPriority::High, [this, timerId, delay, function, isSetTimeout]() {
+				TITANIUM_EXCEPTION_CATCH_START{
+					TITANIUM_LOG_DEBUG((isSetTimeout ? "setTimeout" : "setInterval"), ": id=", timerId, " delay=", delay.count());
+					const auto found = timer_callback_map__.find(timerId);
+
+					//
+					// This could happen when setInterval/Timeout is cleared while waiting for invocation.
+					// In that case we can just ignore the callback.
+					//
+					if (found == timer_callback_map__.end()) {
+						TITANIUM_LOG_DEBUG("setInterval/Timeout is cleared while waiting for invocation: ", timerId);
+						return;
+					}
+
+					auto callback = found->second;
+					TITANIUM_ASSERT(callback.IsFunction());
+					callback(get_context().get_global_object());
+
+					if (isSetTimeout) {
+						clearTimeout(timerId);
+					}
+				} TITANIUM_EXCEPTION_CATCH_END
+			});
+		};
+
+		//
+		// Invoke callback immediately when interval equals zero
+		//
+		if (delay.count() == 0) {
+			run();
+			return timerId;
+		}
+
+		// A Windows::Foundation::TimeSpan is a time period expressed in
+		// 100-nanosecond units.
+		//
+		// Reference:
+		// http://msdn.microsoft.com/en-us/library/windows/apps/windows.foundation.timespan
+		std::chrono::duration<std::chrono::nanoseconds::rep, std::ratio_multiply<std::ratio<100>, std::nano>> timer_interval_ticks = delay;
+
+		Windows::Foundation::TimeSpan time_span;
+		time_span.Duration = timer_interval_ticks.count();
+		auto dispatcher_timer = Windows::System::Threading::ThreadPoolTimer::CreatePeriodicTimer(
+			ref new Windows::System::Threading::TimerElapsedHandler([run](Windows::System::Threading::ThreadPoolTimer ^timer) {
+			run();
+		}), time_span);
+
+		timer_dispatcher_map__->Insert(timerId, dispatcher_timer);
+
+		return timerId;
+	}
+
+
 	void GlobalObject::registerNativeModuleRequireHook(const std::vector<std::string>& native_module_names, const std::unordered_map<std::string, JSValue>& preloaded_modules, std::function<JSValue(const JSContext&, const std::string&)> requireHook)
 	{
 		// store supported native module names
@@ -201,104 +297,10 @@ namespace TitaniumWindows
 		return TitaniumWindows::Utility::ConvertUTF8String(content);
 	}
 
-#pragma warning(push)
-#pragma warning(disable : 4251)
-	class TITANIUMWINDOWS_GLOBAL_EXPORT Timer final : public Titanium::GlobalObject::Timer, public std::enable_shared_from_this<Timer>
-	{
-#pragma warning(pop)
-	public:
-		Timer(Titanium::GlobalObject::Callback_t callback, const std::chrono::milliseconds& _interval)
-		    : Titanium::GlobalObject::Timer(callback, _interval), callback__(callback)
-		{
-			TITANIUM_LOG_DEBUG("Timer: ctor");
-
-			std::chrono::milliseconds interval = _interval;
-			// Avoid zero interval
-			if (interval.count() == 0) {
-				interval = std::chrono::milliseconds(static_cast<std::chrono::milliseconds::rep>(100));
-			}
-
-			// A Windows::Foundation::TimeSpan is a time period expressed in
-			// 100-nanosecond units.
-			//
-			// Reference:
-			// http://msdn.microsoft.com/en-us/library/windows/apps/windows.foundation.timespan
-			std::chrono::duration<std::chrono::nanoseconds::rep, std::ratio_multiply<std::ratio<100>, std::nano>> timer_interval_ticks = interval;
-			TITANIUM_LOG_DEBUG("Timer: ctor: timer_interval_ticks = ", timer_interval_ticks.count());
-
-			Windows::Foundation::TimeSpan time_span;
-			time_span.Duration = timer_interval_ticks.count();
-			dispatcher_timer__ = ref new Windows::UI::Xaml::DispatcherTimer();
-			dispatcher_timer__->Interval = time_span;
-		}
-
-		virtual ~Timer()
-		{
-			TITANIUM_LOG_DEBUG("Timer: dtor");
-			if (dispatcher_timer__->IsEnabled) {
-				dispatcher_timer__->Stop();
-			}
-
-			// TODO: what happens if start was never called? Is this an error?
-			dispatcher_timer__->Tick -= event_registration_token__;
-			dispatcher_timer__ = nullptr;
-		}
-
-		virtual void Start() TITANIUM_NOEXCEPT override final
-		{
-			TITANIUM_LOG_DEBUG("Timer::Start");
-			std::call_once(dispatcher_timer_once_flag__, [this] {
-				// Bring in the placeholders _1, _2, etc. for std::bind.
-				using namespace std::placeholders;
-				std::weak_ptr<Timer> weakThis(shared_from_this());
-				auto callback = std::bind([](const std::weak_ptr<Timer>& weakThis, Platform::Object^ sender, Platform::Object^ event) {
-						auto strong_ptr = weakThis.lock();
-						if (strong_ptr) {
-							strong_ptr->callback__();
-						}
-					},
-					std::move(weakThis), _1, _2);
-        
-				this->event_registration_token__ = this->dispatcher_timer__->Tick += ref new Windows::Foundation::EventHandler<Platform::Object^>(callback);
-			});
-
-			if (!(dispatcher_timer__->IsEnabled)) {
-				TITANIUM_LOG_DEBUG("Timer::Start: start timer ");
-				dispatcher_timer__->Start();
-			} else {
-				TITANIUM_LOG_WARN("Timer::Start: start called while timer is already running");
-			}
-		}
-
-		virtual void Stop() TITANIUM_NOEXCEPT override final
-		{
-			TITANIUM_LOG_DEBUG("Timer::Stop");
-			if (dispatcher_timer__->IsEnabled) {
-				TITANIUM_LOG_DEBUG("Timer::Stop: stop timer ");
-				dispatcher_timer__->Stop();
-			} else {
-				TITANIUM_LOG_WARN("Timer::Stop: stop called while timer is not running");
-			}
-		}
-
-	private:
-#pragma warning(push)
-#pragma warning(disable : 4251)
-		Titanium::GlobalObject::Callback_t callback__;
-		std::once_flag dispatcher_timer_once_flag__;
-#pragma warning(pop)
-		Windows::UI::Xaml::DispatcherTimer^ dispatcher_timer__;
-		Windows::Foundation::EventRegistrationToken event_registration_token__;
-	};
-
-	std::shared_ptr<Titanium::GlobalObject::Timer> GlobalObject::CreateTimer(Titanium::GlobalObject::Callback_t callback, const std::chrono::milliseconds& interval) const TITANIUM_NOEXCEPT
-	{
-		TITANIUM_LOG_DEBUG("Timer::CreateTimer");
-		return std::make_shared<TitaniumWindows::Timer>(callback, interval);
-	}
 	GlobalObject::GlobalObject(const JSContext& js_context) TITANIUM_NOEXCEPT
 	    : Titanium::GlobalObject(js_context),
 		seed__(nullptr)
+		, timer_dispatcher_map__(ref new Platform::Collections::Map<unsigned, Windows::System::Threading::ThreadPoolTimer^>())
 	{
 		TITANIUM_LOG_DEBUG("GlobalObject::ctor");
 	}

--- a/Source/TitaniumKit/examples/NativeGlobalObjectExample.cpp
+++ b/Source/TitaniumKit/examples/NativeGlobalObjectExample.cpp
@@ -29,40 +29,6 @@ std::string NativeGlobalObjectExample::readRequiredModule(const JSObject& parent
 	return require_resource__.at(path);
 }
 
-class NativeGlobalObjectTimerExample final : public Titanium::GlobalObject::Timer
-{
-public:
-	NativeGlobalObjectTimerExample(Titanium::GlobalObject::Callback_t callback, const std::chrono::milliseconds& interval)
-	    : Timer(callback, interval), callback__(callback)
-	{
-		TITANIUM_LOG_DEBUG("NativeGlobalObjectTimerExample: ctor");
-	}
-
-	virtual ~NativeGlobalObjectTimerExample()
-	{
-		TITANIUM_LOG_DEBUG("NativeGlobalObjectTimerExample: dtor");
-	}
-
-	virtual void Start() TITANIUM_NOEXCEPT override final
-	{
-		TITANIUM_LOG_DEBUG("NativeGlobalObjectTimerExample::Start");
-	}
-
-	virtual void Stop() TITANIUM_NOEXCEPT override final
-	{
-		TITANIUM_LOG_DEBUG("NativeGlobalObjectTimerExample::Stop");
-	}
-
-private:
-	Titanium::GlobalObject::Callback_t callback__;
-};
-
-std::shared_ptr<Titanium::GlobalObject::Timer> NativeGlobalObjectExample::CreateTimer(Titanium::GlobalObject::Callback_t callback, const std::chrono::milliseconds& interval) const TITANIUM_NOEXCEPT
-{
-	TITANIUM_LOG_DEBUG("NativeGlobalObjectExample::CreateTimer");
-	return std::make_shared<NativeGlobalObjectTimerExample>(callback, interval);
-}
-
 NativeGlobalObjectExample::NativeGlobalObjectExample(const JSContext& js_context) TITANIUM_NOEXCEPT
     : Titanium::GlobalObject(js_context)
 {

--- a/Source/TitaniumKit/examples/NativeGlobalObjectExample.hpp
+++ b/Source/TitaniumKit/examples/NativeGlobalObjectExample.hpp
@@ -40,7 +40,6 @@ public:
 protected:
 	virtual std::string readRequiredModule(const JSObject& parent, const std::string& path) const override final;
 	virtual bool requiredModuleExists(const std::string& path) const TITANIUM_NOEXCEPT override final;
-	virtual std::shared_ptr<Timer> CreateTimer(Callback_t callback, const std::chrono::milliseconds& interval) const TITANIUM_NOEXCEPT override final;
 
 private:
 	std::unordered_map<std::string, std::string> require_resource__;

--- a/Source/TitaniumKit/include/Titanium/GlobalObject.hpp
+++ b/Source/TitaniumKit/include/Titanium/GlobalObject.hpp
@@ -106,7 +106,7 @@ namespace Titanium
 
 		  @result Unique timer identifier (Number).
 		*/
-		virtual unsigned setTimeout(JSObject&& function, const std::chrono::milliseconds& delay) TITANIUM_NOEXCEPT final;
+		virtual unsigned setTimeout(JSObject& function, const std::chrono::milliseconds& delay) TITANIUM_NOEXCEPT;
 
 		/*!
 		  @method
@@ -120,7 +120,7 @@ namespace Titanium
 
 		  @result void
 		*/
-		virtual void clearTimeout(const unsigned& timerId) TITANIUM_NOEXCEPT final;
+		virtual void clearTimeout(const unsigned& timerId) TITANIUM_NOEXCEPT;
 
 		/*!
 		  @method
@@ -142,7 +142,7 @@ namespace Titanium
 
 		  @result Unique timer identifier (Number).
 		*/
-		virtual unsigned setInterval(JSObject&& function, const std::chrono::milliseconds& delay) TITANIUM_NOEXCEPT final;
+		virtual unsigned setInterval(JSObject& function, const std::chrono::milliseconds& delay) TITANIUM_NOEXCEPT;
 
 		/*!
 		  @method
@@ -156,7 +156,7 @@ namespace Titanium
 
 		  @result void
 		*/
-		virtual void clearInterval(const unsigned& timerId) TITANIUM_NOEXCEPT final;
+		virtual void clearInterval(const unsigned& timerId) TITANIUM_NOEXCEPT;
 
 		GlobalObject(const JSContext&) TITANIUM_NOEXCEPT;
 		virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;
@@ -179,81 +179,6 @@ namespace Titanium
 		TITANIUM_FUNCTION_DEF(clearTimeout);
 		TITANIUM_FUNCTION_DEF(setInterval);
 		TITANIUM_FUNCTION_DEF(clearInterval);
-
-		using Callback_t = std::function<void()>;
-
-		/*!
-		  @class
-
-		  @discussion This is an abstract base class used in the
-		  implemenations of setTimeout, clearTimeout, setInterval and
-		  clearInterval that native platforms must provide implementations
-		  for.
-		*/
-		class TITANIUMKIT_EXPORT Timer
-		{
-		public:
-			/*!
-			  @method
-
-			  @abstract Create a Timer instance that repeatedly calls the
-			  given callback at the given interval after the Start method is
-			  called.
-
-			  @param callback The function to call repeatedly at the given
-			  interval after the Start method is called.
-
-			  @param interval The interval to repeatedly call the given
-			  function after the Start method is called.
-			*/
-			Timer(Callback_t callback, const std::chrono::milliseconds& interval);
-
-			virtual ~Timer() = default;
-			Timer(const Timer&) = default;
-			Timer& operator=(const Timer&) = default;
-#ifdef TITANIUM_MOVE_CTOR_AND_ASSIGN_DEFAULT_ENABLE
-			Timer(Timer&&) = default;
-			Timer& operator=(Timer&&) = default;
-#endif
-
-			/*!
-			  @method
-
-			  @abstract Start calling the callback repeatedly at the given
-			  interval.
-
-			  @result void
-			*/
-			virtual void Start() TITANIUM_NOEXCEPT = 0;
-
-			/*!
-			  @method
-
-			  @abstract Stop calling the callback repeatedly at the given
-			  interval.
-
-			  @result void
-			*/
-			virtual void Stop() TITANIUM_NOEXCEPT = 0;
-
-			/*!
-			  @method
-
-			  @abstract Return the interval that the Timer was constructed
-			  with.
-
-			  @result The interval that the Timer was constructed with.
-			*/
-			virtual std::chrono::milliseconds get_interval() const TITANIUM_NOEXCEPT final;
-
-		private:
-// Silence 4251 on Windows since private member variables do not
-// need to be exported from a DLL.
-#pragma warning(push)
-#pragma warning(disable : 4251)
-			std::chrono::milliseconds interval__;
-#pragma warning(pop)
-		};
 
 	protected:
 		// Silence 4251 on Windows since private member variables do not
@@ -283,34 +208,7 @@ namespace Titanium
 		virtual bool requiredNativeModuleExists(const JSContext& js_context, const std::string& moduleId) const TITANIUM_NOEXCEPT;
 		virtual JSValue requireNativeModule(const JSContext& js_context, const std::string& moduleId);
 
-		/*!
-		  @method
-
-		  @abstract Create a Timer instance that repeatedly calls the given
-		  callback at the given interval after its Start method is
-		  called. Native platforms must implementat this method in order
-		  for setTimeout, clearTimeout, setInterval and clearInterval to
-		  function correctly.
-
-		  @param callback The function to call repeatedly at the given
-		  interval after the Timer's Start method is called.
-
-		  @param interval The interval to repeatedly call the given
-		  function after the Timer's Start method is called.
-
-		  @result A std::shared_ptr<Timer> instance that repeatedly calls
-		  the given callback at the given interval after its Start method
-		  is called.
-		*/
-		virtual std::shared_ptr<Timer> CreateTimer(Callback_t callback, const std::chrono::milliseconds& interval) const TITANIUM_NOEXCEPT;
-
 	private:
-
-		void RegisterCallback(JSObject&& function, const unsigned& timerId) TITANIUM_NOEXCEPT;
-		void UnregisterCallback(const unsigned& timerId) TITANIUM_NOEXCEPT;
-		void InvokeCallback(const unsigned& timerId) TITANIUM_NOEXCEPT;
-		void StartTimer(Callback_t&& callback, const unsigned& timerId, const std::chrono::milliseconds& delay) TITANIUM_NOEXCEPT;
-		void StopTimer(const unsigned& timerId) TITANIUM_NOEXCEPT;
 
 // Silence 4251 on Windows since private member variables do not
 // need to be exported from a DLL.
@@ -319,10 +217,6 @@ namespace Titanium
 		std::unordered_map<std::string, std::string> module_path_cache__;
 		std::unordered_map<std::string, JSValue> module_cache__;
 		std::string currentDir__;
-		std::unordered_map<unsigned, std::shared_ptr<Timer>> timer_map__;
-		std::unordered_map<unsigned, JSObject> timer_callback_map__;
-
-		static std::atomic<unsigned> timer_id_generator__;
 #pragma warning(pop)
 
 #undef TITANIUM_GLOBALOBJECT_LOCK_GUARD

--- a/Source/TitaniumKit/src/GlobalObject.cpp
+++ b/Source/TitaniumKit/src/GlobalObject.cpp
@@ -9,7 +9,6 @@
 #include "Titanium/GlobalObject.hpp"
 #include "Titanium/detail/TiUtil.hpp"
 #include "Titanium/detail/TiImpl.hpp"
-#include "Titanium/Module.hpp"
 #include <sstream>
 #include <functional>
 #include <boost/algorithm/string/predicate.hpp>
@@ -21,7 +20,6 @@ namespace Titanium
 	using namespace Titanium::detail;
 
 	const std::string GlobalObject::COMMONJS_SEPARATOR__{"/"};
-	std::atomic<std::uint32_t> GlobalObject::timer_id_generator__;
 	std::uint32_t GlobalObject::require_nested_count__ = 0;
 
 	GlobalObject::GlobalObject(const JSContext& js_context) TITANIUM_NOEXCEPT
@@ -373,97 +371,26 @@ namespace Titanium
 		return js_context.CreateUndefined();
 	}
 
-	unsigned GlobalObject::setTimeout(JSObject&& function, const std::chrono::milliseconds& delay) TITANIUM_NOEXCEPT
+	unsigned GlobalObject::setTimeout(JSObject& function, const std::chrono::milliseconds& delay) TITANIUM_NOEXCEPT
 	{
-		const auto timerId = timer_id_generator__++;
-
-		RegisterCallback(std::move(function), timerId);
-
-		Callback_t callback = [this, timerId]() mutable {
-			InvokeCallback(timerId);
-			clearTimeout(timerId);
-		};
-
-		StartTimer(std::move(callback), timerId, delay);
-
-		return timerId;
+		TITANIUM_LOG_ERROR("GlobalObject::setTimeout: Unimplemented");
+		return 0;
 	}
 
 	void GlobalObject::clearTimeout(const unsigned& timerId) TITANIUM_NOEXCEPT
 	{
-		StopTimer(timerId);
+		TITANIUM_LOG_ERROR("GlobalObject::clearTimeout: Unimplemented");
 	}
 
-	unsigned GlobalObject::setInterval(JSObject&& function, const std::chrono::milliseconds& delay) TITANIUM_NOEXCEPT
+	unsigned GlobalObject::setInterval(JSObject& function, const std::chrono::milliseconds& delay) TITANIUM_NOEXCEPT
 	{
-		const auto timerId = timer_id_generator__++;
-
-		RegisterCallback(std::move(function), timerId);
-
-		Callback_t callback = [this, timerId]() mutable {
-			InvokeCallback(timerId);
-		};
-
-		StartTimer(std::move(callback), timerId, delay);
-
-		return timerId;
+		TITANIUM_LOG_ERROR("GlobalObject::setInterval: Unimplemented");
+		return 0;
 	}
 
 	void GlobalObject::clearInterval(const unsigned& timerId) TITANIUM_NOEXCEPT
 	{
-		StopTimer(timerId);
-	}
-
-	void GlobalObject::RegisterCallback(JSObject&& function, const unsigned& timerId) TITANIUM_NOEXCEPT
-	{
-		TITANIUM_ASSERT(function.IsFunction());
-		TITANIUM_ASSERT(timer_callback_map__.find(timerId) == timer_callback_map__.end());
-		timer_callback_map__.emplace(timerId, function);
-	}
-
-	void GlobalObject::UnregisterCallback(const unsigned& timerId) TITANIUM_NOEXCEPT
-	{
-		TITANIUM_ASSERT(timer_callback_map__.find(timerId) != timer_callback_map__.end());
-		timer_callback_map__.erase(timerId);
-	}
-
-	void GlobalObject::InvokeCallback(const unsigned& timerId) TITANIUM_NOEXCEPT
-	{
-		TITANIUM_EXCEPTION_CATCH_START{
-			const auto found = timer_callback_map__.find(timerId);
-			TITANIUM_ASSERT(found != timer_callback_map__.end());
-			auto callback = found->second;
-			TITANIUM_ASSERT(callback.IsFunction());
-			callback(get_context().get_global_object());
-		} TITANIUM_EXCEPTION_CATCH_END
-	}
-
-	void GlobalObject::StartTimer(Callback_t&& callback, const unsigned& timerId, const std::chrono::milliseconds& delay) TITANIUM_NOEXCEPT
-	{
-		auto timer = CreateTimer(callback, delay);
-		const auto timer_insert_result = timer_map__.emplace(timerId, timer);
-		const bool timer_inserted = timer_insert_result.second;
-		TITANIUM_ASSERT(timer_inserted);
-		TITANIUM_LOG_DEBUG("GlobalObject::setInterval: starting timer for timerId ", timerId);
-		timer->Start();
-	}
-
-	void GlobalObject::StopTimer(const unsigned& timerId) TITANIUM_NOEXCEPT
-	{
-		const auto timer_position = timer_map__.find(timerId);
-		const bool timer_found = timer_position != timer_map__.end();
-		if (timer_found) {
-			TITANIUM_LOG_DEBUG("GlobalObject::clearInterval: timerId ", timerId, " cleared");
-			auto timer_ptr = timer_position->second;
-			timer_ptr->Stop();
-			const auto number_of_elements_removed = timer_map__.erase(timerId);
-			TITANIUM_ASSERT(number_of_elements_removed == 1);
-
-			TITANIUM_ASSERT(timer_callback_map__.find(timerId) != timer_callback_map__.end());
-			timer_callback_map__.erase(timerId);
-		} else {
-			TITANIUM_LOG_WARN("GlobalObject::clearTimeout: timerId ", timerId, " is not registered");
-		}
+		TITANIUM_LOG_ERROR("GlobalObject::clearInterval: Unimplemented");
 	}
 
 	bool GlobalObject::requiredModuleExists(const std::string& path) const TITANIUM_NOEXCEPT
@@ -476,47 +403,6 @@ namespace Titanium
 	{
 		TITANIUM_LOG_ERROR("GlobalObject::readRequiredModule: Unimplemented");
 		return "";
-	}
-
-	GlobalObject::Timer::Timer(Callback_t callback, const std::chrono::milliseconds& interval)
-	    : interval__(interval)
-	{
-		TITANIUM_LOG_DEBUG("GlobalObject::Timer: interval = ", interval.count(), "ms");
-	}
-
-	std::chrono::milliseconds GlobalObject::Timer::get_interval() const TITANIUM_NOEXCEPT
-	{
-		return interval__;
-	}
-
-	class UnimplementedTimer final : public GlobalObject::Timer
-	{
-	public:
-		UnimplementedTimer(GlobalObject::Callback_t callback, const std::chrono::milliseconds& interval)
-		    : Timer(callback, interval)
-		{
-			TITANIUM_LOG_ERROR("GlobalObject::Timer: Unimplemented");
-		}
-
-		virtual ~UnimplementedTimer()
-		{
-		}
-
-		virtual void Start() TITANIUM_NOEXCEPT override final
-		{
-			TITANIUM_LOG_ERROR("GlobalObject::Timer::Start: Unimplemented");
-		}
-
-		virtual void Stop() TITANIUM_NOEXCEPT override final
-		{
-			TITANIUM_LOG_ERROR("GlobalObject::Timer::Stop: Unimplemented");
-		}
-	};
-
-	std::shared_ptr<GlobalObject::Timer> GlobalObject::CreateTimer(Callback_t callback, const std::chrono::milliseconds& interval) const TITANIUM_NOEXCEPT
-	{
-		TITANIUM_LOG_ERROR("GlobalObject::CreateTimer: Unimplemented");
-		return std::make_shared<UnimplementedTimer>(callback, interval);
 	}
 
 	void GlobalObject::JSExportInitialize()
@@ -563,7 +449,7 @@ namespace Titanium
 		const auto global_ptr = global_object.GetPrivate<GlobalObject>();
 		TITANIUM_ASSERT(global_ptr);
 
-		return this_object.get_context().CreateNumber(global_ptr->setTimeout(std::move(function), chrono_delay));
+		return this_object.get_context().CreateNumber(global_ptr->setTimeout(function, chrono_delay));
 	}
 
 	TITANIUM_FUNCTION(GlobalObject, clearTimeout)
@@ -592,7 +478,7 @@ namespace Titanium
 		const auto global_ptr = global_object.GetPrivate<GlobalObject>();
 		TITANIUM_ASSERT(global_ptr);
 
-		return this_object.get_context().CreateNumber(global_ptr->setInterval(std::move(function), chrono_delay));
+		return this_object.get_context().CreateNumber(global_ptr->setInterval(function, chrono_delay));
 	}
 
 	TITANIUM_FUNCTION(GlobalObject, clearInterval)


### PR DESCRIPTION
JIRA ticket: [TIMOB-25344](https://jira.appcelerator.org/browse/TIMOB-25344)

According to the studies from [TIMOB-25019](https://github.com/appcelerator/titanium_mobile_windows/commits/TIMOB-25019), we found some pitfalls in current `setTimeout/setInterval` implementations. There may be rare chances to encounter but we want simpler/faster/safer implementation for it. 

- Make sure to clear callback right after callback is actually called from `setTimeout`. 
- Invoke callback immediately when interval equals zero. It had synchronization issue with `clearTimeout/clearInterval`.
- `Xaml::DispatcherTimer` functions should have been called from UI thread. Use `ThreadPoolTimer` when possible, because it doesn't have the issue. 
- With `ThreadPoolTimer`, make sure to invoke callback from UI thread.

I also observed that new implementation is much faster than old implementation. It had `30%` faster (14sec->10sec) on debug mode by simple code like below.

Note that this is about internal implementation, so the API functionalities setTimeout/setInterval/clearTimeout/clearInterval should not be changed.

```js
var win = Ti.UI.createWindow({ backgroundColor: 'green' });
var label = Ti.UI.createLabel({ text: '0' });

var count = 0;
win.addEventListener('open', function () {
    var start = +new Date();
    var id = setInterval(function () {
        if (count > 100) {
            clearInterval(id);
            Ti.API.info((+new Date() - start));
            return;
        }
        count++;
        label.text = count;
    }, 100);
});

win.add(label);
win.open();
```

```js
var win = Ti.UI.createWindow({ backgroundColor: 'green' });
var label = Ti.UI.createLabel({ text: '0' });

var count = 0;
function test() {
    setTimeout(function () {
        count++;
        label.text = count;
        if (count < 100) {
            test();
        }
    }, 100);
}

win.addEventListener('open', function () {
    test();
});

win.add(label);
win.open();
```