### PR TITLE
[TIMOB-25325] Wrong Y-coordinate for click event

### DIFF
--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -1393,7 +1393,7 @@ namespace TitaniumWindows
 						// Set center of the button since Button::Click does not provide position info
 						Windows::Foundation::Point pos;
 						pos.X = static_cast<float>(button->ActualWidth  * 0.5);
-						pos.Y = static_cast<float>(button->ActualWidth * 0.5);
+						pos.Y = static_cast<float>(button->ActualHeight * 0.5);
 						fireSimplePositionEvent("click", pos);
 					});
 				} else {


### PR DESCRIPTION
[TIMOB-25325](https://jira.appcelerator.org/browse/TIMOB-25325)

Reopened ticket, it returned wrong Y-coordinate.

```js
var win = Ti.UI.createWindow({ backgroundColor: 'green' });
var button = Ti.UI.createButton({
    title: 'push',
    width: 100,
    height: 50,
});

button.addEventListener('click', function (e) {
    alert(e.x + ' : ' + e.y);
});

win.add(button);
win.open();
```

Expected: This should return "50 : 25" (center coordinate of the button)
