### PR TITLE
[TIMOB-25385] TableViewRow with Label breaks layout

### DIFF
--- a/Source/UI/src/Label.cpp
+++ b/Source/UI/src/Label.cpp
@@ -79,7 +79,9 @@ namespace TitaniumWindows
 							const auto width  = panel->ActualWidth;
 							const auto height = panel->ActualHeight;
 							if (width > 0) {
-								if (!skipResizing) label__->MaxWidth = width;
+								if (!skipResizing) {
+									label__->MaxWidth = width;
+								}
 								if (!layout->get_right().empty()) {
 									const auto ppi = WindowsViewLayoutDelegate::ComputePPI(Titanium::LayoutEngine::ValueName::Width);
 									const auto rightPadding = Titanium::LayoutEngine::parseUnitValue(layout->get_right(), Titanium::LayoutEngine::ValueType::Fixed, ppi, "px");
@@ -89,7 +91,9 @@ namespace TitaniumWindows
 								}
 							}
 							if (height > 0) {
-								if (!skipResizing) label__->MaxHeight = height;
+								if (!skipResizing) {
+									label__->MaxHeight = height;
+								}
 								if (!layout->get_bottom().empty()) {
 									const auto ppi = WindowsViewLayoutDelegate::ComputePPI(Titanium::LayoutEngine::ValueName::Height);
 									const auto bottomPadding = Titanium::LayoutEngine::parseUnitValue(layout->get_height(), Titanium::LayoutEngine::ValueType::Fixed, ppi, "px");

--- a/Source/UI/src/Label.cpp
+++ b/Source/UI/src/Label.cpp
@@ -66,11 +66,20 @@ namespace TitaniumWindows
 					if (border__->Parent) {
 						const auto panel = dynamic_cast<FrameworkElement^>(border__->Parent);
 						if (panel) {
+							//
+							// TIMOB-25385: Workaround: Skip limiting Label size when parent view is TableViewRow
+							// because table view row doesn't return property width on the event for some reason.
+							//
+							auto skipResizing = false;
+							const auto parent = get_parent();
+							if (parent && parent->get_apiName() == "Ti.UI.TableViewRow") {
+								skipResizing = true;
+							}
 							const auto layout = getViewLayoutDelegate<WindowsViewLayoutDelegate>();
 							const auto width  = panel->ActualWidth;
 							const auto height = panel->ActualHeight;
 							if (width > 0) {
-								label__->MaxWidth = width;
+								if (!skipResizing) label__->MaxWidth = width;
 								if (!layout->get_right().empty()) {
 									const auto ppi = WindowsViewLayoutDelegate::ComputePPI(Titanium::LayoutEngine::ValueName::Width);
 									const auto rightPadding = Titanium::LayoutEngine::parseUnitValue(layout->get_right(), Titanium::LayoutEngine::ValueType::Fixed, ppi, "px");
@@ -80,7 +89,7 @@ namespace TitaniumWindows
 								}
 							}
 							if (height > 0) {
-								label__->MaxHeight = height;
+								if (!skipResizing) label__->MaxHeight = height;
 								if (!layout->get_bottom().empty()) {
 									const auto ppi = WindowsViewLayoutDelegate::ComputePPI(Titanium::LayoutEngine::ValueName::Height);
 									const auto bottomPadding = Titanium::LayoutEngine::parseUnitValue(layout->get_height(), Titanium::LayoutEngine::ValueType::Fixed, ppi, "px");


### PR DESCRIPTION
[TIMOB-25385](https://jira.appcelerator.org/browse/TIMOB-25385)

The first row in `TableView` is not displayed when using with `Label`. I'm pushing this to `6_3_X` too because it's critical.

```js
var win = Ti.UI.createWindow({
    backgroundColor: 'green',
    layout: "vertical",
});

var row1 = Ti.UI.createTableViewRow();
row1.add(Ti.UI.createLabel({
    text: "THIS IS THE FIRST ROW",
}));

var row2 = Ti.UI.createTableViewRow();
row2.add(Ti.UI.createLabel({
    text: "THIS IS THE SECOND ROW",
}));

var table = Ti.UI.createTableView({
    data: [row1, row2],
});

var label = Ti.UI.createLabel({
    text: "This label breaks first row",
});

win.add(label);
win.add(table);

win.open();
```

Note: This is only a workaround because I'm still not sure why table view row returns incorrect row size only for the first row.
