### PR TITLE
[TIMOB-24746] Upgrade JavaScriptCore, use DLL instead of Lib

### DIFF
--- a/Examples/NG/CMakeLists.txt
+++ b/Examples/NG/CMakeLists.txt
@@ -38,6 +38,7 @@ get_filename_component(Utility_SOURCE_DIR       ${PROJECT_SOURCE_DIR}/../../Sour
 get_filename_component(UI_SOURCE_DIR            ${PROJECT_SOURCE_DIR}/../../Source/UI            ABSOLUTE)
 get_filename_component(TitaniumKit_SOURCE_DIR   ${PROJECT_SOURCE_DIR}/../../Source/TitaniumKit   ABSOLUTE)
 get_filename_component(HAL_SOURCE_DIR           ${PROJECT_SOURCE_DIR}/../../Source/HAL           ABSOLUTE)
+get_filename_component(Ti_CMAKE_MODULE_DIR      ${PROJECT_SOURCE_DIR}/../../Source/cmake         ABSOLUTE)
 
 include_external_msproject(
     TitaniumWindows_Hyperloop ${PROJECT_SOURCE_DIR}/TitaniumWindows_Hyperloop/TitaniumWindows_Hyperloop.csproj
@@ -96,6 +97,9 @@ if(NOT TARGET TitaniumWindows_Native)
   add_subdirectory(${Native_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/Native EXCLUDE_FROM_ALL)
 endif()
 
+list(INSERT CMAKE_MODULE_PATH 0 ${Ti_CMAKE_MODULE_DIR})
+find_package(JavaScriptCore REQUIRED)
+
 # No user-servicable parts below this line.
 
 # Variable naming the built executable.
@@ -135,6 +139,8 @@ set(SOURCE_Assets
   src/Assets/sample.jpg
   src/Assets/require_test.js
   src/Assets/Styles.xaml
+  ${JavaScriptCore_LIBRARY_DIR}/Release/JavaScriptCore.dll
+  ${JavaScriptCore_LIBRARY_DIR}/Release/WTF.dll
   )
 
 set_property(SOURCE ${SOURCE_Assets} PROPERTY VS_DEPLOYMENT_CONTENT 1)

--- a/Examples/NMocha/CMakeLists.txt
+++ b/Examples/NMocha/CMakeLists.txt
@@ -36,6 +36,7 @@ get_filename_component(Utility_SOURCE_DIR       ${PROJECT_SOURCE_DIR}/../../Sour
 get_filename_component(UI_SOURCE_DIR            ${PROJECT_SOURCE_DIR}/../../Source/UI            ABSOLUTE)
 get_filename_component(TitaniumKit_SOURCE_DIR   ${PROJECT_SOURCE_DIR}/../../Source/TitaniumKit   ABSOLUTE)
 get_filename_component(HAL_SOURCE_DIR           ${PROJECT_SOURCE_DIR}/../../Source/HAL           ABSOLUTE)
+get_filename_component(Ti_CMAKE_MODULE_DIR      ${PROJECT_SOURCE_DIR}/../../Source/cmake         ABSOLUTE)
 
 if(NOT TARGET TitaniumWindows)
   add_subdirectory(${Titanium_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/Titanium EXCLUDE_FROM_ALL)
@@ -85,6 +86,9 @@ if (NOT TARGET HAL)
   add_subdirectory(${HAL_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/HAL EXCLUDE_FROM_ALL)
 endif()
 
+list(INSERT CMAKE_MODULE_PATH 0 ${Ti_CMAKE_MODULE_DIR})
+find_package(JavaScriptCore REQUIRED)
+
 # No user-servicable parts below this line.
 
 # Variable naming the built executable.
@@ -115,6 +119,8 @@ list(REMOVE_ITEM ASSETS_DIRECTORY ${I18N_FILES})
 set(SOURCE_Assets
   ${CMAKE_CURRENT_BINARY_DIR}/${APP_MANIFEST_NAME}
   ${ASSETS_DIRECTORY}
+  ${JavaScriptCore_LIBRARY_DIR}/Release/JavaScriptCore.dll
+  ${JavaScriptCore_LIBRARY_DIR}/Release/WTF.dll
   )
 
 set_property(SOURCE ${SOURCE_Assets} PROPERTY VS_DEPLOYMENT_CONTENT 1)

--- a/Tools/Scripts/build/build.js
+++ b/Tools/Scripts/build/build.js
@@ -354,6 +354,15 @@ function build(sdkVersion, sha, msBuildVersion, buildType, targets, options, fin
 			timer = process.hrtime();
 			next();
 		},
+		function copyJavaScriptCore(next) {
+			async.eachSeries(targets, function (configuration, next) {
+				var parts = configuration.split('-'); // target platform(WindowsStore|WindowsPhone)-arch(ARM|x86)
+				console.log('Copying JavaScriptCore for ' + parts[1] + '...');
+				var newDir = path.join(distLib, 'JavaScriptCore', 'win10', parts[1]);
+				wrench.mkdirSyncRecursive(newDir);
+				wrench.copyDirRecursive(path.join(process.env.JavaScriptCore_HOME, parts[1], 'Release'), newDir, {forceDelete: true}, next);
+			}, next);
+		},
 		function copyIncludedHeaders(next) {
 			console.log('Copying over include headers...');
 			var newDir = path.join(distLib, 'TitaniumKit', 'include', 'Titanium');

--- a/Tools/Scripts/build/build.js
+++ b/Tools/Scripts/build/build.js
@@ -359,8 +359,10 @@ function build(sdkVersion, sha, msBuildVersion, buildType, targets, options, fin
 				var parts = configuration.split('-'); // target platform(WindowsStore|WindowsPhone)-arch(ARM|x86)
 				console.log('Copying JavaScriptCore for ' + parts[1] + '...');
 				var newDir = path.join(distLib, 'JavaScriptCore', 'win10', parts[1]);
+				var fromDir = path.join(process.env.JavaScriptCore_HOME, parts[1]);
 				wrench.mkdirSyncRecursive(newDir);
-				wrench.copyDirRecursive(path.join(process.env.JavaScriptCore_HOME, parts[1], 'Release'), newDir, {forceDelete: true}, next);
+				wrench.copyDirSyncRecursive(path.join(fromDir, 'Release'), newDir, {forceDelete: true});
+				fs.createReadStream(path.join(fromDir, 'JavaScriptCore-Release.lib')).pipe(fs.createWriteStream(path.join(newDir, 'JavaScriptCore.lib'))).on('finish', next);
 			}, next);
 		},
 		function copyIncludedHeaders(next) {

--- a/Tools/Scripts/setup.js
+++ b/Tools/Scripts/setup.js
@@ -34,7 +34,7 @@ var async = require('async'),
 	// Default JSC URL to build for Win 8.1.
 	JSC_81_URL = 'http://timobile.appcelerator.com.s3.amazonaws.com/jscore/dist/JavaScriptCore-Windows-1472849469.zip',
 	// Default JSC URL for building against Win 10
-	JSC_10_URL = 'http://timobile.appcelerator.com.s3.amazonaws.com/jscore/dist/JavaScriptCore-Windows-1507888382280-win10.zip',
+	JSC_10_URL = 'http://timobile.appcelerator.com.s3.amazonaws.com/jscore/dist/JavaScriptCore-Windows-1508145738839-win10.zip',
 	JSC_DIR = 'JavaScriptCore', // directory inside zipfile
 	GTEST_URL = (os.platform() === 'win32') ? 'http://timobile.appcelerator.com.s3.amazonaws.com/gtest-1.7.0-windows.zip' : 'http://timobile.appcelerator.com.s3.amazonaws.com/gtest-1.7.0-osx.zip',
 	GTEST_DIR = (os.platform() === 'win32') ? 'gtest-1.7.0-windows' : 'gtest-1.7.0-osx', // directory inside zipfile

--- a/Tools/Scripts/setup.js
+++ b/Tools/Scripts/setup.js
@@ -34,7 +34,7 @@ var async = require('async'),
 	// Default JSC URL to build for Win 8.1.
 	JSC_81_URL = 'http://timobile.appcelerator.com.s3.amazonaws.com/jscore/dist/JavaScriptCore-Windows-1472849469.zip',
 	// Default JSC URL for building against Win 10
-	JSC_10_URL = 'http://timobile.appcelerator.com.s3.amazonaws.com/jscore/dist/JavaScriptCore-Windows-1472849469-win10.zip',
+	JSC_10_URL = 'http://timobile.appcelerator.com.s3.amazonaws.com/jscore/dist/JavaScriptCore-Windows-1507888382280-win10.zip',
 	JSC_DIR = 'JavaScriptCore', // directory inside zipfile
 	GTEST_URL = (os.platform() === 'win32') ? 'http://timobile.appcelerator.com.s3.amazonaws.com/gtest-1.7.0-windows.zip' : 'http://timobile.appcelerator.com.s3.amazonaws.com/gtest-1.7.0-osx.zip',
 	GTEST_DIR = (os.platform() === 'win32') ? 'gtest-1.7.0-windows' : 'gtest-1.7.0-osx', // directory inside zipfile

--- a/templates/build/CMakeLists.txt.ejs
+++ b/templates/build/CMakeLists.txt.ejs
@@ -85,6 +85,8 @@ set(SOURCE_Assets
   ${CMAKE_CURRENT_BINARY_DIR}/${APP_MANIFEST_NAME}
   lib/TitaniumKit.dll
   lib/HAL.dll
+  "${WINDOWS_SOURCE_DIR}/lib/JavaScriptCore/${PLATFORM}/${Ti_ARCH}/JavaScriptCore.dll"
+  "${WINDOWS_SOURCE_DIR}/lib/JavaScriptCore/${PLATFORM}/${Ti_ARCH}/WTF.dll"
 <% for(var i = 0; i < thirdPartyReferences.length; i++) { -%>
 <% if (thirdPartyReferences[i].ContentPath) { -%>
   "<%= thirdPartyReferences[i].ContentPath.replace(/\\/g, '/') %>"

--- a/templates/build/cmake/FindJavaScriptCore.cmake
+++ b/templates/build/cmake/FindJavaScriptCore.cmake
@@ -1,61 +1,40 @@
-# HAL
+# FindJavaScriptCore
+# Author: Chris Williams
 #
 # Copyright (c) 2014 by Appcelerator, Inc. All Rights Reserved.
 # Licensed under the terms of the Apache Public License.
 # Please see the LICENSE included with this distribution for details.
 
-# Author: Matt Langston
-# Created: 2014.09.03
-#
-# Try to find JavaScriptCore. Once done this will define:
-#
-#  JavaScriptCore_FOUND       - system has JavaScriptCore
-#  JavaScriptCore_INCLUDE_DIRS - the include directory
-#  JavaScriptCore_LIBRARY_DIR - the directory containing the library
-#  JavaScriptCore_LIBRARIES   - link these to use JavaScriptCore
+# Author: Chris Williams
+# Created: 2014.12.02
 
-find_package(PkgConfig)
-
-pkg_check_modules(PC_JavaScriptCore QUIET JavaScriptCore)
-
-find_path(JavaScriptCore_INCLUDE_DIRS
-  NAMES JavaScriptCore/JavaScript.h
-  HINTS ${PC_JavaScriptCore_INCLUDE_DIRS} ${PC_JavaScriptCore_INCLUDEDIR}
-  PATHS ENV JavaScriptCore_HOME
-  PATH_SUFFIXES includes
-  )
+if (${CMAKE_SYSTEM_VERSION} MATCHES "^10.0")
+  set(PLATFORM win10)
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsPhone")
+  set(PLATFORM phone)
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsStore")
+  set(PLATFORM store)
+else()
+  message(FATAL_ERROR "This app supports Store / Phone only.")
+endif()
 
 set(JavaScriptCore_ARCH "x86")
 if(CMAKE_GENERATOR MATCHES "^Visual Studio .+ ARM$")
   set(JavaScriptCore_ARCH "arm")
 endif()
 
-find_library(JavaScriptCore_LIBRARIES
-  NAMES JavaScriptCore JavaScriptCore-Debug JavaScriptCore-Release
-  HINTS ${PC_JavaScriptCore_LIBRARY_DIRS} ${PC_JavaScriptCore_LIBDIR}
-  PATHS ENV JavaScriptCore_HOME
-  PATH_SUFFIXES ${JavaScriptCore_ARCH}
+# Taken and slightly modified from build's JavaScriptCore_Targets.cmake file
+# INTERFACE_INCLUDE_DIRECTORIES is modified to point to our pre-packaged include dir for module
+
+# Create imported target JavaScriptCore
+add_library(JavaScriptCore SHARED IMPORTED)
+
+set_target_properties(JavaScriptCore PROPERTIES
+  COMPATIBLE_INTERFACE_STRING "JavaScriptCore_MAJOR_VERSION"
+  INTERFACE_JavaScriptCore_MAJOR_VERSION "0"
+)
+
+set_target_properties(JavaScriptCore PROPERTIES
+  IMPORTED_IMPLIB "${WINDOWS_SOURCE_DIR}/lib/JavaScriptCore/${PLATFORM}/${JavaScriptCore_ARCH}/JavaScriptCore.lib"
+  IMPORTED_LOCATION "${WINDOWS_SOURCE_DIR}/lib/JavaScriptCore/${PLATFORM}/${JavaScriptCore_ARCH}/JavaScriptCore.dll"
   )
-
-if(NOT JavaScriptCore_LIBRARIES MATCHES ".+-NOTFOUND")
-  get_filename_component(JavaScriptCore_LIBRARY_DIR ${JavaScriptCore_LIBRARIES} DIRECTORY)
-
-  # If we found the JavaScriptCore library and we're using a Visual
-  # Studio generator and we're targeting either WindowsStore or
-  # WindowsPhone, then allow Visual Studio to use both the
-  # JavaScriptCore-Debug.lib and JavaScriptCore-Release.lib if they
-  # exist.
-  if(CMAKE_GENERATOR MATCHES "^Visual Studio .+" AND CMAKE_SYSTEM_NAME MATCHES "^Windows(Store|Phone)")
-    string(REGEX REPLACE "-(Debug|Release)" "-$(Configuration)" JavaScriptCore_LIBRARIES ${JavaScriptCore_LIBRARIES})
-  endif()
-
-endif()
-
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(JavaScriptCore DEFAULT_MSG JavaScriptCore_INCLUDE_DIRS JavaScriptCore_LIBRARIES)
-
-# message(STATUS "MDL: CMAKE_CONFIGURATION_TYPES   = ${CMAKE_CONFIGURATION_TYPES}")
-# message(STATUS "MDL: JAVASCRIPTCORE_FOUND        = ${JAVASCRIPTCORE_FOUND}")
-# message(STATUS "MDL: JavaScriptCore_INCLUDE_DIRS = ${JavaScriptCore_INCLUDE_DIRS}")
-# message(STATUS "MDL: JavaScriptCore_LIBRARY_DIR  = ${JavaScriptCore_LIBRARY_DIR}")
-# message(STATUS "MDL: JavaScriptCore_LIBRARIES    = ${JavaScriptCore_LIBRARIES}")

--- a/templates/module/default/template/windows/CMakeLists.txt.ejs
+++ b/templates/module/default/template/windows/CMakeLists.txt.ejs
@@ -44,6 +44,7 @@ list(INSERT CMAKE_MODULE_PATH 0 ${APPCELERATOR_CMAKE_MODULE_PATH})
 find_package(HAL REQUIRED)
 find_package(TitaniumKit REQUIRED)
 find_package(TitaniumWindows_Utility REQUIRED)
+find_package(JavaScriptCore REQUIRED)
 
 enable_testing()
 
@@ -75,6 +76,7 @@ target_include_directories(<%- moduleIdAsIdentifier %> PUBLIC
 file(GLOB MODULE_TARGET_LIBS ${PROJECT_SOURCE_DIR}/lib/${PLATFORM}/${<%- moduleIdAsIdentifier %>_ARCH}/*.lib)
 
 target_link_libraries(<%- moduleIdAsIdentifier %>
+  JavaScriptCore
   HAL
   TitaniumKit
   TitaniumWindows_Utility

--- a/templates/module/default/template/windows/manifest.ejs
+++ b/templates/module/default/template/windows/manifest.ejs
@@ -4,7 +4,7 @@
 #
 
 version: 1.0.0
-apiversion: 3
+apiversion: 4
 architectures: ARM x86
 description: <%- moduleName %>
 author: <%- author %>


### PR DESCRIPTION
[TIMOB-24746](https://jira.appcelerator.org/browse/TIMOB-24746)

We need to catch up on the latest JavaScriptCore. We are also going to use **JavaScriptCore.DLL** instead of **JavaScriptCore.LIB**, that is much smaller regarding file size (**2GB -> 100MB**), and thus it should make our build faster. I expect this could make our CI build more stable because this should use less internal network resources.
