### PR TITLE
[7_1_X][TIMOB-25692] Pickers populated at run time do not fire change events

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/Picker.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/Picker.hpp
@@ -91,7 +91,7 @@ namespace TitaniumWindows
 
 			void addColumns(const std::vector<std::shared_ptr<Titanium::UI::PickerColumn>>& columns);
 			std::vector<JSValue> getSelectedJSValues();
-
+			void unregisterChangeEvents();
 #pragma warning(pop)
 		};
 	} // namespace UI


### PR DESCRIPTION
Cherry-pick #1174 for 7_1_X again, as #1196 was not actually merged to 7_1_X.