### PR TITLE
[TIMOB-25908] Add ability to require with namespace 

### DIFF
--- a/Source/Global/include/TitaniumWindows/GlobalObject.hpp
+++ b/Source/Global/include/TitaniumWindows/GlobalObject.hpp
@@ -48,6 +48,9 @@ namespace TitaniumWindows
 		// store supported module names and its loaded status
 		std::unordered_map<std::string, bool> native_module_names__;
 
+		// store supported native namespaces to require namespace like "require(package_name)"
+		std::unordered_set<std::string> native_module_namespaces__;
+
 		// cache for native module
 		std::unordered_map<std::string, JSValue> native_module_cache__;
 		std::function<JSValue(const JSContext& js_context, const std::string&)> native_module_requireHook__;

--- a/Source/Global/src/GlobalObject.cpp
+++ b/Source/Global/src/GlobalObject.cpp
@@ -36,8 +36,7 @@ namespace TitaniumWindows
 			// The module name which ends with ".*" means it is a native namespace. 
 			// Then it should not be treated as a standard module.
 			if (boost::ends_with(v, ".*")) {
-				const auto name = v.substr(0, v.length() - 2);
-				const auto insert_result = native_module_namespaces__.emplace(name);
+				const auto insert_result = native_module_namespaces__.emplace(v);
 				TITANIUM_ASSERT(insert_result.second);
 			} else {
 				const auto insert_result = native_module_names__.emplace(v, false);

--- a/Source/Global/src/GlobalObject.cpp
+++ b/Source/Global/src/GlobalObject.cpp
@@ -33,8 +33,16 @@ namespace TitaniumWindows
 	{
 		// store supported native module names
 		for (const auto v : native_module_names) {
-			const auto insert_result = native_module_names__.emplace(v,  false);
-			TITANIUM_ASSERT(insert_result.second);
+			// The module name which ends with ".*" means it is a native namespace. 
+			// Then it should not be treated as a standard module.
+			if (boost::ends_with(v, ".*")) {
+				const auto name = v.substr(0, v.length() - 2);
+				const auto insert_result = native_module_namespaces__.emplace(name);
+				TITANIUM_ASSERT(insert_result.second);
+			} else {
+				const auto insert_result = native_module_names__.emplace(v, false);
+				TITANIUM_ASSERT(insert_result.second);
+			}
 		}
 
 		// register preloaded modules
@@ -50,7 +58,7 @@ namespace TitaniumWindows
 
 	bool GlobalObject::requiredNativeModuleExists(const JSContext& js_context, const std::string& moduleId) const TITANIUM_NOEXCEPT
 	{
-		return native_module_names__.find(moduleId) != native_module_names__.end();
+		return native_module_names__.find(moduleId) != native_module_names__.end() || native_module_namespaces__.find(moduleId) != native_module_namespaces__.end();
 	}
 
 	JSValue GlobalObject::requireNativeModule(const JSContext& js_context, const std::string& moduleId) TITANIUM_NOEXCEPT
@@ -60,10 +68,10 @@ namespace TitaniumWindows
 			return native_module_cache__.at(moduleId);
 		}
 
-		TITANIUM_ASSERT(native_module_names__.find(moduleId) != native_module_names__.end());
-
-		// mark it as loaded
-		native_module_names__[moduleId] = true;
+		if (native_module_names__.find(moduleId) != native_module_names__.end()) {
+			// mark it as loaded
+			native_module_names__[moduleId] = true;
+		}
 
 		// otherwise try to load dynamically
 		return native_module_requireHook__(js_context, moduleId);

--- a/cli/lib/stub.js
+++ b/cli/lib/stub.js
@@ -107,7 +107,7 @@ function generateNativeTypeHelper(dest, native_types, native_events, next) {
  * @param {Array[map]} modules - 
  * @param {Function} next - 
  */
-function generateRequireHook(dest, modules, native_types, next) {
+function generateRequireHook(dest, modules, native_types, native_namespaces, next) {
 	var require_hook = path.join(dest, 'src', 'RequireHook.cpp'),
 		template = path.join(dest, 'src', 'RequireHook.cpp.ejs');
 	// Now we'll add all the types we know about as includes into our require hook class
@@ -135,6 +135,7 @@ function generateRequireHook(dest, modules, native_types, next) {
 
 		data = ejs.render(data, { 
 			native_module_includes:native_module_includes,
+			native_namespaces:native_namespaces,
 			native_modules:native_modules,
 			native_types:native_types
 			}, {});
@@ -302,7 +303,7 @@ exports.generate = function generate(builder, finished) {
 				},
 				function(cb) {
 					builder.cli.createHook('build.windows.stub.generateRequireHook', builder, function (builder, cb) {
-						generateRequireHook(dest_Native, builder.modules, builder.native_types, cb);
+						generateRequireHook(dest_Native, builder.modules, builder.native_types, builder.native_namespaces, cb);
 					})(builder, cb);
 				}
 			], function() {
@@ -343,7 +344,7 @@ exports.generate = function generate(builder, finished) {
 				generateCmakeList(dest_Native, modules, callback);
 			},
 			function(callback) {
-				generateRequireHook(dest_Native, modules, native_types, callback);
+				generateRequireHook(dest_Native, modules, native_types, {}, callback);
 			}
 		], finished);
 	}

--- a/templates/build/Native/src/RequireHook.cpp.ejs
+++ b/templates/build/Native/src/RequireHook.cpp.ejs
@@ -65,12 +65,19 @@ namespace TitaniumWindows_Native
 		auto names = ref new ::Platform::Collections::Vector<::Platform::String^>();
 
 		//// INSERT SUPPORTED NATIVE MODULE NAMES START
+		// modules
 <% for(var i=0; i<native_modules.length; i++) { -%>
 		names->Append("<%- native_modules[i].name %>");
 <% } -%>
+		// native types
 <% for(var key in native_types) { -%>
 		names->Append("<%- native_types[key].name %>");
 <% } -%>
+		// native namespaces
+<% for(var key in native_namespaces) { -%>
+		names->Append("<%- native_namespaces[key].name %>.*");
+<% } -%>
+
 		//// INSERT SUPPORTED NATIVE MODULE NAMES END
 
 		return names;


### PR DESCRIPTION
[TIMOB-25908](https://jira.appcelerator.org/browse/TIMOB-25908)

Add ability to require with namespace such as `require(package_name.*)`. This also enables ES6-style multiple imports such as `import { UICommand, MessageDialog } from 'Windows.UI.Popups.*';`.

This requires https://github.com/appcelerator/hyperloop.next/pull/281 to be merged together.

```js
// ES5-style require call with namespace
var System = require('System.*');
var Int32  = System.Int32;

// ES6-style import
import Button from 'Windows.UI.Xaml.Controls.Button';
import PropertyValue from 'Windows.Foundation.PropertyValue';

// ES6-style require with namespace
import { UICommand, MessageDialog } from 'Windows.UI.Popups.*';

let win = Ti.UI.createWindow({ backgroundColor: 'green' }),
	button = new Button();

button.Content = "PUSH";
button.addEventListener('Tapped', () => {
    const dialog = new MessageDialog('My Message');
    dialog.Title = 'My Title';
    dialog.DefaultCommandIndex = 0;
    dialog.Commands.Add(new UICommand('OK', null, PropertyValue.CreateInt32(0)));
    dialog.Commands.Add(new UICommand('Cancel', null, PropertyValue.CreateInt32(1)));
    dialog.ShowAsync().then(function (command) {
        const id = Int32.cast(command.Id);
        alert((id == 0) ? 'Pushed "OK"' : 'Pushed "Cancel"')
    });
});

win.add(button);
win.open();
```