### PR TITLE
[TIMOB-25274] TableView.setData does not render UI elements

### DIFF
--- a/Source/TitaniumKit/src/UI/TableView.cpp
+++ b/Source/TitaniumKit/src/UI/TableView.cpp
@@ -60,6 +60,12 @@ namespace Titanium
 
 		void TableView::set_data(const std::vector<JSObject>& data) TITANIUM_NOEXCEPT
 		{
+			// Clear exsting sections in model
+			for (const auto section : model__->get_sections()) {
+				for (const auto row : section->get_rows()) {
+					section->remove(row);
+				}
+			}
 			model__->clear();
 			for (std::uint32_t i = 0; i < data.size(); i++) {
 				const auto datum    = data.at(i);

--- a/Source/UI/src/TableView.cpp
+++ b/Source/UI/src/TableView.cpp
@@ -237,7 +237,6 @@ namespace TitaniumWindows
 		void TableView::set_data(const std::vector<JSObject>& data) TITANIUM_NOEXCEPT
 		{
 			if (propertiesSet__) {
-				unregisterSections();
 				Titanium::UI::TableView::set_data(data);
 				createTableSectionUIElements();
 			} else {


### PR DESCRIPTION
[TIMOB-25274](https://jira.appcelerator.org/browse/TIMOB-25274)

```js
var _window = Ti.UI.createWindow({ backgroundColor: 'green' });
var data = [];
var row = Ti.UI.createTableViewRow();
var lbl = Ti.UI.createLabel({
    text: 'LABEL'
})
row.add(lbl)
data.push(row);
var table = Titanium.UI.createTableView({
    top: 100,
    data: data
});
var btn = Ti.UI.createButton({
    title: 'Add new data',
    top: 5
});
btn.addEventListener('click', function () {
    var newData = [];
    var newRow = Ti.UI.createTableViewRow();
    var newLbl = Ti.UI.createLabel({
        text: 'NEW LABEL'
    })
    newRow.add(newLbl)
    newData.push(newRow);
    table.setData(newData);
});

var oldbtn = Ti.UI.createButton({
    title: 'Add old data',
    top: 50
});
oldbtn.addEventListener('click', function () {
    table.setData(data)
})
_window.add(btn);
_window.add(oldbtn)
_window.add(table);
_window.open();
```

Expected:
- Clicking "Add new data" button should set "NEW LABEL" row
- Clicking "Add old data" button should set "LABEL" row
