### PR TITLE
[6_3_X] 6.3.X backports

### DIFF
--- a/Source/TitaniumKit/include/Titanium/UI/PickerColumn.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/PickerColumn.hpp
@@ -73,6 +73,13 @@ namespace Titanium
 			*/
 			virtual void removeRow(const std::shared_ptr<PickerRow>& row) TITANIUM_NOEXCEPT;
 
+			/*!
+			  @method
+			  @abstract reload
+			  @discussion reload this column.
+			*/
+			virtual void reload() TITANIUM_NOEXCEPT;
+
 			PickerColumn(const JSContext&) TITANIUM_NOEXCEPT;
 			virtual ~PickerColumn()                      = default;
 			PickerColumn(const PickerColumn&)            = default;

--- a/Source/TitaniumKit/src/UI/Picker.cpp
+++ b/Source/TitaniumKit/src/UI/Picker.cpp
@@ -105,7 +105,7 @@ namespace Titanium
 
 		void Picker::reloadColumn(const std::shared_ptr<PickerColumn>& column) TITANIUM_NOEXCEPT
 		{
-			set_columns({ column });
+			column->reload();
 		}
 
 		std::shared_ptr<PickerRow> Picker::getSelectedRow(const std::uint32_t& columnIndex) TITANIUM_NOEXCEPT

--- a/Source/TitaniumKit/src/UI/PickerColumn.cpp
+++ b/Source/TitaniumKit/src/UI/PickerColumn.cpp
@@ -42,6 +42,11 @@ namespace Titanium
 			}
 		}
 
+		void PickerColumn::reload() TITANIUM_NOEXCEPT
+		{
+			TITANIUM_LOG_WARN("PickerColumn::reload() is not implemented");
+		}
+
 		void PickerColumn::JSExportInitialize()
 		{
 			JSExport<PickerColumn>::SetClassVersion(1);

--- a/Source/UI/include/TitaniumWindows/UI/PickerColumn.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/PickerColumn.hpp
@@ -48,6 +48,7 @@ namespace TitaniumWindows
 			virtual void addRow(const std::shared_ptr<Titanium::UI::PickerRow>& row) TITANIUM_NOEXCEPT override;
 			virtual void removeRow(const std::shared_ptr<Titanium::UI::PickerRow>& row) TITANIUM_NOEXCEPT override;
 			virtual std::shared_ptr<Titanium::UI::PickerRow> get_selectedRow() const TITANIUM_NOEXCEPT override;
+			virtual void set_selectedRow(const std::shared_ptr<Titanium::UI::PickerRow>&) TITANIUM_NOEXCEPT override;
 
 			Windows::UI::Xaml::Controls::ComboBox^ getComponent() const TITANIUM_NOEXCEPT
 			{

--- a/Source/UI/include/TitaniumWindows/UI/PickerColumn.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/PickerColumn.hpp
@@ -49,6 +49,7 @@ namespace TitaniumWindows
 			virtual void removeRow(const std::shared_ptr<Titanium::UI::PickerRow>& row) TITANIUM_NOEXCEPT override;
 			virtual std::shared_ptr<Titanium::UI::PickerRow> get_selectedRow() const TITANIUM_NOEXCEPT override;
 			virtual void set_selectedRow(const std::shared_ptr<Titanium::UI::PickerRow>&) TITANIUM_NOEXCEPT override;
+			virtual void reload() TITANIUM_NOEXCEPT override;
 
 			Windows::UI::Xaml::Controls::ComboBox^ getComponent() const TITANIUM_NOEXCEPT
 			{

--- a/Source/UI/src/PickerColumn.cpp
+++ b/Source/UI/src/PickerColumn.cpp
@@ -110,6 +110,11 @@ namespace TitaniumWindows
 #endif
 		}
 
+		void PickerColumn::reload() TITANIUM_NOEXCEPT
+		{
+			refreshRows();
+		}
+
 		void PickerColumn::JSExportInitialize()
 		{
 			JSExport<PickerColumn>::SetClassVersion(1);

--- a/Source/UI/src/PickerColumn.cpp
+++ b/Source/UI/src/PickerColumn.cpp
@@ -46,6 +46,13 @@ namespace TitaniumWindows
 			}
 		}
 
+		void PickerColumn::set_selectedRow(const std::shared_ptr<Titanium::UI::PickerRow>& selectedRow) TITANIUM_NOEXCEPT
+		{
+			Titanium::UI::PickerColumn::set_selectedRow(selectedRow);
+			const auto row = std::dynamic_pointer_cast<TitaniumWindows::UI::PickerRow>(selectedRow);
+			picker__->SelectedItem = row->getComboBoxItem();
+		}
+
 		void PickerColumn::addRow(const std::shared_ptr<Titanium::UI::PickerRow>& r) TITANIUM_NOEXCEPT
 		{
 			Titanium::UI::PickerColumn::addRow(r);

--- a/Source/UI/src/Window.cpp
+++ b/Source/UI/src/Window.cpp
@@ -53,8 +53,6 @@ namespace TitaniumWindows
 					if (!IS_WINDOWS_MOBILE) {
 						updateWindowSize();
 					}
-					// Update back button visibility. Note that back button is available on Store App too.
-					SystemNavigationManager::GetForCurrentView()->AppViewBackButtonVisibility = AppViewBackButtonVisibility::Visible;
 				} catch (...) {
 					TITANIUM_LOG_DEBUG("Error at root frame Navigated");
 				}
@@ -268,6 +266,9 @@ namespace TitaniumWindows
 						}
 					}
 
