### PR TITLE
[TIMOB-24124] TableView.updateSection causes layout issue

### DIFF
--- a/Source/UI/src/TableView.cpp
+++ b/Source/UI/src/TableView.cpp
@@ -390,10 +390,11 @@ namespace TitaniumWindows
 		{
 			Titanium::UI::TableView::updateSection(index, section, animation);
 			unbindCollectionViewSource();
-			collectionViewItems__->SetAt(index, createUIElementsForSection(index));
 
 			// Make sure to unregister rows from LayoutEngine
 			unregisterSectionLayoutNode(section);
+
+			collectionViewItems__->SetAt(index, createUIElementsForSection(index));
 
 			bindCollectionViewSource();
 		}


### PR DESCRIPTION
[TIMOB-24124](https://jira.appcelerator.org/browse/TIMOB-24124)

```js
var win = Ti.UI.createWindow({
    backgroundColor: 'blue'
});

var header1 = Ti.UI.createView({ backgroundColor: 'red ' });
var label = Ti.UI.createLabel({
    text: "That Section"
});
header1.add(label);

var section_0 = Ti.UI.createTableViewSection({ headerView: header1 });
section_0.add(Ti.UI.createTableViewRow({ title: 'Red' }));


var header2 = Ti.UI.createView();
var label2 = Ti.UI.createLabel({
    text: "This Section"
});
header2.add(label2);
var section_2 = Ti.UI.createTableViewSection({ headerView: header2 });
section_2.add(Ti.UI.createTableViewRow({ title: 'Gray' }));;

var tableView = Ti.UI.createTableView({
    data: [section_0]
});

win.addEventListener('open', function () {
    setTimeout(function () {
        tableView.updateSection(0, section_2);
    }, 5000);
});

win.add(tableView);
win.open();
```

Expected: The header "This Section" and row "Gray" should be fully displayed 5 seconds after Window.open event.