### PR TITLE
[TIMOB-25325] Click event of Button does not provide coordinates

### DIFF
--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -1392,8 +1392,8 @@ namespace TitaniumWindows
 						const auto button = safe_cast<Controls::Button^>(sender);
 						// Set center of the button since Button::Click does not provide position info
 						Windows::Foundation::Point pos;
-						pos.X = static_cast<float>(button->Width  * 0.5);
-						pos.Y = static_cast<float>(button->Height * 0.5);
+						pos.X = static_cast<float>(button->ActualWidth  * 0.5);
+						pos.Y = static_cast<float>(button->ActualWidth * 0.5);
 						fireSimplePositionEvent("click", pos);
 					});
 				} else {


### PR DESCRIPTION
[TIMOB-25325](https://jira.appcelerator.org/browse/TIMOB-25325)

```js
var win = Ti.UI.createWindow({ backgroundColor: 'green' });
var button = Ti.UI.createButton({
    title: 'push',
    height: 100,
    width: 100
});

button.addEventListener('click', function (e) {
    // This should always returns "50 : 50" (center coordinate of the button) on Windows
    alert(e.x + ' : ' + e.y);
});

win.add(button);
win.open();
```

Note: On Windows, `x` and `y` always returns center position of the Button because Windows Button does not actually provide the pointer coordinate information along with the event. 