### PR TITLE
[TIMOB-25250] Implement ActivityIndicator.indicatorDiameter

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/ActivityIndicator.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/ActivityIndicator.hpp
@@ -65,6 +65,7 @@ namespace TitaniumWindows
 			virtual void set_font(const Titanium::UI::Font& font) TITANIUM_NOEXCEPT override;
 			virtual void set_message(const std::string& message)  TITANIUM_NOEXCEPT override;
 			virtual void set_indicatorColor(const std::string& color) TITANIUM_NOEXCEPT override;
+			virtual void set_indicatorDiameter(const std::string& diameter) TITANIUM_NOEXCEPT override;
 
 		private:
 			Windows::UI::Xaml::Controls::StackPanel^ panel__;

--- a/Source/UI/src/ActivityIndicator.cpp
+++ b/Source/UI/src/ActivityIndicator.cpp
@@ -61,10 +61,9 @@ namespace TitaniumWindows
 
 			label__->FontSize = TitaniumWindows::UI::Label::DefaultFontSize;
 
-			// relative position from container should start from top & left
-			panel__->VerticalAlignment   = VerticalAlignment::Top;
-			panel__->HorizontalAlignment = HorizontalAlignment::Left;
-			label__->HorizontalAlignment = HorizontalAlignment::Center;
+			// alignment of the components should be centered
+			panel__->VerticalAlignment   = VerticalAlignment::Center;
+			panel__->HorizontalAlignment = HorizontalAlignment::Center;
 
 			panel__->Children->Append(ring__);
 			panel__->Children->Append(label__);
@@ -87,6 +86,14 @@ namespace TitaniumWindows
 			Titanium::UI::ActivityIndicator::set_indicatorColor(colorName);
 			const auto color_obj = WindowsViewLayoutDelegate::ColorForName(colorName);
 			ring__->Foreground = ref new Windows::UI::Xaml::Media::SolidColorBrush(color_obj);
+		}
+
+		void ActivityIndicator::set_indicatorDiameter(const std::string& diameter) TITANIUM_NOEXCEPT
+		{
+			Titanium::UI::ActivityIndicator::set_indicatorDiameter(diameter);
+			const auto value = std::stod(diameter);
+			ring__->Width  = value;
+			ring__->Height = value;
 		}
 
 		void ActivityIndicator::set_font(const Titanium::UI::Font& font) TITANIUM_NOEXCEPT

--- a/Source/UI/src/ActivityIndicator.cpp
+++ b/Source/UI/src/ActivityIndicator.cpp
@@ -91,7 +91,8 @@ namespace TitaniumWindows
 		void ActivityIndicator::set_indicatorDiameter(const std::string& diameter) TITANIUM_NOEXCEPT
 		{
 			Titanium::UI::ActivityIndicator::set_indicatorDiameter(diameter);
-			const auto value = std::stod(diameter);
+			const auto ppi = TitaniumWindows::UI::WindowsViewLayoutDelegate::ComputePPI(Titanium::LayoutEngine::ValueName::Width);
+			const auto value = Titanium::LayoutEngine::parseUnitValue(diameter, Titanium::LayoutEngine::ValueType::Fixed, ppi, "px");
 			ring__->Width  = value;
 			ring__->Height = value;
 		}


### PR DESCRIPTION
[TIMOB-25250](https://jira.appcelerator.org/browse/TIMOB-25250)

Implement `ActivityIndicator.indicatorDiameter` property. Without specifying `indicatorDiameter`, the progress ring goes to have a default size which tends to be small. You can resize size of the ring by changing `indicatorDiameter` property.

```js
﻿﻿var win = Ti.UI.createWindow({
    backgroundColor: 'white',
});

var activityIndicator = Ti.UI.createActivityIndicator({
    message: 'Loading...',
    top: 10,
    left: 10,
    height: 120,
    width: 120,
    indicatorDiameter: 80,
});

win.add(activityIndicator);

win.addEventListener('open', function (e) {
    activityIndicator.show();
});

win.open();
```