### PR TITLE
[TIMOB-25275] index property of TableView click event

### DIFF
--- a/Source/TitaniumKit/include/Titanium/UI/ListModel.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/ListModel.hpp
@@ -25,6 +25,7 @@ namespace Titanium
 			bool found { false };
 			std::uint32_t sectionIndex { 0 };
 			std::uint32_t rowIndex { 0 };
+			std::uint32_t fullIndex{ 0 }; // index without header through whole table items
 			bool header { false };
 			bool footer { false };
 		};
@@ -66,6 +67,8 @@ namespace Titanium
 					return result;
 				}
 
+				result.fullIndex = selectedIndex;
+
 				std::uint32_t sectionIndex = 0;
 				std::uint32_t totalItemCount = offset__;
 
@@ -75,6 +78,9 @@ namespace Titanium
 					const auto rowCountIncludingHeader = itemCount + (section->hasHeader() ? 1 : 0) + (section->hasFooter() ? 1 : 0);
 					const int32_t rowIndex = selectedIndex - totalItemCount - (section->hasHeader() ? 1 : 0);
 					totalItemCount += rowCountIncludingHeader;
+
+					result.fullIndex -= (section->hasHeader() ? 1 : 0);
+
 					if (totalItemCount <= selectedIndex) {
 						// we just count the total item
 						continue;

--- a/Source/UI/src/TableView.cpp
+++ b/Source/UI/src/TableView.cpp
@@ -506,7 +506,7 @@ namespace TitaniumWindows
 						if (result.found) {
 							JSObject  eventArgs = ctx.CreateObject();
 							eventArgs.SetProperty("sectionIndex", ctx.CreateNumber(result.sectionIndex));
-							eventArgs.SetProperty("index", ctx.CreateNumber(result.rowIndex));
+							eventArgs.SetProperty("index", ctx.CreateNumber(result.fullIndex));
 
 							const auto section = model__->getFilteredSectionAtIndex(result.sectionIndex);
 							const auto row = section->get_rows().at(result.rowIndex);


### PR DESCRIPTION
[TIMOB-25275](https://jira.appcelerator.org/browse/TIMOB-25275)

The index property of a tableview click event should be in relation to the entirety of the tableview.

```js
var win = Ti.UI.createWindow();

var sectionFruit = Ti.UI.createTableViewSection({ headerTitle: 'Fruit' });
sectionFruit.add(Ti.UI.createTableViewRow({ title: 'Apples' }));
sectionFruit.add(Ti.UI.createTableViewRow({ title: 'Bananas' }));

var sectionVeg = Ti.UI.createTableViewSection({ headerTitle: 'Vegetables' });
sectionVeg.add(Ti.UI.createTableViewRow({ title: 'Carrots' }));
sectionVeg.add(Ti.UI.createTableViewRow({ title: 'Potatoes' }));

var table = Ti.UI.createTableView({
    data: [sectionFruit, sectionVeg]
});

table.addEventListener('click', function (e) {
    alert(e.index);
});

win.add(table);
win.open();
```

Expected: 

- When you click `Apples`, it should show `0`
- When you click `Bananas`, it should show `1`
- When you click `Carrots`, it should show `2`
- When you click `Potatoes`, it should show `3`

