### PR TITLE
[TIMOB-25616] Don't uninstall exisitng app unless user explicitly specifies it

### DIFF
--- a/Tools/Scripts/build/test.js
+++ b/Tools/Scripts/build/test.js
@@ -307,7 +307,7 @@ function runBuild(target, deviceId, sdkVersion, count, next) {
 			'--target', target,
 			'--wp-sdk', sdkVersion,
 			'--win-publisher-id', '13AFB724-65F2-4F30-8994-C79399EDBD80',
-			'--no-prompt', '--no-colors'
+			'--no-prompt', '--no-colors', '--forceUnInstall'
 		];
 	if (deviceId) {
 		args = args.concat('--device-id', deviceId);

--- a/cli/hooks/wp-run.js
+++ b/cli/hooks/wp-run.js
@@ -201,6 +201,7 @@ exports.init = function (logger, config, cli) {
 					dependenciesDir = path.resolve(appxDir, 'Dependencies', (builder.cmakeArch == 'Win32') ? 'x86' : builder.cmakeArch),
 					// Options for installing app
 					opts = appc.util.mix({
+						forceUnInstall: cli.argv['forceUnInstall'],
 						killIfRunning: false,
 						timeout: config.get('windows.log.timeout', 60000),
 						wpsdk: builder.wpsdk

--- a/cli/hooks/wp-run.js
+++ b/cli/hooks/wp-run.js
@@ -201,7 +201,7 @@ exports.init = function (logger, config, cli) {
 					dependenciesDir = path.resolve(appxDir, 'Dependencies', (builder.cmakeArch == 'Win32') ? 'x86' : builder.cmakeArch),
 					// Options for installing app
 					opts = appc.util.mix({
-						forceUnInstall: cli.argv['forceUnInstall'],
+						forceUnInstall: cli.argv.hasOwnProperty('forceUnInstall'),
 						killIfRunning: false,
 						timeout: config.get('windows.log.timeout', 60000),
 						wpsdk: builder.wpsdk

--- a/cli/hooks/ws-run.js
+++ b/cli/hooks/ws-run.js
@@ -164,8 +164,12 @@ exports.init = function (logger, config, cli) {
 					}, builder.windowslibOptions);
 
 				async.series([function(next) {
-					logger.info(__('Uninstalling old versions of the application'));
-					windowslib.winstore.uninstall(appId, opts, next);
+					if (cli.argv.hasOwnProperty('forceUnInstall')) {
+						logger.info(__('Uninstalling old versions of the application'));
+						windowslib.winstore.uninstall(appId, opts, next);
+					} else {
+						next();
+					}
 				}, function(next) {
 					logger.info(__('Installing the application'));
 					windowslib.winstore.install(projectDir, opts, next);


### PR DESCRIPTION
This requires https://github.com/appcelerator/windowslib/pull/83 to be merged.

[TIMOB-25616](https://jira.appcelerator.org/browse/TIMOB-25616)

Titanium have been uninstalling existing app in order to complete the installation when same version of the app is already installed, but we should not uninstall existing app unless user explicitly specifies `--forceUnInstall`option. It should ends up showing error message when there's same version of the app installed, which should be the default behavior.

Expected:

1. Installation should succeed when there's no same app installed.
2. Installation should fail when there's same app installed. 
3. Installation should succeed with `--forceUnInstall` option when there's same app installed. 

```
appc ti build -p windows --wp-sdk 10.0 --target wp-device --skipInstallDependencies -l trace --forceUnInstall
```