### PR TITLE
[TIMOB-25255] Fallback to default color on invalid Label.color name

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/Label.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/Label.hpp
@@ -62,6 +62,7 @@ namespace TitaniumWindows
 
 			Windows::UI::Xaml::Controls::Border^ border__;
 			Windows::UI::Xaml::Controls::TextBlock^ label__;
+			Windows::UI::Color defaultForegroundColor__;
 
 			bool need_measure__ { false };
 #pragma warning(push)

--- a/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
@@ -559,7 +559,7 @@ namespace TitaniumWindows
 			// compute its fixed size when either width or height (not both) is Ti.UI.SIZE
 			virtual Titanium::LayoutEngine::Rect computeRelativeSize(const double& x, const double& y,  const double& baseWidth, const double& baseHeight);
 
-			static Windows::UI::Color ColorForName(const std::string& colorName);
+			static Windows::UI::Color ColorForName(const std::string& colorName, const Windows::UI::Color defaultColor = Windows::UI::Colors::Transparent);
 			static Windows::UI::Color ColorForHexCode(const std::string& hexCode);
 
 			virtual void setDefaultBackground();

--- a/Source/UI/src/Label.cpp
+++ b/Source/UI/src/Label.cpp
@@ -47,6 +47,12 @@ namespace TitaniumWindows
 			border__ = ref new Controls::Border();
 			label__ = ref new Windows::UI::Xaml::Controls::TextBlock();
 
+			// default color inspection
+			const auto currentBrush = dynamic_cast<Media::SolidColorBrush^>(label__->Foreground);
+			if (currentBrush) {
+				defaultForegroundColor__ = currentBrush->Color;
+			}
+
 			Titanium::UI::Label::setLayoutDelegate<WindowsViewLayoutDelegate>();
 
 			label__->TextWrapping = Windows::UI::Xaml::TextWrapping::Wrap;
@@ -143,7 +149,7 @@ namespace TitaniumWindows
 		void Label::set_color(const std::string& colorName) TITANIUM_NOEXCEPT
 		{
 			Titanium::UI::Label::set_color(colorName);
-			const auto color_obj = WindowsViewLayoutDelegate::ColorForName(colorName);
+			const auto color_obj = WindowsViewLayoutDelegate::ColorForName(colorName, defaultForegroundColor__);
 			label__->Foreground = ref new Windows::UI::Xaml::Media::SolidColorBrush(color_obj);
 		}
 

--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -1974,12 +1974,11 @@ namespace TitaniumWindows
 #define INSERT_WINDOWS_UI_COLOR(COLOR_NAME) color_name_map.insert(std::make_pair(toLowerCase(#COLOR_NAME), Windows::UI::Colors::##COLOR_NAME));
 
 		// Can this be optimized? MS is giving a lot of choices for colors!
-		Windows::UI::Color WindowsViewLayoutDelegate::ColorForName(const std::string& colorName)
+		Windows::UI::Color WindowsViewLayoutDelegate::ColorForName(const std::string& colorName, const Windows::UI::Color defaultColor)
 		{
 			// pre condition
 			TITANIUM_ASSERT(!colorName.empty());
 
-			static const Windows::UI::Color defaultColor = Windows::UI::Colors::Transparent;
 			using ColorNameMap_t = std::unordered_map<std::string, Windows::UI::Color>;
 			static ColorNameMap_t color_name_map;
 			static std::once_flag of;


### PR DESCRIPTION
[TIMOB-25255](https://jira.appcelerator.org/browse/TIMOB-25255)

```js
var _window = Ti.UI.createWindow({ backgroundColor: 'gray' });
var label = Ti.UI.createLabel({
    text: 'just a test label',
    color: 'pink'
});
label.addEventListener('click', function (e) {
    label.color = null;
});
_window.add(label);
_window.open();
```

Expected: Label color should be black when you click on the Label.
