### PR TITLE
[TIMOB-25641] View.add should be ignored when it's ready added

### DIFF
--- a/Source/LayoutEngine/src/Element.cpp
+++ b/Source/LayoutEngine/src/Element.cpp
@@ -53,20 +53,26 @@ namespace Titanium
 
 		void addChildElement(Element* parent, Element* child)
 		{
-			(*parent).children.push_back(child);
+			const auto it = std::find(parent->children.begin(), parent->children.end(), child);
+			if (it == parent->children.end()) {
+				parent->children.push_back(child);
+			}
 		}
 
 		void removeChildElement(struct Element* parent, struct Element* child)
 		{
-			auto i = std::find(parent->children.begin(), parent->children.end(), child);
-			if (i != parent->children.end()) {
-				parent->children.erase(i);
+			const auto it = std::find(parent->children.begin(), parent->children.end(), child);
+			if (it != parent->children.end()) {
+				parent->children.erase(it);
 			}
 		}
 
 		void insertChildElementAt(Element* parent, Element* child, unsigned int index) 
 		{
-			parent->children.insert(parent->children.begin() + index, child);
+			const auto it = std::find(parent->children.begin(), parent->children.end(), child);
+			if (it == parent->children.end()) {
+				parent->children.insert(parent->children.begin() + index, child);
+			}
 		}
 	} // namespace LayoutEngine
 } // namespace Titanium

--- a/Source/LayoutEngine/src/Node.cpp
+++ b/Source/LayoutEngine/src/Node.cpp
@@ -31,7 +31,7 @@ namespace Titanium
 
 		void nodeRemoveChild(struct Node* parent, struct Node* child)
 		{
-			child->parent = 0;
+			child->parent = nullptr;
 			if (child->prev) {
 				child->prev->next = child->next;
 			} else {

--- a/Source/TitaniumKit/src/UI/View.cpp
+++ b/Source/TitaniumKit/src/UI/View.cpp
@@ -113,13 +113,20 @@ namespace Titanium
 				return;
 			}
 			auto view_ptr = view.GetPrivate<View>();
+			const auto parent_view_ptr = this->get_object().GetPrivate<View>();
+
+			// Compare parent, this indicates you're trying to add it before it's removed
+			if (view_ptr->get_parent() == parent_view_ptr) {
+				get_context().JSEvaluateScript("Ti.API.warn('View.add: This indicates this component is already added');");
+				return;
+			}
 
 			// For mixing Ti.Ui.View and native view.
 			if (view_ptr == nullptr) {
 				view_ptr = layoutDelegate__->rescueGetView(view);
 			}
 
-			view_ptr->set_parent(this->get_object().GetPrivate<View>());
+			view_ptr->set_parent(parent_view_ptr);
 
 			layoutDelegate__->add(view_ptr);
 		}
@@ -663,7 +670,9 @@ namespace Titanium
 		{
 			CHECK_UI_DELEGATE_GETTER
 			ENSURE_OBJECT_AT_INDEX(view, 0);
-			layoutDelegate__->remove(view.GetPrivate<View>());
+			const auto view_ptr = view.GetPrivate<View>();
+			view_ptr->set_parent(nullptr);
+			layoutDelegate__->remove(view_ptr);
 			return get_context().CreateUndefined();
 		}
 
@@ -680,7 +689,20 @@ namespace Titanium
 			CHECK_UI_DELEGATE_GETTER
 			ENSURE_OBJECT_AT_INDEX(params, 0);
 
-			layoutDelegate__->insertAt(js_to_ViewInsertOrReplaceParams(params));
+			const auto viewInsertParams = js_to_ViewInsertOrReplaceParams(params);
+			const auto view_ptr = viewInsertParams.view;
+
+			const auto parent_view_ptr = this->get_object().GetPrivate<View>();
+
+			// Compare parent, this indicates you're trying to add it before it's removed
+			if (view_ptr->get_parent() == parent_view_ptr) {
+				get_context().JSEvaluateScript("Ti.API.warn('View.add: This indicates this component is already added');");
+				return get_context().CreateUndefined();
+			}
+
+			view_ptr->set_parent(this->get_object().GetPrivate<View>());
+
+			layoutDelegate__->insertAt(viewInsertParams);
 			return get_context().CreateUndefined();
 		}
 
@@ -689,7 +711,11 @@ namespace Titanium
 			CHECK_UI_DELEGATE_GETTER
 			ENSURE_OBJECT_AT_INDEX(params, 0);
 
-			layoutDelegate__->replaceAt(js_to_ViewInsertOrReplaceParams(params));
+			const auto viewInsertParams = js_to_ViewInsertOrReplaceParams(params);
+			const auto view_ptr = viewInsertParams.view;
+			view_ptr->set_parent(this->get_object().GetPrivate<View>());
+
+			layoutDelegate__->replaceAt(viewInsertParams);
 			return get_context().CreateUndefined();
 		}
 

