### PR TITLE
[CVE-2017-18214] Fix potential vulnerability in moment

### DIFF
--- a/Tools/Scripts/package.json
+++ b/Tools/Scripts/package.json
@@ -32,7 +32,7 @@
 		"async": "~0.9.0",
 		"colors": "~0.6.2",
 		"commander": "~2.9.0",
-		"moment": "~2.11.2",
+		"moment": "~2.19.3",
 		"node-appc": "0.2.21",
 		"request": "~2.27.0",
 		"temp": "~0.6.0",


### PR DESCRIPTION
github recently alerted [potential security vulnerability in dependencies](https://help.github.com/articles/about-security-alerts-for-vulnerable-dependencies/) in [moment package before 2.19.3](https://nvd.nist.gov/vuln/detail/CVE-2017-18214). I believe this has to be small impact for us because it is only internal tools for development, but I would like to suppress the warning.