### PR TITLE
Fix potential security vulnerability in dependencies. (CVE-2016-4055)

### DIFF
--- a/Tools/Scripts/package.json
+++ b/Tools/Scripts/package.json
@@ -32,7 +32,7 @@
 		"async": "~0.9.0",
 		"colors": "~0.6.2",
 		"commander": "~2.9.0",
-		"moment": "~2.8.3",
+		"moment": "~2.11.2",
 		"node-appc": "0.2.21",
 		"request": "~2.27.0",
 		"temp": "~0.6.0",


### PR DESCRIPTION
github recently alerted [potential security vulnerability in dependencies](https://help.github.com/articles/about-security-alerts-for-vulnerable-dependencies/) in [moment package before 2.11.2](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4055). I believe this has to be small impact for us because it is only internal tools for development, but I would like to suppress the warning.