### PR TITLE
[TIMOB-25587] Stop deleting build directory on rebuild

### DIFF
--- a/cli/commands/_build/checks.js
+++ b/cli/commands/_build/checks.js
@@ -207,10 +207,6 @@ function checkIfNeedToRecompile(next) {
 		wrench.rmdirSyncRecursive(this.buildDir);
 	}
 
-	// now that we've read the build manifest, delete it so if this build
-	// becomes incomplete, the next build will be a full rebuild
-	fs.existsSync(this.buildManifestFile) && fs.unlinkSync(this.buildManifestFile);
-
 	next();
 };
 

--- a/cli/commands/_build/copy.js
+++ b/cli/commands/_build/copy.js
@@ -21,29 +21,7 @@ exports.mixin = mixin;
  Implementation.
  */
 function mixin(WindowsBuilder) {
-	WindowsBuilder.prototype.copyResultsToProject = copyResultsToProject;
 	WindowsBuilder.prototype.copyResources = copyResources;
-}
-
-// Copy to original location!
-/**
- * Copies the build directory back to the project's build directory if we compiled in temp.
- *
- * @param {Function} next - A function to call after the build manifest has been written.
- */
-function copyResultsToProject(next) {
-	if (this.originalBuildDir) {
-		this.logger.info(__('Copying results back to project build directory'));
-		// if already exists, wipe it
-		fs.existsSync(this.originalBuildDir) && wrench.rmdirSyncRecursive(this.originalBuildDir);
-		// make sure destination exists
-		fs.existsSync(this.originalBuildDir) || wrench.mkdirSyncRecursive(this.originalBuildDir);
-		// Now copy this.buildDir into this.originalBuildDir
-		wrench.copyDirSyncRecursive(this.buildDir, this.originalBuildDir, {
-			forceDelete: true
-		});
-	}
-	next();
 }
 
 /**

--- a/cli/commands/_build/run.js
+++ b/cli/commands/_build/run.js
@@ -68,7 +68,6 @@ function run(logger, config, cli, finished) {
 		},
 
 		'writeBuildManifest',
-		'copyResultsToProject',
 
 		function (next) {
 			// now that the app is built, if we're going to do some logging, then we print how long the app took so far


### PR DESCRIPTION
[TIMOB-25587](https://jira.appcelerator.org/browse/TIMOB-25587)

Windows build wipes out the directory and rebuilds each time. We should be able to re-use existing project directory and stop wiping it out on each build, which should improve build time.

I observed that this improves build time, for me it was `48 sec` to `35 sec`.

**Expected**: `C:\Users\USER_NAME\.titanium\vsbuild\PROJECT_NAME` should not be erased on each re-build.