### PR TITLE
[TIMOB-24610] Make transpiling off by default

### DIFF
--- a/cli/commands/_build/validate.js
+++ b/cli/commands/_build/validate.js
@@ -85,7 +85,7 @@ function validate(logger, config, cli) {
 			this.buildConfiguration = 'Release';
 	}
 
-	this.transpile = this.cli.tiapp.transpile !== false;
+	this.transpile = this.cli.tiapp.transpile === true;
 
 	if (cli.argv['skip-js-minify']) {
 		this.minifyJS = false;


### PR DESCRIPTION
Windows version of appcelerator/titanium_mobile/pull/9879

**JIRA:** https://jira.appcelerator.org/browse/TIMOB-24610 (do we need another one?)

Make babel transpilation an opt in process by using the `<transpile>true</transpile>` flag in the tiapp.xml

Test steps

1. Add the following to an app.js
```js
var undefined = 'This will error in strict mode as we are overwriting undefined';
```
2. Build for any target
3. Add `<transpile>true</transpile>` to your tiapp.xml
4. Build again

## Expected

The app should throw an error similar to below the second time

```
[ERROR] Script Error {
[ERROR]     column = 16;
[ERROR]     line = 5;
[ERROR]     message = "Attempted to assign to readonly property.";
[ERROR]     sourceURL = "file:///Users/eharris/Library/Developer/CoreSimulator/Devices/19A348C6-7F86-4096-AEDE-90BB291BC971/data/Containers/Bundle/Application/2FCEAB2E-C77B-4CAC-9DA3-301B781DDD62/testbabelstuff.app/app.js";
[ERROR] }
```