### PR TITLE
[TIMOB-25327]  ScrollableViewer.currentPage not changed with scrollend

### DIFF
--- a/Source/UI/src/ScrollableView.cpp
+++ b/Source/UI/src/ScrollableView.cpp
@@ -108,6 +108,11 @@ namespace TitaniumWindows
 			layoutDelegate->setStyleComponent(scroll_viewer__);
 			layoutDelegate->setComponent(border__, nullptr, border__);
 
+			scroll_viewer__->ViewChanged += ref new Windows::Foundation::EventHandler<Windows::UI::Xaml::Controls::ScrollViewerViewChangedEventArgs ^>(
+				[this](Platform::Object ^sender, Windows::UI::Xaml::Controls::ScrollViewerViewChangedEventArgs ^args) {
+				currentPage__ = scroll_viewer__->HorizontalOffset / getViewLayoutDelegate<WindowsViewLayoutDelegate>()->getComponent()->Width;
+			});
+
 			auto contentLayoutDelegate = getContentViewLayoutDelegate();
 
 			auto nativeChildView = content->getComponent();


### PR DESCRIPTION
[TIMOB-25327](https://jira.appcelerator.org/browse/TIMOB-25327)

```js
var win = Ti.UI.createWindow();
var view1 = Ti.UI.createView({ backgroundColor: 'green' });
var view2 = Ti.UI.createView({ backgroundColor: 'red' });
var view3 = Ti.UI.createView({ backgroundColor: 'blue' });
var scrollableView = Ti.UI.createScrollableView({
    views: [view1, view2, view3],
    showPagingControl: true
});
scrollableView.addEventListener('scrollend', function (e) {
    console.log(e.currentPage)
})
win.add(scrollableView);
win.open();
```

Expected: `currentPage` should be changed along with scroll event (tested on Windows & scrolled with mouse wheel)
