### PR TITLE
[TIMOB-25257] Crash when adding view back

### DIFF
--- a/Examples/NMocha/src/Assets/ti.ui.layout.test.js
+++ b/Examples/NMocha/src/Assets/ti.ui.layout.test.js
@@ -1668,5 +1668,20 @@ describe('Titanium.UI.Layout', function () {
 	    win.open();
 	});
 
+	it('TIMOB-25257', function (finish) {
+	    var win = createWindow({}, finish);
+	    var view = Ti.UI.createView({
+	        backgroundColor: 'green',
+	        width: 50, height: 50
+	    });
+	    win.add(view);
+	    win.addEventListener('open', function (e) {
+	        win.remove(view);
+	        setTimeout(function () {
+                win.add(view);
+	        }, 500);
+	    });
+	    win.open();
+	});
 
 });

--- a/Source/LayoutEngine/src/Node.cpp
+++ b/Source/LayoutEngine/src/Node.cpp
@@ -43,6 +43,8 @@ namespace Titanium
 				parent->lastChild = child->prev;
 			}
 
+			child->next = nullptr;
+
 			removeChildElement(&parent->element, &child->element);
 		}
 


### PR DESCRIPTION
[TIMOB-25257](https://jira.appcelerator.org/browse/TIMOB-25257)

It turns out this is layout engine issue and happens on all View subclasses.

```js
﻿﻿﻿var _window = Ti.UI.createWindow();

var view = Ti.UI.createTableView({
    backgroundColor: 'green',
    width: 50, height: 50
});

_window.addEventListener('open', function () {
    _window.remove(view);
    setTimeout(function () {
        _window.add(view);
        alert('passed');
    }, 1000);
});

_window.add(view);
_window.open();
```

```js
﻿﻿﻿var _window = Ti.UI.createWindow();

var view = Ti.UI.createView({
    backgroundColor: 'green',
    width: 50, height: 50
});

_window.addEventListener('open', function () {
    _window.remove(view);
    setTimeout(function () {
        _window.add(view);
        alert('passed');
    }, 1000);
});

_window.add(view);
_window.open();
```


Expected: App should not crash