### PR TITLE
[TIMOB-25814] UI is not resized properly on incorrect operations

### DIFF
--- a/Source/LayoutEngine/src/Node.cpp
+++ b/Source/LayoutEngine/src/Node.cpp
@@ -17,6 +17,10 @@ namespace Titanium
 	{
 		void nodeAddChild(struct Node* parent, struct Node* child)
 		{
+			if (child->parent) {
+				nodeRemoveChild(child->parent, child);
+			}
+
 			child->parent = parent;
 			if (parent->lastChild) {
 				child->prev = parent->lastChild;
@@ -31,6 +35,10 @@ namespace Titanium
 
 		void nodeRemoveChild(struct Node* parent, struct Node* child)
 		{
+			if (child->parent != parent) {
+				return;
+			}
+
 			child->parent = nullptr;
 			if (child->prev) {
 				child->prev->next = child->next;
@@ -50,6 +58,10 @@ namespace Titanium
 
 		void nodeInsertChildAt(struct Node* parent, struct Node* child, unsigned int index) 
 		{
+			if (child->parent) {
+				nodeRemoveChild(child->parent, child);
+			}
+
 			child->parent = parent;
 
 			// find target node

--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -1756,8 +1756,6 @@ namespace TitaniumWindows
 
 		void WindowsViewLayoutDelegate::requestLayout(const bool& fire_event)
 		{
-			Titanium::LayoutEngine::nodeLayout(layout_node__);
-
 			const auto root = Titanium::LayoutEngine::nodeRequestLayout(layout_node__);
 			if (root) {
 				Titanium::LayoutEngine::nodeLayout(root);


### PR DESCRIPTION
[TIMOB-25814](https://jira.appcelerator.org/browse/TIMOB-25814)

UI rendering is broken when you add/remove/insert incorrectly. For instance:

- Add a view that is already added
- Insert a view that is already inserted
- Remove a view from wrong parent view
