### PR TITLE
[TIMOB-25175] Unexpected scrollbar appears on ListView

### DIFF
--- a/Source/UI/src/ListView.cpp
+++ b/Source/UI/src/ListView.cpp
@@ -71,11 +71,18 @@ namespace TitaniumWindows
 				//
 				const auto layout = getViewLayoutDelegate<WindowsViewLayoutDelegate>();
 				const auto isSize = layout->get_height() == Titanium::UI::Constants::to_string(Titanium::UI::LAYOUT::SIZE);
-				if (isSize && e->NewSize.Height > e->PreviousSize.Height) {
-					// Workaround: According to the studies from some environments ListView needs some more margins,
-					// otherwise unexpected scrollbar appears. Following number worked fine but I don't know why.
-					double margin = 6 * listview__->Items->Size;
-					layout->set_height(std::to_string(e->NewSize.Height + margin));
+				double newHeight = e->NewSize.Height;
+				if (isSize && newHeight > 0) {
+					// Don't exceed parent height otherwize scrollbar never appears
+					const auto parentHeight = get_parent()->getViewLayoutDelegate<WindowsViewLayoutDelegate>()->getComponent()->ActualHeight;
+					if (newHeight > parentHeight) {
+						newHeight = parentHeight;
+					} else {
+						// Workaround: According to the studies from some environments ListView needs some more margins,
+						// otherwise unexpected scrollbar appears. Following number worked fine but I don't know why.
+						newHeight = newHeight + 6 * listview__->Items->Size;
+					}
+					layout->set_height(std::to_string(newHeight));
 				}
 			});
 

--- a/Source/UI/src/ListView.cpp
+++ b/Source/UI/src/ListView.cpp
@@ -71,8 +71,11 @@ namespace TitaniumWindows
 				//
 				const auto layout = getViewLayoutDelegate<WindowsViewLayoutDelegate>();
 				const auto isSize = layout->get_height() == Titanium::UI::Constants::to_string(Titanium::UI::LAYOUT::SIZE);
-				if (isSize && e->NewSize.Height > 0) {
-					layout->set_height(std::to_string(e->NewSize.Height));
+				if (isSize && e->NewSize.Height > e->PreviousSize.Height) {
+					// Workaround: According to the studies from some environments ListView needs some more margins,
+					// otherwise unexpected scrollbar appears. Following number worked fine but I don't know why.
+					double margin = 7 * listview__->Items->Size;
+					layout->set_height(std::to_string(e->NewSize.Height + margin));
 				}
 			});
 

--- a/Source/UI/src/ListView.cpp
+++ b/Source/UI/src/ListView.cpp
@@ -74,7 +74,7 @@ namespace TitaniumWindows
 				if (isSize && e->NewSize.Height > e->PreviousSize.Height) {
 					// Workaround: According to the studies from some environments ListView needs some more margins,
 					// otherwise unexpected scrollbar appears. Following number worked fine but I don't know why.
-					double margin = 7 * listview__->Items->Size;
+					double margin = 6 * listview__->Items->Size;
 					layout->set_height(std::to_string(e->NewSize.Height + margin));
 				}
 			});


### PR DESCRIPTION
[TIMOB-25175](https://jira.appcelerator.org/browse/TIMOB-25175)

Workaround. According to the studies from some environments ListView needs some more margins, otherwise unexpected scrollbar appears on the ListView. It seems it depends on device screen size (and default Window size at launch on desktop) but we needed more margins for the rows.

```js
var win = Ti.UI.createWindow({ backgroundColor: 'green' });

var myTemplate = {
    childTemplates: [
        {
            type: 'Ti.UI.View',
            bindId: 'itemContainer',
            properties: {
                height: 50,
                width: Ti.UI.FILL
            }
        },
    ]
};

var listView = Ti.UI.createListView({
    templates: { 'template': myTemplate },
    width: Ti.UI.FILL,
    height: Ti.UI.SIZE,
});
var section = Ti.UI.createListSection();
var listItems = [];


for (var i = 0; i < 10; i++) {
    listItems.push({
        template: 'template',
        itemContainer: {
            backgroundColor: (i % 2 === 0) ? 'red' : 'blue'
        }
    });
}

section.setItems(listItems);

listView.setSections([ section ]);
win.add(listView);
win.open();
```

Expected: Scrollbar should not appear on the ListView when parent view (Window) has enough space.
