### PR TITLE
[TIMOB-25794] Adding hyperloop view to a Titanium View crashes

### DIFF
--- a/Source/TitaniumKit/src/UI/View.cpp
+++ b/Source/TitaniumKit/src/UI/View.cpp
@@ -113,17 +113,20 @@ namespace Titanium
 				return;
 			}
 			auto view_ptr = view.GetPrivate<View>();
+
+			// For mixing Ti.Ui.View and native view.
+			if (view_ptr == nullptr) {
+				view_ptr = layoutDelegate__->rescueGetView(view);
+			}
+
+			TITANIUM_ASSERT(view_ptr != nullptr);
+
 			const auto parent_view_ptr = this->get_object().GetPrivate<View>();
 
 			// Compare parent, this indicates you're trying to add it before it's removed
 			if (view_ptr->get_parent() == parent_view_ptr) {
 				TITANIUM_LOG_WARN("View.add: This indicates this component is already added");
 				return;
-			}
-
-			// For mixing Ti.Ui.View and native view.
-			if (view_ptr == nullptr) {
-				view_ptr = layoutDelegate__->rescueGetView(view);
 			}
 
 			view_ptr->set_parent(parent_view_ptr);


### PR DESCRIPTION
[TIMOB-25794](https://jira.appcelerator.org/browse/TIMOB-25794)

```js
var win = Ti.UI.createWindow();
var Canvas = require('Windows.UI.Xaml.Controls.Canvas');
var view = Ti.UI.createView({
    backgroundColor: 'white'
});
var SolidColorBrush = require('Windows.UI.Xaml.Media.SolidColorBrush');
var Colors = require('Windows.UI.Colors');
var box = new Canvas();
box.Background = new SolidColorBrush(Colors.Red);
box.Width = 50;
box.Height = 50;
win.addEventListener('click', function () {
    view.add(box);
});

win.add(view);
win.open();
```

Expected: This should not crashes app.
