### PR TITLE
[TIMOB-24858] TableViewRow defaults to horizontal layout

### DIFF
--- a/Source/UI/src/TableViewRow.cpp
+++ b/Source/UI/src/TableViewRow.cpp
@@ -50,7 +50,6 @@ namespace TitaniumWindows
 			layoutDelegate__->set_defaultHeight(Titanium::UI::LAYOUT::SIZE);
 
 			getViewLayoutDelegate<WindowsTableViewRowLayoutDelegate>()->setComponent(content__);
-			getViewLayoutDelegate()->set_layout("horizontal");
 		}
 
 		void TableViewRow::JSExportInitialize() 


### PR DESCRIPTION
[TIMOB-24858](https://jira.appcelerator.org/browse/TIMOB-24858)

```js
var _window = Ti.UI.createWindow();
var row = Ti.UI.createTableViewRow({
    width: 300,
    height: 40
});
var nameLabel = Titanium.UI.createLabel({
    text: 'Title',
    left: 10,
    backgroundColor: 'pink'
});
row.add(nameLabel);
var tableView = Ti.UI.createTableView({
    top: 100,
    width: 300,
    height: '60%',
    data: [row],
    borderWidth: 1,
    borderColor: 'black'
});
var addButton = Ti.UI.createButton({
    title: 'Add Label',
    width: 200,
    height: 100,
    bottom: 0
});

addButton.addEventListener('click', function () {
    var valueLabel1 = Ti.UI.createLabel({
        text: 'New Label'
    });
    row.add(valueLabel1);
});
_window.add(tableView);
_window.add(addButton);
console.log(row.layout);
_window.open();
```

Expected: The label "Title" should be on position of `left:10`, and the "New Label" should be positioned to center of the row.

![row](https://user-images.githubusercontent.com/1661068/32030925-2582cc36-ba39-11e7-8cb2-16b13d2ae41c.png)
