### PR TITLE
[TIMOB-24816] Update the mocha suite in titanium_mobile_windows

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,43 +93,6 @@ timestamps {
 		}
 
 		parallel(
-			'Windows 8.1 Store x86': {
-				node('msbuild-12 && (vs2013 || vs2015) && hyper-v && windows-sdk-8.1 && npm && node && cmake && jsc') {
-					build('8.1', '12.0', 'WindowsStore-x86', gitCommit)
-
-					unstash 'NMocha' // for tests
-					dir('Tools/Scripts/build') {
-						timeout(testTimeout) {
-							echo 'Running Tests on Windows 8.1 Desktop'
-							bat "node test.js -s 8.1 -T ws-local -p Windows8_1.Store -b ${targetBranch}"
-						}
-						// Kill the desktop app, so workspace cleanup works...
-						bat 'taskkill /IM Mocha.exe /F 2> nul'
-					}
-					junit 'dist/junit_report.xml'
-				}
-			},
-			'Windows 8.1 Phone x86': {
-				node('msbuild-12 && (vs2013 || vs2015) && hyper-v && windows-sdk-8.1 && npm && node && cmake && jsc') {
-					build('8.1', '12.0', 'WindowsPhone-x86', gitCommit)
-
-					unstash 'NMocha' // for tests
-					dir('Tools/Scripts/build') {
-						timeout(testTimeout) {
-							echo 'Running Tests on Windows 8.1 Phone Emulator'
-							bat "node test.js -s 8.1 -T wp-emulator -p Windows8_1.Phone -b ${targetBranch}"
-						}
-						// Kill the phone emulator, so workspace cleanup works...
-						bat 'taskkill /IM xde.exe 2> nul'
-					}
-					junit 'dist/junit_report.xml'
-				}
-			},
-			'Windows 8.1 Phone ARM': {
-				node('msbuild-12 && (vs2013 || vs2015) && windows-sdk-8.1 && npm && node && cmake && jsc') {
-					build('8.1', '12.0', 'WindowsPhone-ARM', gitCommit)
-				}
-			},
 			'Windows 10 x86': {
 				node('msbuild-14 && vs2015 && hyper-v && windows-sdk-10 && npm && node && cmake && jsc') {
 					build('10.0', '14.0', 'WindowsStore-x86', gitCommit)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,43 +3,97 @@
 properties([buildDiscarder(logRotator(numToKeepStr: '30', artifactNumToKeepStr: '5'))])
 
 def gitCommit = ''
-def testTimeout = 25
+// Variables we can change
+// FIXME Using the nodejs jenkins plugin introduces complications that cause us not to properly connect to the Windows Phone emulator for logs
+// Likely need to modify the firewall rules to allow traffic from the new nodejs install like we do for system install!
+def nodeVersion = '6.10.3' // NOTE that changing this requires we set up the desired version on jenkins master first!
 
-def build(sdkVersion, msBuildVersion, architecture, gitCommit) {
+def build(sdkVersion, msBuildVersion, architecture, gitCommit, nodeVersion) {
 	unstash 'sources' // for build
 	if (fileExists('dist/windows')) {
 		bat 'rmdir dist\\windows /Q /S'
 	}
 	bat 'mkdir dist\\windows'
 
-	dir('Tools/Scripts') {
-		bat 'npm install .'
-		echo "Installing JSC built for Windows ${sdkVersion}"
-		bat "node setup.js -s ${sdkVersion} --no-color --no-progress-bars"
-		bat 'rmdir node_modules /Q /S'
-	}
-
-	dir('Tools/Scripts/build') {
-		bat 'npm install .'
-
-		timeout(45) {
-			echo "Building for ${architecture} ${sdkVersion}"
-			def raw = bat(returnStdout: true, script: "echo %JavaScriptCore_${sdkVersion}_HOME%").trim()
-			def jscHome = raw.split('\n')[-1]
-			echo "Setting JavaScriptCore_HOME to ${jscHome}"
-			withEnv(["JavaScriptCore_HOME=${jscHome}"]) {
-				bat "node build.js -s ${sdkVersion} -m ${msBuildVersion} -o ${architecture} --sha ${gitCommit}"
-			}
+	// nodejs(nodeJSInstallationName: "node ${nodeVersion}") {
+	// 	bat 'npm install -g npm@5.4.1' // Install NPM 5.4.1
+	// 	def nodeHome = tool(name: "node ${nodeVersion}", type: 'nodejs')
+	// 	echo nodeHome
+	// 	bat "netsh advfirewall firewall add rule name=\"Node ${nodeVersion}\ TCP" program=\"${nodeHome}\\node.exe\" dir=in action=allow protocol=TCP"
+	// 	bat "netsh advfirewall firewall add rule name=\"Node ${nodeVersion}\ UDP" program=\"${nodeHome}\\node.exe\" dir=in action=allow protocol=UDP"
+		dir('Tools/Scripts') {
+			bat 'npm install .'
+			echo "Installing JSC built for Windows ${sdkVersion}"
+			bat "node setup.js -s ${sdkVersion} --no-color --no-progress-bars"
+			bat 'rmdir node_modules /Q /S'
 		}
-	}
+
+		dir('Tools/Scripts/build') {
+			bat 'npm install .'
+
+			timeout(45) {
+				echo "Building for ${architecture} ${sdkVersion}"
+				def raw = bat(returnStdout: true, script: "echo %JavaScriptCore_${sdkVersion}_HOME%").trim()
+				def jscHome = raw.split('\n')[-1]
+				echo "Setting JavaScriptCore_HOME to ${jscHome}"
+				withEnv(["JavaScriptCore_HOME=${jscHome}"]) {
+					bat "node build.js -s ${sdkVersion} -m ${msBuildVersion} -o ${architecture} --sha ${gitCommit}"
+				}
+			} // timeout
+		} // dir Tool/Scripts/build
+	// } // nodejs
 	archiveArtifacts artifacts: 'dist/**/*'
-}
+} // def build
+
+def unitTests(target, branch, testSuiteBranch, nodeVersion) {
+	def defaultEmulatorID = '10-0-1'
+	unarchive mapping: ['dist/' : '.'] // copy in built SDK from dist/ folder (from Build stage)
+	// nodejs(nodeJSInstallationName: "node ${nodeVersion}") {
+		// bat 'npm install -g npm@5.4.1' // Install NPM 5.4.1
+		dir('Tools/Scripts/build') {
+			echo 'Setting up SDK'
+			bat 'npm install .'
+			bat "node setupSDK.js --branch ${branch}"
+		}
+
+		// if our test suite already exists, delete it
+		bat 'if exist titanium-mobile-mocha-suite rmdir titanium-mobile-mocha-suite /Q /S'
+		// clone the tests suite fresh
+		// FIXME Clone once on initial node and use stash/unstash to ensure all OSes use exact same checkout revision
+		dir('titanium-mobile-mocha-suite') {
+			// TODO Do a shallow clone, using same credentials as from scm object
+			git changelog: false, poll: false, credentialsId: 'd05dad3c-d7f9-4c65-9cb6-19fef98fc440', url: 'https://github.com/appcelerator/titanium-mobile-mocha-suite.git', branch: testSuiteBranch
+		}
+
+		dir('titanium-mobile-mocha-suite/scripts') {
+			bat 'npm install .'
+			echo "Running tests on ${target}"
+			try {
+
+				timeout(20) {
+					if ('ws-local'.equals(target)) {
+						bat "node test.js -p windows -T ${target} --skip-sdk-install --cleanup"
+					} else if ('wp-emulator'.equals(target)) {
+						bat "node test.js -p windows -T ${target} -C ${defaultEmulatorID} --skip-sdk-install --cleanup"
+					}
+				}
+			} finally {
+				// kill the emulator/app
+				if ('ws-local'.equals(target)) {
+					bat 'taskkill /IM mocha.exe /F 2> nul'
+				} else if ('wp-emulator'.equals(target)) {
+					bat 'taskkill /IM xde.exe /F 2> nul'
+				}
+			}
+			junit 'junit.*.xml'
+		} // dir 'titanium-mobile-mocha-suite/scripts
+	// } // nodejs
+} // def unitTests
 
 // wrap in timestamps
 timestamps {
-	// Generate docs on generic node
-	stage('Docs') {
-		node('npm && node') {
+	node('git') {
+		stage('Checkout') {
 			// checkout scm
 			// Hack for JENKINS-37658 - see https://support.cloudbees.com/hc/en-us/articles/226122247-How-to-Customize-Checkout-for-Pipeline-Multibranch
 			checkout([
@@ -56,21 +110,27 @@ timestamps {
 			gitCommit = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
 			// Stash our source code/scripts so we don't need to checkout again?
 			stash name: 'sources', includes: '**', excludes: 'apidoc/**,test/**,Examples/**'
-			stash name: 'NMocha', includes: 'Examples/NMocha/**/*'
+		} // Checkout stage
 
+		stage('Docs') {
 			if (isUnix()) {
 				sh 'mkdir -p dist/windows/doc'
 			} else {
 				bat 'mkdir dist\\\\windows\\\\doc'
 			}
 			echo 'Generating docs'
-			dir('apidoc') {
-				if (isUnix()) {
-					sh 'npm install .'
-					sh 'node ti_win_yaml.js'
-				} else {
-					bat 'call npm install .'
-					bat 'call node ti_win_yaml.js'
+
+			nodejs(nodeJSInstallationName: "node ${nodeVersion}") {
+				dir('apidoc') {
+					if (isUnix()) {
+						sh 'npm install -g npm@5.4.1'
+						sh 'npm install .'
+						sh 'node ti_win_yaml.js'
+					} else {
+						bat 'call npm install -g npm@5.4.1'
+						bat 'call npm install .'
+						bat 'call node ti_win_yaml.js'
+					}
 				}
 			}
 			echo 'copying generated docs to dist folder'
@@ -80,58 +140,55 @@ timestamps {
 				bat '(robocopy apidoc\\\\Titanium dist\\\\windows\\\\doc\\\\Titanium /e) ^& IF %ERRORLEVEL% LEQ 3 cmd /c exit 0'
 			}
 			archiveArtifacts artifacts: 'dist/**/*'
-		} // node
-	} // stage('Docs')
+		} // stage('Docs')
+	} // node
 
-	stage ('Build') {
-		def targetBranch = env.CHANGE_TARGET // if it's a PR, use target merge branch as branch of SDK to install
-		if (!env.BRANCH_NAME.startsWith('PR-')) {
-			targetBranch = env.BRANCH_NAME // if it isn't a PR, try to match the current branch
-		}
-		if (!targetBranch) { // if all else fails, use master as SDK branch to test with
-			targetBranch = 'master'
-		}
+	// Are we on a PR/feature branch, or a "mainline" branch like master/6_2_X/7_0_X?
+	def isMainlineBranch = (env.BRANCH_NAME ==~ /master|\d_\d_(X|\d)/)
+	def targetBranch = env.CHANGE_TARGET // if it's a PR, use target merge branch as branch of SDK to install
+	if (isMainlineBranch) { // if it's a mainline branch, use the same branch for titanium_mobile
+		targetBranch = env.BRANCH_NAME
+	}
+	if (!targetBranch) { // if all else fails, use master as SDK branch to test with
+		targetBranch = 'master'
+	}
+	// Trigger titanium_mobile if we're on a mainline branch
+	def triggerDownstream = isMainlineBranch
 
+	stage('Build') {
 		parallel(
 			'Windows 10 x86': {
-				node('msbuild-14 && vs2015 && hyper-v && windows-sdk-10 && npm && node && cmake && jsc') {
-					build('10.0', '14.0', 'WindowsStore-x86', gitCommit)
-
-					unstash 'NMocha' // for tests
-					dir('Tools/Scripts/build') {
-						timeout(testTimeout) {
-							echo 'Running Tests on Windows 10 Desktop'
-							bat "node test.js -s 10.0 -T ws-local -p Windows10.Store -b ${targetBranch}"
-						}
-						// Kill the desktop app, so workspace cleanup works...
-						bat 'taskkill /IM Mocha.exe /F 2> nul'
-					}
-					junit 'dist/junit_report.xml'
-					// Delete the report from store, so if phone fails we don't pick this one up
-					bat 'del /f /q dist\\junit_report.xml'
-
-					dir('Tools/Scripts/build') {
-						timeout(testTimeout) {
-							echo 'Running Tests on Windows 10 Phone Emulator'
-							bat "node test.js -s 10.0.10586 -T wp-emulator -p Windows10.Phone -b ${targetBranch}"
-						}
-						// Kill the phone emulator, so workspace cleanup works...
-						bat 'taskkill /IM xde.exe 2> nul'
-					}
-					junit 'dist/junit_report.xml'
+				node('msbuild-14 && vs2015 && windows-sdk-10 && node && npm && cmake && jsc') {
+					build('10.0', '14.0', 'WindowsStore-x86', gitCommit, nodeVersion)
 				}
 			},
 			'Windows 10 ARM': {
-				node('msbuild-14 && vs2015 && hyper-v && windows-sdk-10 && npm && node && cmake && jsc') {
-					build('10.0', '14.0', 'WindowsStore-ARM', gitCommit)
+				node('msbuild-14 && vs2015 && windows-sdk-10 && node && npm && cmake && jsc') {
+					build('10.0', '14.0', 'WindowsStore-ARM', gitCommit, nodeVersion)
 				}
 			},
 			failFast: true
 		)
-	}
+	} // Stage build
+
+	stage('Test') {
+		def testSuiteBranch = targetBranch
+		parallel(
+			'ws-local': {
+				node('msbuild-14 && vs2015 && windows-sdk-10 && cmake && node && npm') {
+					unitTests('ws-local', targetBranch, testSuiteBranch, nodeVersion)
+				}
+			},
+			'wp-emulator': {
+				node('msbuild-14 && vs2015 && hyper-v && windows-sdk-10 && cmake && node && npm') {
+					unitTests('wp-emulator', targetBranch, testSuiteBranch, nodeVersion)
+				}
+			}
+		)
+	} // stage Test
 
 	// If not a PR, trigger titanium_mobile to build
-	if (!env.BRANCH_NAME.startsWith('PR-')) {
+	if (triggerDownstream) {
 		// Trigger build of titanium_mobile in our pipeline multibranch group!
 		build job: "../titanium_mobile/${env.BRANCH_NAME}", wait: false
 	}

--- a/Tools/Scripts/build/setupSDK.js
+++ b/Tools/Scripts/build/setupSDK.js
@@ -1,0 +1,210 @@
+var path = require('path'),
+	fs = require('fs'),
+	async = require('async'),
+	colors = require('colors'),
+	wrench = require('wrench'),
+	spawn = require('child_process').spawn,
+	exec = require('child_process').exec,
+	titanium = path.join(__dirname, 'node_modules', 'titanium', 'bin', 'titanium'),
+	DIST_DIR = path.join(__dirname, '..', '..', '..', 'dist'),
+	WINDOWS_DIST_DIR = path.join(DIST_DIR, 'windows'),
+	// Global vars
+	hadWindowsSDK = false;
+
+
+/**
+ * Installs the latest SDK from master branch remotely, sets it as the default
+ * SDK. We'll be hacking it to add our locally built Windows SDK into it.
+ *
+ * @param barnch {String} branch name or URL of Titanium SDK to use
+ * @param next {Function} callback function
+ **/
+function installSDK(branch, next) {
+	var prc = spawn('node', [titanium, 'sdk', 'install', '-b', branch, '-d', '--no-colors']),
+		sdkVersion;
+	prc.stdout.on('data', function (data) {
+		var value = data.toString().trim(),
+			regexp = /You're up\-to\-date\. Version (\d+\.\d+\.\d+\.v\d+)/, // when SDK is already installed
+			regexp2 = /Titanium SDK (\d+\.\d+\.\d+\.v\d+) successfully installed/, // when we installed the SDK
+			matches = value.match(regexp);
+		if (!matches) { // first regexp didn't find anything (check if normal successful install)
+			matches = value.match(regexp2);
+		}
+		if (matches) { // did either regexp get the sdk version?
+			sdkVersion = matches[1];
+		}
+		console.log(value);
+	});
+	prc.stderr.on('data', function (data) {
+		console.error(data.toString().trim());
+	});
+
+	prc.on('close', function (code) {
+		if (code != 0) {
+			next("Failed to install SDK. Exit code: " + code);
+		} else {
+			console.log("Making sure " + sdkVersion + " is selected");
+			var selectPrc = spawn('node', [titanium, 'sdk', 'select', sdkVersion]);
+			selectPrc.stdout.on('data', function (data) {
+				console.log(data.toString());
+			});
+			selectPrc.stderr.on('data', function (data) {
+				console.error(data.toString().trim());
+			});
+			selectPrc.on('close', function (code) {
+				if (code != 0) {
+					next("Failed to select SDK. Exit code: " + code);
+				} else {
+					next(null, sdkVersion);
+				}
+			});
+		}
+	});
+}
+
+/**
+ * Look up the full path to the SDK we just installed (the SDK we'll be hacking
+ * to add our locally built Windows SDK into).
+ *
+ * @param tiSDKVersion {String} The versionw e installed (if we know it)
+ * @param next {Function} callback function
+ **/
+function getSDKInstallDir(tiSDKVersion, next) {
+	var prc = exec('node "' + titanium + '" info -o json -t titanium', function (error, stdout, stderr) {
+		var out,
+			selectedSDK;
+		if (error !== null) {
+			return next('Failed to get SDK install dir: ' + error);
+		}
+
+		out = JSON.parse(stdout);
+		if (tiSDKVersion) {
+			console.log("Looks like the SDK was already installed: " + tiSDKVersion);
+			selectedSDK = tiSDKVersion;
+		} else {
+			selectedSDK = out['titaniumCLI']['selectedSDK'];
+		}
+		if (!selectedSDK) {
+			console.error("There is no selected SDK for the titanium CLI and we didn't sniff the version on install!");
+		}
+
+		next(null, out['titanium'][selectedSDK]['path']);
+	});
+}
+
+/**
+ * Adds 'windows' into the list of supported platforms for a given SDK we're
+ * hacking.
+ *
+ * @param sdkPath {String} path to the Titanium SDK we'll be hacking to copy our
+ * 													locally built Windows SDK into
+ * @param next {Function} callback function
+ **/
+function copyWindowsIntoSDK(sdkPath, distDir, next) {
+	var dest = path.join(sdkPath, 'windows');
+	if (fs.existsSync(dest)) {
+		hadWindowsSDK = true;
+		wrench.rmdirSyncRecursive(dest);
+	}
+	// TODO Be smarter about copying to speed it up? Only copy diff?
+	wrench.copyDirSyncRecursive(distDir, dest);
+	next();
+}
+
+/**
+ * Adds 'windows' into the list of supported platforms for a given SDK we're
+ * hacking.
+ *
+ * @param sdkPath {String} path to the Titanium SDK we'll be hacking
+ * @param next {Function} callback function
+ **/
+function addWindowsToSDKManifest(sdkPath, next) {
+	var manifest = path.join(sdkPath, 'manifest.json');
+
+	fs.readFile(manifest, function (err, data) {
+		if (err) {
+			next(err);
+		}
+		// append 'windows' to platforms array
+		var json = JSON.parse(data);
+		json['platforms'].push('windows');
+		// Write new JSON back to file
+		fs.writeFile(manifest, JSON.stringify(json), function (err) {
+			if (err) {
+				next(err);
+			}
+			next();
+		});
+	});
+}
+
+
+function setupSDK(branch, location) {
+
+	async.series([
+		function (next) {
+			// If this is already installed we don't re-install, thankfully
+			console.log("Installing SDK from " + branch + " branch");
+			installSDK(branch, function (err, version) {
+				if (err) {
+					return next(err);
+				}
+				tiSDKVersion = version;
+				next();
+			});
+		},
+		function (next) {
+			getSDKInstallDir(tiSDKVersion, function (err, installPath) {
+				if (err) {
+					return next(err);
+				}
+				sdkPath = installPath;
+				next();
+			});
+		},
+		function (next) {
+			console.log("Copying built Windows SDK from " + location + " into master SDK at " + sdkPath);
+			copyWindowsIntoSDK(sdkPath, location, next);
+			fs.readdirSync(path.join(sdkPath, 'windows', 'lib'))
+				.forEach(lib => {
+					const dir = path.join(sdkPath, 'windows', 'lib', lib, 'win10', 'x86');
+					console.log(dir)
+					if (fs.existsSync(dir)) {
+						console.log(fs.readdirSync(dir));
+					} else {
+						console.log('no exist')
+					}
+				});
+		},
+		function (next) {
+			if (hadWindowsSDK) {
+				next();
+			} else {
+				addWindowsToSDKManifest(sdkPath, next);
+			}
+		}
+	]);
+}
+
+// When run as single script.
+if (module.id === ".") {
+	(function () {
+		var program = require('commander');
+
+		// TODO Allow specifying what device id?
+		program
+			.version('0.0.1')
+			.option('-b, --branch [branch]', 'Specify the Titanium SDK build/branch to use for testing', 'master')
+			.option('-l --location [location]', 'Location of the Windows build dist to use', WINDOWS_DIST_DIR)
+			.parse(process.argv);
+
+		setupSDK(program.branch, program.location, function(err, results) {
+			if (err) {
+				console.error(err.toString().red);
+				process.exit(1);
+			} else {
+				process.exit(0);
+			}
+		});
+	})();
+}

--- a/Tools/Scripts/build/setupSDK.js
+++ b/Tools/Scripts/build/setupSDK.js
@@ -165,16 +165,6 @@ function setupSDK(branch, location) {
 		function (next) {
 			console.log("Copying built Windows SDK from " + location + " into master SDK at " + sdkPath);
 			copyWindowsIntoSDK(sdkPath, location, next);
-			fs.readdirSync(path.join(sdkPath, 'windows', 'lib'))
-				.forEach(lib => {
-					const dir = path.join(sdkPath, 'windows', 'lib', lib, 'win10', 'x86');
-					console.log(dir)
-					if (fs.existsSync(dir)) {
-						console.log(fs.readdirSync(dir));
-					} else {
-						console.log('no exist')
-					}
-				});
 		},
 		function (next) {
 			if (hadWindowsSDK) {

--- a/cli/commands/_build/config/deviceID.js
+++ b/cli/commands/_build/config/deviceID.js
@@ -27,8 +27,11 @@ module.exports = function configOptionDeviceID(order) {
 			 (cli.argv.target === 'wp-device' && value === 'de')) && devices[0]) {
 
 			// if win-sdk is not specified, use wpsdk for device
-			if (devices[0].wpsdk && !this.isWindowsSDKTargetSpecified()) {
+			if (devices[0].wpsdk && !this.isWindowsSDKTargetSpecified() && appc.version.satisfies(devices[0].wpsdk, this.packageJson.vendorDependencies['windows phone sdk'], false)) {
 				cli.argv['win-sdk'] = devices[0].wpsdk;
+			} else {
+				this.logger.error(__('The connected device is running %s, which is unsupported by Titanium SDK %s', devices[0].wpsdk, this.cli.sdk.name));
+				process.exit(0)
 			}
 			return callback(null, devices[0].udid);
 		}
@@ -47,8 +50,11 @@ module.exports = function configOptionDeviceID(order) {
 		}
 
 		// if win-sdk is not specified, use wpsdk specified for device
-		if (dev.wpsdk && !this.isWindowsSDKTargetSpecified()) {
+		if (dev.wpsdk && !this.isWindowsSDKTargetSpecified() && appc.version.satisfies(dev.wpsdk, this.packageJson.vendorDependencies['windows phone sdk'], false)) {
 			cli.argv['win-sdk'] = dev.wpsdk;
+		} else {
+			this.logger.error(__('The connected device is running %s, which is unsupported by Titanium SDK %s', dev.wpsdk, this.cli.sdk.name));
+			process.exit(10)
 		}
 
 		// check the device

--- a/cli/commands/_build/config/deviceID.js
+++ b/cli/commands/_build/config/deviceID.js
@@ -27,11 +27,13 @@ module.exports = function configOptionDeviceID(order) {
 			 (cli.argv.target === 'wp-device' && value === 'de')) && devices[0]) {
 
 			// if win-sdk is not specified, use wpsdk for device
-			if (devices[0].wpsdk && !this.isWindowsSDKTargetSpecified() && appc.version.satisfies(devices[0].wpsdk, this.packageJson.vendorDependencies['windows phone sdk'], false)) {
-				cli.argv['win-sdk'] = devices[0].wpsdk;
-			} else {
-				this.logger.error(__('The connected device is running %s, which is unsupported by Titanium SDK %s', devices[0].wpsdk, this.cli.sdk.name));
-				process.exit(0)
+			if (dev.wpsdk && !this.isWindowsSDKTargetSpecified()) {
+				if (appc.version.satisfies(dev.wpsdk, this.packageJson.vendorDependencies['windows phone sdk'], false)) {
+					cli.argv['win-sdk'] = dev.wpsdk;
+				} else {
+					this.logger.error(__('The connected device is running %s, which is unsupported by Titanium SDK %s', dev.wpsdk, this.cli.sdk.name));
+					process.exit(10)
+				}
 			}
 			return callback(null, devices[0].udid);
 		}
@@ -50,11 +52,13 @@ module.exports = function configOptionDeviceID(order) {
 		}
 
 		// if win-sdk is not specified, use wpsdk specified for device
-		if (dev.wpsdk && !this.isWindowsSDKTargetSpecified() && appc.version.satisfies(dev.wpsdk, this.packageJson.vendorDependencies['windows phone sdk'], false)) {
-			cli.argv['win-sdk'] = dev.wpsdk;
-		} else {
-			this.logger.error(__('The connected device is running %s, which is unsupported by Titanium SDK %s', dev.wpsdk, this.cli.sdk.name));
-			process.exit(10)
+		if (dev.wpsdk && !this.isWindowsSDKTargetSpecified()) {
+			if (appc.version.satisfies(dev.wpsdk, this.packageJson.vendorDependencies['windows phone sdk'], false)) {
+				cli.argv['win-sdk'] = dev.wpsdk;
+			} else {
+				this.logger.error(__('The connected device is running %s, which is unsupported by Titanium SDK %s', dev.wpsdk, this.cli.sdk.name));
+				process.exit(10)
+			}
 		}
 
 		// check the device

--- a/cli/commands/_build/config/wpSDK.js
+++ b/cli/commands/_build/config/wpSDK.js
@@ -11,7 +11,7 @@ var appc = require('node-appc'),
  */
 module.exports = function configOptionSDK(order) {
 	var sdkTargets = [],
-		unsupportedTargets = ['8.0'];
+		unsupportedTargets = ['8.0', '8.1'];
 
 	if (this.windowsInfo) {
 		for (var version in this.windowsInfo.windowsphone) {

--- a/cli/commands/_buildModule.js
+++ b/cli/commands/_buildModule.js
@@ -153,7 +153,8 @@ WindowsModuleBuilder.prototype.initialize = function initialize(next) {
 								_t.logger.debug('targetSdkVersion: ' + sdk_version);
 								// Remove Windows10 target only when it targets to 8.1 explicitly
 								if (sdk_version == '8.1') {
-									types = defaultTypes.slice(0, 2);
+									_t.logger.error('The specified version of the Windows and Windows Phone SDK "%s" is no supported by Titanium %s', sdk_version, _t.titaniumSdkName)
+									process.exit(0)
 								}
 							}
 						}
@@ -217,19 +218,6 @@ WindowsModuleBuilder.prototype.generateModuleProject = function generateModulePr
                     runCmake(data, 'WindowsStore', 'ARM', '10.0', done);
                 }
             ];
-
-            // Visual Studio 2017 doesn't support Windows/Phone 8.1 project anymore
-            if (selectVisualStudio(data) != 'Visual Studio 15 2017') {
-                tasks.push(function(done) {
-                    runCmake(data, 'WindowsPhone', 'Win32', '8.1', done);
-                });
-                tasks.push(function(done) {
-                    runCmake(data, 'WindowsPhone', 'ARM', '8.1', done);
-                });
-                tasks.push(function(done) {
-                    runCmake(data, 'WindowsStore', 'Win32', '8.1', done);
-                });
-            }
 
             appc.async.series(this, tasks, function(err) {
                 next(err);
@@ -488,7 +476,7 @@ WindowsModuleBuilder.prototype.packageZip = function packageZip(next) {
 				_t.logger.debug('Packing: '+JSON.stringify(relative_path, null, 2));
 				archive.append(fs.createReadStream(file.path), {name: relative_path });
 			}
-		}	
+		}
 		archive.finalize();
 	});
 

--- a/cli/commands/_buildModule.js
+++ b/cli/commands/_buildModule.js
@@ -153,7 +153,7 @@ WindowsModuleBuilder.prototype.initialize = function initialize(next) {
 								_t.logger.debug('targetSdkVersion: ' + sdk_version);
 								// Remove Windows10 target only when it targets to 8.1 explicitly
 								if (sdk_version == '8.1') {
-									_t.logger.error('The specified version of the Windows and Windows Phone SDK "%s" is no supported by Titanium %s', sdk_version, _t.titaniumSdkName)
+									_t.logger.error('The specified version of the Windows and Windows Phone SDK "%s" is not supported by Titanium %s', sdk_version, _t.titaniumSdkName)
 									process.exit(0)
 								}
 							}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 	],
 	"vendorDependencies": {
 		"visual studio": ">=12.x <=14.x",
-		"windows phone sdk": "8.1 || 10.0",
+		"windows phone sdk": "10.0",
 		"windows 10 sdk": ">=10.0.10240.0 <=10.0.15063.0",
 		"msbuild": ">=4.0",
 		"node": ">=0.10.0 <=0.12.x",

--- a/templates/module/default/hooks/windows-module.js
+++ b/templates/module/default/hooks/windows-module.js
@@ -74,33 +74,6 @@ exports.init = function (logger, config, cli) {
 						next();
 					},
 					function(next) {
-						if (sdks.windowsphone.hasOwnProperty('8.1')) {
-							logger.info('Generating WindowsPhone ARM project');
-							runCMake(logger, cmake, projectDir, 'WindowsPhone', 'ARM', generator, next);
-						} else {
-							logger.info('Skipping WindowsPhone ARM project as Windows 8.1 SDK is not installed');
-							next()
-						}
-					},
-					function(next) {
-						if (sdks.windowsphone.hasOwnProperty('8.1')) {
-							logger.info('Generating WindowsPhone Win32 project');
-							runCMake(logger, cmake, projectDir, 'WindowsPhone', 'Win32', generator, next);
-						} else {
-							logger.info('Skipping WindowsPhone Win32 project as Windows 8.1 SDK is not installed');
-							next()
-						}
-					},
-					function(next) {
-						if (sdks.windowsphone.hasOwnProperty('8.1')) { // still uses windowsphone sdk
-							logger.info('Generating WindowsStore Win32 project');
-							runCMake(logger, cmake, projectDir, 'WindowsStore', 'Win32', generator, next);
-						} else {
-							logger.info('Skipping WindowsStore Win32 project as Windows 8.1 SDK is not installed');
-							next()
-						}
-					},
-					function(next) {
 						if (sdks.windows.hasOwnProperty('10.0')) {
 							logger.info('Generating Windows 10 Win32 project');
 							runCMake(logger, cmake, projectDir, 'Windows10', 'Win32', generator, next);


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-24816

- drops Windows Desktop/Phone 8.1 support
- Uses the common mocha test suite from https://github.com/appcelerator/titanium-mobile-mocha-suite to run tests against builds on Jenkins

What this doesn't do:
- Remove/handle the `NMocha` test app under `Examples`. So we still have 2 separate test suites here in this repo. We should remove `Examples/NMocha` and use some tooling script to generate the app/sln that can be built/debugged under Visual Studio from our common test suite one-demand. It looks like we already have a script to generate the VS project: https://github.com/appcelerator/titanium_mobile_windows/blob/TIMOB-25019/Tools/Scripts/convert_project_to_example.js So I'm not sure if that's up to date or how much that'd involve...