--- a/Source/TitaniumKit/src/UI/View.cpp
+++ b/Source/TitaniumKit/src/UI/View.cpp
@@ -117,7 +117,7 @@ namespace Titanium
 
 			// Compare parent, this indicates you're trying to add it before it's removed
 			if (view_ptr->get_parent() == parent_view_ptr) {
-				get_context().JSEvaluateScript("Ti.API.warn('View.add: This indicates this component is already added');");
+				TITANIUM_LOG_WARN("Ti.API.warn('View.add: This indicates this component is already added');");
 				return;
 			}
 
@@ -696,7 +696,7 @@ namespace Titanium
 
 			// Compare parent, this indicates you're trying to add it before it's removed
 			if (view_ptr->get_parent() == parent_view_ptr) {
-				get_context().JSEvaluateScript("Ti.API.warn('View.add: This indicates this component is already added');");
+				TITANIUM_LOG_WARN("Ti.API.warn('View.add: This indicates this component is already added');");
 				return get_context().CreateUndefined();
 			}
 

--- a/Source/TitaniumKit/src/UI/View.cpp
+++ b/Source/TitaniumKit/src/UI/View.cpp
@@ -117,7 +117,7 @@ namespace Titanium
 
 			// Compare parent, this indicates you're trying to add it before it's removed
 			if (view_ptr->get_parent() == parent_view_ptr) {
-				TITANIUM_LOG_WARN("Ti.API.warn('View.add: This indicates this component is already added');");
+				TITANIUM_LOG_WARN("View.add: This indicates this component is already added");
 				return;
 			}
 
@@ -696,7 +696,7 @@ namespace Titanium
 
 			// Compare parent, this indicates you're trying to add it before it's removed
 			if (view_ptr->get_parent() == parent_view_ptr) {
-				TITANIUM_LOG_WARN("Ti.API.warn('View.add: This indicates this component is already added');");
+				TITANIUM_LOG_WARN("View.add: This indicates this component is already added");
 				return get_context().CreateUndefined();
 			}
 

--- a/Source/TitaniumKit/src/UI/ViewLayoutDelegate.cpp
+++ b/Source/TitaniumKit/src/UI/ViewLayoutDelegate.cpp
@@ -35,7 +35,7 @@ namespace Titanium
 
 		void ViewLayoutDelegate::add(const std::shared_ptr<Titanium::UI::View>& view) TITANIUM_NOEXCEPT
 		{
-			auto it = std::find(children__.begin(), children__.end(), view);
+			const auto it = std::find(children__.begin(), children__.end(), view);
 			if (it == children__.end()) {
 				children__.push_back(view);
 			}
@@ -43,7 +43,7 @@ namespace Titanium
 
 		void ViewLayoutDelegate::remove(const std::shared_ptr<Titanium::UI::View>& view) TITANIUM_NOEXCEPT
 		{
-			auto it = std::find(children__.begin(), children__.end(), view);
+			const auto it = std::find(children__.begin(), children__.end(), view);
 			if (it != children__.end()) {
 				children__.erase(it);
 			}
@@ -56,13 +56,19 @@ namespace Titanium
 
 		void ViewLayoutDelegate::insertAt(const ViewInsertOrReplaceParams& params) TITANIUM_NOEXCEPT
 		{
-			children__.insert(children__.begin() + params.position, params.view);
+			const auto it = std::find(children__.begin(), children__.end(), params.view);
+			if (it == children__.end()) {
+				children__.insert(children__.begin() + params.position, params.view);
+			}
 		}
 
 		void ViewLayoutDelegate::replaceAt(const ViewInsertOrReplaceParams& params) TITANIUM_NOEXCEPT
 		{
-			children__.erase(children__.begin() + params.position);
-			children__.insert(children__.begin() + params.position, params.view);
+			const auto it = std::find(children__.begin(), children__.end(), params.view);
+			if (it != children__.end()) {
+				children__.erase(children__.begin() + params.position);
+				children__.insert(children__.begin() + params.position, params.view);
+			}
 		}
 
 		void ViewLayoutDelegate::animate(const std::shared_ptr<Titanium::UI::Animation>& animation, JSObject& callback, const JSObject& this_object) TITANIUM_NOEXCEPT

--- a/Source/UI/src/ListView.cpp
+++ b/Source/UI/src/ListView.cpp
@@ -625,6 +625,7 @@ namespace TitaniumWindows
 			}
 			auto layoutDelegate = getViewLayoutDelegate<WindowsViewLayoutDelegate>();
 			Titanium::LayoutEngine::nodeAddChild(layoutDelegate->getLayoutNode(), view->getViewLayoutDelegate<WindowsViewLayoutDelegate>()->getLayoutNode());
+			Titanium::LayoutEngine::nodeLayout(layoutDelegate->getLayoutNode());
 		}
 
 		void ListView::unregisterListViewItemAsLayoutNode(const std::shared_ptr<Titanium::UI::View>& view) 

