### PR TITLE
[TIMOB-25602] Wrong value for FileSystem external storage

### DIFF
--- a/Source/Filesystem/src/Filesystem.cpp
+++ b/Source/Filesystem/src/Filesystem.cpp
@@ -83,6 +83,9 @@ namespace TitaniumWindows
 		// Need to check exception here because this requires "Removable Storage" capability
 		try {
 			const auto value = Windows::Storage::KnownFolders::RemovableDevices->Path;
+			if (value->IsEmpty()) {
+				return "";
+			}
 			return TitaniumWindows::Utility::ConvertString(value) + separator(); // FIXME Only append separator if not already there!
 		} catch (Platform::AccessDeniedException^ e) {
 			return "";


### PR DESCRIPTION
[TIMOB-25602](https://jira.appcelerator.org/browse/TIMOB-25602)

`Ti.Filesystem.isExternalStoragePresent()` returns true even when there's no external storage, and thus `Ti.Filesystem.applicationDataDirectory` returns wrong value (such as `\`). Following app failed because it tries to handle non-existing folders.

```js
var cDir;

if (Ti.Filesystem.isExternalStoragePresent()) {
    cDir = Ti.Filesystem.externalStorageDirectory + "/Attachments";
} else {
    cDir = Ti.Filesystem.applicationDataDirectory + "/Attachments";
}

var folder = Titanium.Filesystem.getFile(cDir);
if (!folder.exists()) {
    folder.createDirectory();
}

Ti.API.info("folder exists:" + folder.exists());

var cDirTemp;
cDirTemp = cDir + "/Temp";
var folderTemp = Titanium.Filesystem.getFile(cDirTemp);

if (!folderTemp.exists()) {
    folderTemp.createDirectory();
} else {
    folderTemp.deleteDirectory(true);
    folderTemp.createDirectory();
}
```

Expexted: `"folder exists:true"` is printed and application should not crash.