### PR TITLE
[TIMOB-25235] Implement TextField.blur()

### DIFF
--- a/Source/TitaniumKit/include/Titanium/UI/TextField.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/TextField.hpp
@@ -257,32 +257,6 @@ namespace Titanium
 			/*!
 			  @method
 
-			  @abstract blur() : void
-
-			  @discussion Forces the field to lose focus.
-
-			  @param
-
-			  @result void
-			*/
-			virtual void blur() TITANIUM_NOEXCEPT;
-
-			/*!
-			  @method
-
-			  @abstract focus() : void
-
-			  @discussion Forces the field to gain focus.
-
-			  @param
-
-			  @result void
-			*/
-			virtual void focus() TITANIUM_NOEXCEPT;
-
-			/*!
-			  @method
-
 			  @abstract hasText() : Boolean
 
 			  @discussion Returns true if this text field contains text.

--- a/Source/TitaniumKit/src/UI/TextField.cpp
+++ b/Source/TitaniumKit/src/UI/TextField.cpp
@@ -69,16 +69,6 @@ namespace Titanium
 			}
 		}
 
-		void TextField::blur() TITANIUM_NOEXCEPT
-		{
-			TITANIUM_LOG_DEBUG("TextField::blur");
-		}
-
-		void TextField::focus() TITANIUM_NOEXCEPT
-		{
-			TITANIUM_LOG_DEBUG("TextField::focus");
-		}
-
 		bool TextField::hasText() TITANIUM_NOEXCEPT
 		{
 			TITANIUM_LOG_DEBUG("TextField::hasText");

--- a/Source/UI/include/TitaniumWindows/UI/TextField.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/TextField.hpp
@@ -38,7 +38,6 @@ namespace TitaniumWindows
 			TITANIUM_PROPERTY_UNIMPLEMENTED(returnKeyType);
 			TITANIUM_PROPERTY_UNIMPLEMENTED(rightButtonMode);
 			TITANIUM_PROPERTY_UNIMPLEMENTED(suppressReturn);
-			TITANIUM_FUNCTION_UNIMPLEMENTED(blur);
 
 			TextField(const JSContext&) TITANIUM_NOEXCEPT;
 

--- a/Source/UI/src/Window.cpp
+++ b/Source/UI/src/Window.cpp
@@ -173,8 +173,10 @@ namespace TitaniumWindows
 
 			SetActiveTabWindow(get_object().GetPrivate<Window>());
 
-			// Xaml Canvas doesn't actually fire GotFocus. Let's fire Ti event manually
-			fireEvent("focus");
+			const auto rootFrame = dynamic_cast<Windows::UI::Xaml::Controls::Frame^>(Windows::UI::Xaml::Window::Current->Content);
+			if (rootFrame) {
+				rootFrame->Focus(Windows::UI::Xaml::FocusState::Programmatic);
+			}
 		}
 
 		void Window::SetActiveTabWindow(const std::shared_ptr<TitaniumWindows::UI::Window>& window)

--- a/Source/UI/src/Window.cpp
+++ b/Source/UI/src/Window.cpp
@@ -177,6 +177,8 @@ namespace TitaniumWindows
 			if (rootFrame) {
 				rootFrame->Focus(Windows::UI::Xaml::FocusState::Programmatic);
 			}
+
+			fireEvent("focus");
 		}
 
 		void Window::SetActiveTabWindow(const std::shared_ptr<TitaniumWindows::UI::Window>& window)

--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -104,15 +104,17 @@ namespace TitaniumWindows
 
 		void WindowsViewLayoutDelegate::blur()
 		{
-			TITANIUM_LOG_WARN("blur() is not supported on Windows");
+			const auto parent = get_parent();
+			if (parent) {
+				parent->focus();
+			}
 		}
 
 		void WindowsViewLayoutDelegate::focus()
 		{
-			if (is_control__) {
-				dynamic_cast<Control^>(component__)->Focus(FocusState::Programmatic);
-			} else {
-				TITANIUM_LOG_WARN("focus() is not supported for this control");
+			const auto component = dynamic_cast<Control^>(getEventComponent());
+			if (component) {
+				component->Focus(FocusState::Programmatic);
 			}
 		}
 


### PR DESCRIPTION
[TIMOB-25235](https://jira.appcelerator.org/browse/TIMOB-25235)

```js
var _window = Ti.UI.createWindow({ backgroundColor: 'green' });
var textfield0 = Titanium.UI.createTextField({
    width: Ti.UI.FILL,
    top: 100
});
var textfield1 = Titanium.UI.createTextField({
    width: Ti.UI.FILL,
    top: 150
});
var textfield2 = Titanium.UI.createTextField({
    width: Ti.UI.FILL,
    top: 200
});

_window.addEventListener('open', function () {
    setTimeout(function () {
        textfield1.focus();
        setTimeout(function () {
            textfield1.blur();
            Ti.API.info('lost focus?');
        }, 3000);
    }, 1000);
});

_window.add(textfield0);
_window.add(textfield1);
_window.add(textfield2);
_window.open()
```

Expected: second text field should gain focus after 1 sec passed, and then lost focus after 3 sec passed.
