### PR TITLE
[TIMOB-23247] CLI: Implement Native Module clean

### DIFF
--- a/cli/commands/_cleanModule.js
+++ b/cli/commands/_cleanModule.js
@@ -1,0 +1,44 @@
+/**
+* Android module clean command.
+*
+* @module cli/_cleanModule
+*
+* @copyright
+* Copyright (c) 2018 by Appcelerator, Inc. All Rights Reserved.
+*
+* @license
+* Licensed under the terms of the Apache Public License
+* Please see the LICENSE included with this distribution for details.
+*/
+
+'use strict';
+const path = require('path');
+const fs = require('fs-extra');
+const appc = require('node-appc');
+const __ = appc.i18n(__dirname).__;
+
+exports.run = function run(logger, config, cli, finished) {
+	const projectDir = cli.argv['project-dir'];
+
+	// Guess the generated zipfile name!
+	// TODO: Use a glob and delete any version zipfile generated?
+	const moduleId = cli.manifest.moduleid;
+	const moduleVersion = cli.manifest.version;
+	const moduleZipName = [ moduleId, '-windows-', moduleVersion, '.zip' ].join('');
+
+	const toDelete = [
+		'build', 'dist', 'Windows10.ARM', 'Windows10.Win32', 'WindowsPhone.ARM/',
+		'WindowsPhone.Win32', 'WindowsStore.Win32', 'CMakeLists.txt', moduleZipName
+	];
+	toDelete.forEach((f) => {
+		const target = path.join(projectDir, f);
+		if (appc.fs.exists(target)) {
+			logger.debug(__('Deleting %s', target.cyan));
+			fs.removeSync(target);
+		} else {
+			logger.debug(__('File does not exist %s', target.cyan));
+		}
+	});
+
+	finished();
+};

--- a/cli/commands/_cleanModule.js
+++ b/cli/commands/_cleanModule.js
@@ -1,5 +1,5 @@
 /**
-* Android module clean command.
+* Windows module clean command.
 *
 * @module cli/_cleanModule
 *
@@ -26,8 +26,9 @@ exports.run = function run(logger, config, cli, finished) {
 	const moduleVersion = cli.manifest.version;
 	const moduleZipName = [ moduleId, '-windows-', moduleVersion, '.zip' ].join('');
 
+	const moduleBuildDir = path.join('build', moduleId);
 	const toDelete = [
-		'build', 'dist', 'Windows10.ARM', 'Windows10.Win32', 'WindowsPhone.ARM/',
+		moduleBuildDir, 'dist', 'Windows10.ARM', 'Windows10.Win32', 'WindowsPhone.ARM/',
 		'WindowsPhone.Win32', 'WindowsStore.Win32', 'CMakeLists.txt', moduleZipName
 	];
 	toDelete.forEach((f) => {


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-23247

**Description:**
```
 ti clean -p <platform>
```

This hooks up ti clean as a command that can be used for modules as we do with normal apps.
It's implemented in a single-platform at a time way, and isn't meant to yet support multi-platform modules like say hyperloop.

I took a best guess at the files we should be wiping out, but certainly open to suggestions/tweaks here.

Should be merged in conjunction with appcelerator/titanium_mobile#9807