### PR TITLE
 [TIMOB-25582] Support for ti.ui.defaultunit 

### DIFF
--- a/Source/TitaniumKit/include/Titanium/App.hpp
+++ b/Source/TitaniumKit/include/Titanium/App.hpp
@@ -56,8 +56,6 @@ namespace Titanium
 		*/
 		virtual std::string copyright() const TITANIUM_NOEXCEPT;
 
-		std::string defaultUnit() TITANIUM_NOEXCEPT;
-
 		/*!
 		  @property
 		  @abstract deployType
@@ -247,7 +245,6 @@ namespace Titanium
 		bool accessibilityEnabled__;
 		bool analytics__;
 		std::string copyright__;
-		std::string defaultUnit__;
 		std::string deployType__;
 		std::string description__;
 		bool disableNetworkActivityIndicator__;

--- a/Source/TitaniumKit/include/Titanium/UI/ViewLayoutDelegate.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/ViewLayoutDelegate.hpp
@@ -619,9 +619,13 @@ namespace Titanium
 			ViewLayoutDelegate() TITANIUM_NOEXCEPT;
 			virtual ~ViewLayoutDelegate();
 
+			static std::string GetDefaultUnit(const std::shared_ptr<ViewLayoutEventDelegate>& event_delegate) TITANIUM_NOEXCEPT;
+
 		protected:
 #pragma warning(push)
 #pragma warning(disable : 4251)
+			static std::string DefaultUnit__;
+
 			std::shared_ptr<View> parent__;
 			std::vector<std::shared_ptr<View>> children__;
 			std::string backgroundImage__;

--- a/Source/TitaniumKit/src/App.cpp
+++ b/Source/TitaniumKit/src/App.cpp
@@ -62,7 +62,6 @@ namespace Titanium
 		accessibilityEnabled__(false),
 		analytics__(false),
 		copyright__("__COPYRIGHT__"),
-		defaultUnit__(""),
 		deployType__("__DEPLOY_TYPE__"),
 		description__("__DESCRIPTION__"),
 		disableNetworkActivityIndicator__(false),
@@ -130,36 +129,6 @@ namespace Titanium
 	std::string AppModule::copyright() const TITANIUM_NOEXCEPT
 	{
 		return copyright__;
-	}
-
-	std::string AppModule::defaultUnit() TITANIUM_NOEXCEPT
-	{
-		if (defaultUnit__.empty()) {
-			JSObject App = GetStaticObject(get_context());
-
-			JSValue Properties_property = App.GetProperty("Properties");
-			TITANIUM_ASSERT(Properties_property.IsObject());  // precondition
-			JSObject Properties = static_cast<JSObject>(Properties_property);
-
-			auto props = Properties.GetPrivate<::Titanium::App::Properties>();
-			auto defaultUnit = props->getString("ti.ui.defaultunit", boost::optional<std::string>("px"));
-
-			if (!defaultUnit || *defaultUnit == "system")
-			{
-				defaultUnit__ = "px";
-			}
-			// Validate that unit is one of our set of known units!
-			// FIXME Some platforms allow other units. See "sp" and "sip" for Android
-			if (defaultUnit__ != "mm" && defaultUnit__ != "cm" &&
-				defaultUnit__ != "em" && defaultUnit__ != "pt" &&
-				defaultUnit__ != "pc" && defaultUnit__ != "in" &&
-				defaultUnit__ != "px" && defaultUnit__ != "dp" &&
-				defaultUnit__ != "dip")
-			{
-				defaultUnit__ = "px";
-			}
-		}
-		return defaultUnit__;
 	}
 
 	std::string AppModule::deployType() const TITANIUM_NOEXCEPT

--- a/Source/TitaniumKit/src/UI/ViewLayoutDelegate.cpp
+++ b/Source/TitaniumKit/src/UI/ViewLayoutDelegate.cpp
@@ -509,6 +509,8 @@ namespace Titanium
 				if (!defaultUnit || *defaultUnit == "system")
 				{
 					DefaultUnit__ = "px";
+				} else {
+					DefaultUnit__ = *defaultUnit;
 				}
 				// Validate that unit is one of our set of known units!
 				// FIXME Some platforms allow other units. See "sp" and "sip" for Android

--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -1057,20 +1057,24 @@ namespace TitaniumWindows
 
 			const auto ppi = ComputePPI(Titanium::LayoutEngine::ValueName::Width);
 
+			auto event_delegate = event_delegate__.lock();
+			TITANIUM_ASSERT(event_delegate != nullptr);
+			std::string defaultUnits = ViewLayoutDelegate::GetDefaultUnit(event_delegate);
+
 			if ((is_control__ || underlying_control__) && !is_border__) {
 				// Xaml::Control descendant has its own border property.
 				// Use it then, it usually works better than Xaml::Border. Note that it doesn't support border radius though...
 				const auto control = underlying_control__ ? underlying_control__ : dynamic_cast<Control^>(component__);
 				control->BorderBrush = borderColorBrush__;
-				control->BorderThickness = Titanium::LayoutEngine::parseUnitValue(borderWidth, Titanium::LayoutEngine::ValueType::Fixed, ppi, "px");
+				control->BorderThickness = Titanium::LayoutEngine::parseUnitValue(borderWidth, Titanium::LayoutEngine::ValueType::Fixed, ppi, defaultUnits);
 			} else if (border__) {
 				border__->BorderBrush = borderColorBrush__;
-				border__->BorderThickness = Titanium::LayoutEngine::parseUnitValue(borderWidth, Titanium::LayoutEngine::ValueType::Fixed, ppi, "px");
-				border__->CornerRadius = CornerRadiusHelper::FromUniformRadius(Titanium::LayoutEngine::parseUnitValue(get_borderRadius(), Titanium::LayoutEngine::ValueType::Fixed, ppi, "px"));
+				border__->BorderThickness = Titanium::LayoutEngine::parseUnitValue(borderWidth, Titanium::LayoutEngine::ValueType::Fixed, ppi, defaultUnits);
+				border__->CornerRadius = CornerRadiusHelper::FromUniformRadius(Titanium::LayoutEngine::parseUnitValue(get_borderRadius(), Titanium::LayoutEngine::ValueType::Fixed, ppi, defaultUnits));
 			} else if (is_grid__) {
 				const auto control = dynamic_cast<Controls::Grid^>(component__);
 				control->BorderBrush = borderColorBrush__;
-				control->BorderThickness = Titanium::LayoutEngine::parseUnitValue(borderWidth, Titanium::LayoutEngine::ValueType::Fixed, ppi, "px");
+				control->BorderThickness = Titanium::LayoutEngine::parseUnitValue(borderWidth, Titanium::LayoutEngine::ValueType::Fixed, ppi, defaultUnits);
 			}
 		}
 
@@ -1666,8 +1670,13 @@ namespace TitaniumWindows
 			if (parent__) {
 				const auto p_border = parent__->getViewLayoutDelegate()->get_borderWidth();
 				const auto ppi = ComputePPI(Titanium::LayoutEngine::ValueName::Width);
-				rect.x -= Titanium::LayoutEngine::parseUnitValue(p_border, Titanium::LayoutEngine::ValueType::Fixed, ppi, "px");
-				rect.y -= Titanium::LayoutEngine::parseUnitValue(p_border, Titanium::LayoutEngine::ValueType::Fixed, ppi, "px");
+
+				auto event_delegate = event_delegate__.lock();
+				TITANIUM_ASSERT(event_delegate != nullptr);
+				std::string defaultUnits = ViewLayoutDelegate::GetDefaultUnit(event_delegate);
+
+				rect.x -= Titanium::LayoutEngine::parseUnitValue(p_border, Titanium::LayoutEngine::ValueType::Fixed, ppi, defaultUnits);
+				rect.y -= Titanium::LayoutEngine::parseUnitValue(p_border, Titanium::LayoutEngine::ValueType::Fixed, ppi, defaultUnits);
 			}
 
 			auto skipHeight = shouldUseOwnHeight() || (is_default_height_size__ && rect.height == 0);
@@ -1902,22 +1911,9 @@ namespace TitaniumWindows
 			double ppi = ComputePPI(name);
 
 			// Get the defaultUnits from ti.ui.defaultUnit!
-			std::string defaultUnits = "px";
 			auto event_delegate = event_delegate__.lock();
-		 	if (event_delegate != nullptr) {
-			 	JSContext js_context = event_delegate->get_context();
-
-			 	JSValue Titanium_property = js_context.get_global_object().GetProperty("Titanium");
-				TITANIUM_ASSERT(Titanium_property.IsObject());  // precondition
-				JSObject Titanium = static_cast<JSObject>(Titanium_property);
-
-				JSValue App_property = Titanium.GetProperty("App");
-				TITANIUM_ASSERT(App_property.IsObject());  // precondition
-				JSObject App = static_cast<JSObject>(App_property);
-
-				const auto object_ptr = App.GetPrivate<Titanium::AppModule>();
-				defaultUnits = object_ptr->defaultUnit();
-		 	}
+			TITANIUM_ASSERT(event_delegate != nullptr);
+			std::string defaultUnits = ViewLayoutDelegate::GetDefaultUnit(event_delegate);
 			Titanium::LayoutEngine::populateLayoutProperties(prop, properties ? properties.get() : &layout_node__->properties, ppi, defaultUnits);
 
 			if (isLoaded()) {


### PR DESCRIPTION
**DO NOT MERGE**: This should introduce breaking change on view size for most apps:

[TIMOB-25582](https://jira.appcelerator.org/browse/TIMOB-25582)

```js
var win = Ti.UI.createWindow();

var view1 = Ti.UI.createView({
    width: "100px", height: "100px",
    top: 100, left: 100,
    backgroundColor: 'blue',
});

var view2 = Ti.UI.createView({
    width: "100dp", height: "100dp",
    top: 200, left: 100,
    backgroundColor: 'red',
});

var view3 = Ti.UI.createView({
    width: "100", height: "100",
    top: 300, left: 100,
    backgroundColor: 'yellow',
});

var view4 = Ti.UI.createView({
    width: 100, height: 100,
    top: 400, left: 100,
    backgroundColor: 'pink',
});

win.add(view1);
win.add(view2);
win.add(view3);
win.add(view4);
win.open();
```

Add ability to set default units in `tiapp.xml`.

It turns out [TIMOB-19350](https://jira.appcelerator.org/browse/TIMOB-19350) should have taken care of this but it was not actually working. I also noticed that the default `tiapp.xml` template that CLI produces with `appc new` sets **dp** for default `ti.ui.defaultunit`, which will cause problem because we have been using **px** for default unit for Windows.

```xml
  <property name="ti.ui.defaultunit" type="string">dp</property>
```

So if you implement this feature, you should see breaking changes regarding view size (`px` to `dp`) for most of apps. For instance when you have a view with `width: 100`, we have treated it as `100px`, but because you have `ti.ui.defaultunit=dp` in default template, it will be treated it as `100dp`. I'm not sure how we should treat this without causing breaking change.
