### PR TITLE
[TIMOB-26028] Add parity for Ti.Filesystem.File

### DIFF
--- a/Source/TitaniumKit/include/Titanium/Filesystem/File.hpp
+++ b/Source/TitaniumKit/include/Titanium/Filesystem/File.hpp
@@ -268,6 +268,7 @@ namespace Titanium
 			TITANIUM_FUNCTION_DEF(createDirectory);
 			TITANIUM_FUNCTION_DEF(createFile);
 			TITANIUM_FUNCTION_DEF(createTimestamp);
+			TITANIUM_FUNCTION_DEF(createdAt);
 			TITANIUM_FUNCTION_DEF(deleteDirectory);
 			TITANIUM_FUNCTION_DEF(deleteFile);
 			TITANIUM_FUNCTION_DEF(exists);
@@ -276,6 +277,7 @@ namespace Titanium
 			TITANIUM_FUNCTION_DEF(isDirectory);
 			TITANIUM_FUNCTION_DEF(isFile);
 			TITANIUM_FUNCTION_DEF(modificationTimestamp);
+			TITANIUM_FUNCTION_DEF(modifiedAt);
 			TITANIUM_FUNCTION_DEF(move);
 			TITANIUM_FUNCTION_DEF(open);
 			TITANIUM_FUNCTION_DEF(read);

--- a/Source/TitaniumKit/src/Filesystem/File.cpp
+++ b/Source/TitaniumKit/src/Filesystem/File.cpp
@@ -51,6 +51,7 @@ namespace Titanium
 			TITANIUM_ADD_FUNCTION(File, createDirectory);
 			TITANIUM_ADD_FUNCTION(File, createFile);
 			TITANIUM_ADD_FUNCTION(File, createTimestamp);
+			TITANIUM_ADD_FUNCTION(File, createdAt);
 			TITANIUM_ADD_FUNCTION(File, deleteDirectory);
 			TITANIUM_ADD_FUNCTION(File, deleteFile);
 			TITANIUM_ADD_FUNCTION(File, exists);
@@ -59,6 +60,7 @@ namespace Titanium
 			TITANIUM_ADD_FUNCTION(File, isDirectory);
 			TITANIUM_ADD_FUNCTION(File, isFile);
 			TITANIUM_ADD_FUNCTION(File, modificationTimestamp);
+			TITANIUM_ADD_FUNCTION(File, modifiedAt);
 			TITANIUM_ADD_FUNCTION(File, move);
 			TITANIUM_ADD_FUNCTION(File, open);
 			TITANIUM_ADD_FUNCTION(File, read);
@@ -451,7 +453,18 @@ namespace Titanium
 
 		TITANIUM_FUNCTION(File, createTimestamp)
 		{
-			return get_context().CreateNumber(static_cast<double>(createTimestamp().count()));
+			const auto ctx = get_context();
+			ctx.JSEvaluateScript("Ti.API.warn('createTimestamp() has been deprecated in 7.2.0 in favor of createdAt() to avoid platform-differences for return type. createdAt() will return a Date object on all platforms.');");
+
+			return ctx.CreateNumber(static_cast<double>(createTimestamp().count()));
+		}
+
+		TITANIUM_FUNCTION(File, createdAt)
+		{
+			const auto ctx = get_context();
+
+			const std::vector<JSValue> dateArg = { ctx.CreateNumber(static_cast<double>(createTimestamp().count())) };
+			return ctx.CreateDate(dateArg);
 		}
 
 		TITANIUM_FUNCTION(File, deleteDirectory)
@@ -504,7 +517,18 @@ namespace Titanium
 
 		TITANIUM_FUNCTION(File, modificationTimestamp)
 		{
-			return get_context().CreateNumber(static_cast<double>(modificationTimestamp().count()));
+			const auto ctx = get_context();
+			ctx.JSEvaluateScript("Ti.API.warn('modificationTimestamp() has been deprecated in 7.2.0 in favor of modifiedAt() to avoid platform-differences for return type. modifiedAt() will return a Date object on all platforms.');");
+
+			return ctx.CreateNumber(static_cast<double>(modificationTimestamp().count()));
+		}
+
+		TITANIUM_FUNCTION(File, modifiedAt)
+		{
+			const auto ctx = get_context();
+
+			const std::vector<JSValue> dateArg = { ctx.CreateNumber(static_cast<double>(modificationTimestamp().count())) };
+			return ctx.CreateDate(dateArg);
 		}
 
 		TITANIUM_FUNCTION(File, move)

--- a/apidoc/Titanium/Filesystem/File.yml
+++ b/apidoc/Titanium/Filesystem/File.yml
@@ -40,6 +40,8 @@ methods:
     platforms: [windowsphone]
   - name: createTimestamp
     platforms: [windowsphone]
+  - name: createdAt
+    platforms: [windowsphone]
   - name: deleteDirectory
     platforms: [windowsphone]
   - name: deleteFile
@@ -55,6 +57,8 @@ methods:
   - name: isFile
     platforms: [windowsphone]
   - name: modificationTimestamp
+    platforms: [windowsphone]
+  - name: modifiedAt
     platforms: [windowsphone]
   - name: move
     platforms: [windowsphone]


### PR DESCRIPTION
[TIMOB-26028](https://jira.appcelerator.org/browse/TIMOB-26028)

- deprecate File.createTimestamp and modificationTimestamp
- add createdAt and modifiedAt that returns Date value

(See also https://github.com/appcelerator/titanium_mobile/pull/10019)

```js
var file = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, 'app.js');

Ti.API.info('createTimestamp: ' + file.createTimestamp());       // This should show warning message.
Ti.API.info('modificationTimestamp: ' + file.modificationTimestamp()); // This should show warning message.

var created   = file.createdAt();    // This should return Date value.
var modified = file.modifiedAt();  // This should return Date value.

Ti.API.info('createdAt: '  + (created instanceof Date)  + ' ' + created);
Ti.API.info('modifiedAt: ' + (modified instanceof Date) + ' ' + modified);
```