+#if defined(IS_WINDOWS_10)
+					SystemNavigationManager::GetForCurrentView()->AppViewBackButtonVisibility = window_stack__.size() > 1 ? AppViewBackButtonVisibility::Visible : AppViewBackButtonVisibility::Collapsed;
+#endif
 					// start accepting events for the new Window
 					next_window->enableEvents();
 					next_window->focus();
@@ -376,6 +377,10 @@ namespace TitaniumWindows
 			if (tab__ == nullptr) {
 				window_stack__.push_back(this->get_object().GetPrivate<Window>());
 			}
+
+#if defined(IS_WINDOWS_10)
+			SystemNavigationManager::GetForCurrentView()->AppViewBackButtonVisibility = window_stack__.size() > 1 ? AppViewBackButtonVisibility::Visible : AppViewBackButtonVisibility::Collapsed;
+#endif
 
 			// start accepting events
 			enableEvents();

--- a/cli/hooks/wp-run.js
+++ b/cli/hooks/wp-run.js
@@ -286,8 +286,14 @@ exports.init = function (logger, config, cli) {
 								next(err.message);
 							})
 							.on('error', function (err) {
-								logRelay && logRelay.stop();
-								next(err.message);
+								// We should skip installing dependency when it is aready there
+								if (err.message && err.message.indexOf('A debug application is already installed') != -1) {
+									logger.info(__('Skipping installing dependency: %s', file));
+									next();
+								} else {
+									logRelay && logRelay.stop();
+									next(err.message);
+								}
 							});
 						});
 					});


### PR DESCRIPTION
Backport #1096 #1108 #1111 #1110 for `6_3_X`


- [[TIMOB-25263](https://jira.appcelerator.org/browse/TIMOB-25263)] Remove back button when there's no window left
- [[TIMOB-25247](https://jira.appcelerator.org/browse/TIMOB-25247)] Picker.setSelectedRow doesn't work
- [[TIMOB-25245](https://jira.appcelerator.org/browse/TIMOB-25245)] picker.reloadColumn removes all other columns
- [[TIMOB-24934](https://jira.appcelerator.org/browse/TIMOB-24934)] Skip installing dependencies when it is already installed 
