### PR TITLE
Fix path error in setup.js

### DIFF
--- a/Tools/Scripts/setup.js
+++ b/Tools/Scripts/setup.js
@@ -235,7 +235,7 @@ function downloadIfNecessary(envKey, defaultDest, expectedDir, url, next) {
 			if (fs.existsSync(destination)) {
 				var urlFile = path.join(destination, 'SOURCE_URL');
 				if (fs.existsSync(urlFile)) {
-					var contents = fs.readFileSync(urlFile);
+					var contents = fs.readFileSync(urlFile).toString();
 					var base = path.basename(contents.slice(7), '.zip');
 					var byURL = path.normalize(path.join(destination, '..', base));
 					console.log('Destination for ' + url + ' already exists, moving existing directory to ' + byURL + ' before extracting.');


### PR DESCRIPTION
Fix path error in setup.js

```
Setting up JavaScriptCore pre-built libraries...
Downloading http://timobile.appcelerator.com.s3.amazonaws.com/jscore/dist/JavaScriptCore-Windows-1508145738839-win10.zip
path.js:28
    throw new TypeError('Path must be a string. Received ' + inspect(path));
    ^
TypeError: Path must be a string. Received <Buffer 74 69 6d 6f 62 69 6c 65 2e 61 70 70 63 65 6c 65 72 61 74 6f 72 2e 63 6f 6d 2e 73 33 2e 61 6d 61 7a 6f 6e 61 77 73 2e 63 6f 6d 2f 6a 73 63 6f 72 65 2f ... >
    at assertPath (path.js:28:11)
    at Object.basename (path.js:820:5)
    at C:\Jenkins\workspace\nium_mobile_windows_PR-1238-TJG2V7CJFECKF2R4R6MQDZUMJB37KCANAWXTHMLBIYLFQWZD4CMQ\Tools\Scripts\setup.js:239:22

```