### PR TITLE
Attempt to clean-up test build directory

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,8 +76,6 @@ def unitTests(target, branch, testSuiteBranch, nodeVersion, npmVersion) {
 			dir('scripts') {
 				try {
 					timeout(30) {
-						// Make sure to clean Titanium build cache directory
-						bat "appc ti clean"
 						if ('ws-local'.equals(target)) {
 							bat "node test.js -p windows -T ${target} --skip-sdk-install --cleanup"
 						} else if ('wp-emulator'.equals(target)) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,6 +76,8 @@ def unitTests(target, branch, testSuiteBranch, nodeVersion, npmVersion) {
 			dir('scripts') {
 				try {
 					timeout(30) {
+						// Make sure to clean Titanium build cache directory
+						bat "appc ti clean"
 						if ('ws-local'.equals(target)) {
 							bat "node test.js -p windows -T ${target} --skip-sdk-install --cleanup"
 						} else if ('wp-emulator'.equals(target)) {

--- a/Tools/Scripts/build/test.js
+++ b/Tools/Scripts/build/test.js
@@ -188,6 +188,27 @@ function generateWindowsProject(next) {
 }
 
 /**
+ * Wiping out project build directory for Windows. (appc ti clean)
+ *
+ * @param next {Function} callback function
+ **/
+function cleanWindowsProject(next) {
+	var prc = spawn('node', [titanium, 'clean', '--project-dir', projectDir]);
+	prc.stdout.on('data', function (data) {
+		console.log(data.toString());
+	});
+	prc.stderr.on('data', function (data) {
+		console.log(data.toString());
+	});
+	prc.on('close', function (code) {
+		if (code != 0) {
+			next("Failed to clean project");
+		} else {
+			next();
+		}
+	});
+}
+/**
  * Add required properties for our unit tests to the tiapp.xml
  *
  * @params sdkVersion {String} '8.1'||'10.0'
@@ -509,6 +530,10 @@ function test(sdkVersion, msbuild, branch, target, deviceId, prefix, callback) {
 		function (next) {
 			console.log("Generating Windows project");
 			generateWindowsProject(next);
+		},
+		function (next) {
+			console.log("Wiping out project build directory");
+			cleanWindowsProject(next);
 		},
 		function (next) {
 			console.log("Adding properties for tiapp.xml");


### PR DESCRIPTION
Mocha test needs to cleanup `C:\Users\build\.titanium\vsbuild\mocha` before build because previous build files are there.