### PR TITLE
[TIMOB-25326] image of ListItem should not overlay text

### DIFF
--- a/Source/TitaniumKit/src/UI/listview.js
+++ b/Source/TitaniumKit/src/UI/listview.js
@@ -12,6 +12,9 @@
  */
 
 var LISTVIEW_LIST_ITEM_TEMPLATE_DEFAULT = {
+	properties: {
+		layout: 'horizontal'
+	},
 	childTemplates: [
 		{
 			type: 'Ti.UI.ImageView',

--- a/Source/TitaniumKit/src/UI/listview.js
+++ b/Source/TitaniumKit/src/UI/listview.js
@@ -17,7 +17,7 @@ var LISTVIEW_LIST_ITEM_TEMPLATE_DEFAULT = {
 			type: 'Ti.UI.ImageView',
 			bindId: 'image',
 			properties: {
-				left: 0, top: 0, width: 50, height: 50
+				left: 0, top: 0
 			}
 		},
 		{
@@ -25,7 +25,7 @@ var LISTVIEW_LIST_ITEM_TEMPLATE_DEFAULT = {
 			bindId: 'text',
 			properties: {
 				color: 'white',
-				left: 52, top: 0,
+				left: 0, top: 0,
 			}
 		}
 	]

--- a/Source/TitaniumKit/src/UI/listview.js
+++ b/Source/TitaniumKit/src/UI/listview.js
@@ -17,7 +17,7 @@ var LISTVIEW_LIST_ITEM_TEMPLATE_DEFAULT = {
 			type: 'Ti.UI.ImageView',
 			bindId: 'image',
 			properties: {
-				left: 0, top: 0
+				left: 0, top: 0, width: 50, height: 50
 			}
 		},
 		{
@@ -25,7 +25,7 @@ var LISTVIEW_LIST_ITEM_TEMPLATE_DEFAULT = {
 			bindId: 'text',
 			properties: {
 				color: 'white',
-				left: 0, top: 0,
+				left: 52, top: 0,
 			}
 		}
 	]


### PR DESCRIPTION
[TIMOB-25326](https://jira.appcelerator.org/browse/TIMOB-25326)

```js
var win = Ti.UI.createWindow({ backgroundColor: 'green' });
var listView = Ti.UI.createListView();
var sections = [];

var vegSection = Ti.UI.createListSection({ headerTitle: 'Vegetables' });
var vegDataSet = [
    { properties: { title: 'Carrots', image: 'http://api.randomuser.me/portraits/women/0.jpg', color: 'black' } },
    { properties: { title: 'Potatoes', color: 'black' } },
];
vegSection.setItems(vegDataSet);
sections.push(vegSection);

listView.sections = sections;
win.add(listView);
win.open();
```

Expected: image ListItem should not overlay text