--- a/Source/UI/src/TableView.cpp
+++ b/Source/UI/src/TableView.cpp
@@ -483,6 +483,7 @@ namespace TitaniumWindows
 		{
 			auto layoutDelegate = getViewLayoutDelegate<WindowsViewLayoutDelegate>();
 			Titanium::LayoutEngine::nodeAddChild(layoutDelegate->getLayoutNode(), view->getViewLayoutDelegate<WindowsViewLayoutDelegate>()->getLayoutNode());
+			Titanium::LayoutEngine::nodeLayout(layoutDelegate->getLayoutNode());
 		}
 
 		// Remove child view 

--- a/Source/UI/src/Window.cpp
+++ b/Source/UI/src/Window.cpp
@@ -450,7 +450,15 @@ namespace TitaniumWindows
 					ui_view = layoutDelegate__->rescueGetView(viewObj);
 				}
 				if (ui_view) {
-					ui_view->set_parent(this->get_object().GetPrivate<View>());
+					const auto parent_view_ptr = this->get_object().GetPrivate<View>();
+
+					// Compare parent, this indicates you're trying to add it before it's removed
+					if (ui_view->get_parent() == parent_view_ptr) {
+						TITANIUM_LOG_WARN("Window.add: This indicates this component is already added");
+						return get_context().CreateUndefined();
+					}
+
+					ui_view->set_parent(parent_view_ptr);
 					layoutDelegate__->add(ui_view);
 				} else {
 					HAL::detail::ThrowRuntimeError("Window::add", "Window.add: Unable to get native view from View");

--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -135,8 +135,6 @@ namespace TitaniumWindows
 
 		void WindowsViewLayoutDelegate::removeView(const std::shared_ptr<Titanium::UI::View>& view) TITANIUM_NOEXCEPT
 		{
-			TITANIUM_LOG_DEBUG("WindowsViewLayoutDelegate::remove ", view.get(), " for ", this);
-
 			if (!is_panel__) {
 				TITANIUM_LOG_WARN("WindowsViewLayoutDelegate::remove: Unknown component");
 				return;
@@ -171,8 +169,6 @@ namespace TitaniumWindows
 		{
 			Titanium::UI::ViewLayoutDelegate::add(view);
 
-			TITANIUM_LOG_WARN("WindowsViewLayoutDelegate::add ", view.get(), " for ", this);
-
 			if (!is_panel__) {
 				TITANIUM_LOG_WARN("WindowsViewLayoutDelegate::add: Unknown component");
 				return;
@@ -186,10 +182,11 @@ namespace TitaniumWindows
 					auto nativeView = dynamic_cast<Controls::Panel^>(component__);
 					uint32_t index = 0;
 					if (nativeView->Children->IndexOf(nativeChildView, &index)) {
-						TITANIUM_LOG_DEBUG("This UI element is already added");
+						TITANIUM_LOG_WARN("This UI element is already added");
 						return;
 					}
 					nativeView->Children->Append(nativeChildView);
+					TITANIUM_LOG_DEBUG("Titanium::LayoutEngine::nodeAddChild ", newView->getLayoutNode(), " for ", layout_node__ );
 					Titanium::LayoutEngine::nodeAddChild(layout_node__, newView->getLayoutNode());
 					if (isLoaded()) {
 						requestLayout();
@@ -1543,6 +1540,7 @@ namespace TitaniumWindows
 					component->ActualWidth,
 					component->ActualHeight
 				);
+
 				onComponentLoaded(rect);
 			});
 
@@ -1758,6 +1756,8 @@ namespace TitaniumWindows
 
 		void WindowsViewLayoutDelegate::requestLayout(const bool& fire_event)
 		{
+			Titanium::LayoutEngine::nodeLayout(layout_node__);
+
 			const auto root = Titanium::LayoutEngine::nodeRequestLayout(layout_node__);
 			if (root) {
 				Titanium::LayoutEngine::nodeLayout(root);


### PR DESCRIPTION
[TIMOB-25641](https://jira.appcelerator.org/browse/TIMOB-25641)

TIMOB-25465 and TIMOB-25639 show that rendering issue happens when you try to add a view that is already added. According to the current code, we are not actually checking if the View is already added but just leaves the platform behavior how to render it in that case. We should just ignore the add operation when it is already added.

For test cases, just make sure nothing wrong happens when you add same view more than twice.

```js
var win = Ti.UI.createWindow();

var view = Ti.UI.createView({
    backgroundColor: 'red',
    width: 100, height: 100
});

win.add(view);
win.add(view);
win.open();
```