### PR TITLE
[TIMOB-26048] Refactor RSOD UI

### DIFF
--- a/Source/Ti/include/TitaniumWindows/Contacts.hpp
+++ b/Source/Ti/include/TitaniumWindows/Contacts.hpp
@@ -49,8 +49,8 @@ namespace TitaniumWindows
 		virtual std::shared_ptr<Titanium::Contacts::Group> getGroupByIdentifier(const std::string& id) TITANIUM_NOEXCEPT override final;
 		virtual std::vector<std::shared_ptr<Titanium::Contacts::Person>> getPeopleWithName(const std::string& name) TITANIUM_NOEXCEPT override final;
 		virtual std::shared_ptr<Titanium::Contacts::Person> getPersonByIdentifier(const std::string& id) TITANIUM_NOEXCEPT override final;
-		virtual JSValue js_createGroup(const std::vector<JSValue>& arguments, JSObject& this_object) TITANIUM_NOEXCEPT override final;
-		virtual JSValue js_createPerson(const std::vector<JSValue>& arguments, JSObject& this_object) TITANIUM_NOEXCEPT override final;
+		virtual JSValue js_hook_createGroup(const std::vector<JSValue>& arguments, JSObject& this_object) TITANIUM_NOEXCEPT override final;
+		virtual JSValue js_hook_createPerson(const std::vector<JSValue>& arguments, JSObject& this_object) TITANIUM_NOEXCEPT override final;
 		virtual void removeGroup(const std::shared_ptr<Titanium::Contacts::Group>& group) TITANIUM_NOEXCEPT override final;
 		virtual void removePerson(const std::shared_ptr<Titanium::Contacts::Person>& person) TITANIUM_NOEXCEPT override final;
 		virtual void revert() TITANIUM_NOEXCEPT override final;

--- a/Source/Ti/src/Contacts.cpp
+++ b/Source/Ti/src/Contacts.cpp
@@ -189,7 +189,7 @@ namespace TitaniumWindows
 		return result;
 	}
 
-	JSValue ContactsModule::js_createGroup(const std::vector<JSValue>& arguments, JSObject& this_object) TITANIUM_NOEXCEPT
+	JSValue ContactsModule::js_hook_createGroup(const std::vector<JSValue>& arguments, JSObject& this_object) TITANIUM_NOEXCEPT
 	{
 		auto result = Titanium::ContactsModule::js_createGroup(arguments, this_object);
 		// record group we'll need to save later!
@@ -275,7 +275,7 @@ namespace TitaniumWindows
 	}
 #endif
 
-	JSValue ContactsModule::js_createPerson(const std::vector<JSValue>& arguments, JSObject& this_object) TITANIUM_NOEXCEPT
+	JSValue ContactsModule::js_hook_createPerson(const std::vector<JSValue>& arguments, JSObject& this_object) TITANIUM_NOEXCEPT
 	{
 		auto result = Titanium::ContactsModule::js_createPerson(arguments, this_object);
 #if defined(IS_WINDOWS_10)

--- a/Source/TitaniumKit/include/Titanium/API.hpp
+++ b/Source/TitaniumKit/include/Titanium/API.hpp
@@ -135,7 +135,6 @@ namespace Titanium
 		TITANIUM_FUNCTION_DEF(debug);
 		TITANIUM_FUNCTION_DEF(trace);
 		TITANIUM_FUNCTION_DEF(log);
-		TITANIUM_FUNCTION_DEF_NOHOOK(_saveStacktrace);
 
 	private:
 		enum class LogSeverityLevel {

--- a/Source/TitaniumKit/include/Titanium/API.hpp
+++ b/Source/TitaniumKit/include/Titanium/API.hpp
@@ -135,6 +135,7 @@ namespace Titanium
 		TITANIUM_FUNCTION_DEF(debug);
 		TITANIUM_FUNCTION_DEF(trace);
 		TITANIUM_FUNCTION_DEF(log);
+		TITANIUM_FUNCTION_DEF_NOHOOK(_saveStacktrace);
 
 	private:
 		enum class LogSeverityLevel {

--- a/Source/TitaniumKit/include/Titanium/Module.hpp
+++ b/Source/TitaniumKit/include/Titanium/Module.hpp
@@ -12,6 +12,7 @@
 #include "Titanium/detail/TiBase.hpp"
 #include <unordered_map>
 #include <vector>
+#include <deque>
 
 namespace Titanium
 {
@@ -148,6 +149,11 @@ namespace Titanium
 		Module(Module&&) = default;
 		Module& operator=(Module&&) = default;
 #endif
+
+#pragma warning(push)
+#pragma warning(disable : 4251)
+		static std::deque<std::string> BackTrace__;
+#pragma warning(pop)
 
 		// TODO: The following functions can automatically be generated from
 		// the YAML API docs.

--- a/Source/TitaniumKit/include/Titanium/detail/TiBase.hpp
+++ b/Source/TitaniumKit/include/Titanium/detail/TiBase.hpp
@@ -56,6 +56,10 @@
 
 // For defining the bridge function for a function property exposed on JS Object (hpp)
 #define TITANIUM_FUNCTION_DEF(NAME) \
+JSValue js_hook_##NAME(const std::vector<JSValue>& arguments, JSObject& this_object); \
+JSValue js_##NAME(const std::vector<JSValue>& arguments, JSObject& this_object)
+
+#define TITANIUM_FUNCTION_DEF_NOHOOK(NAME) \
 JSValue js_##NAME(const std::vector<JSValue>& arguments, JSObject& this_object)
 
 // For defining the getter bridge function for a read-only property exposed on JS Object (hpp)

--- a/Source/TitaniumKit/include/Titanium/detail/TiImpl.hpp
+++ b/Source/TitaniumKit/include/Titanium/detail/TiImpl.hpp
@@ -27,6 +27,22 @@
 
 // For implementing the bridge getter function for a function property (cpp)
 #define TITANIUM_FUNCTION(MODULE, NAME) \
+JSValue MODULE::js_hook_##NAME(const std::vector<JSValue>& arguments, JSObject& this_object) \
+{ \
+    Titanium::Module::BackTrace__.push_back(#MODULE "::" #NAME); \
+    if (Titanium::Module::BackTrace__.size() > 10) { \
+        Titanium::Module::BackTrace__.pop_front(); \
+    } \
+    const auto value = js_##NAME(arguments, this_object); \
+    Titanium::Module::BackTrace__.pop_back(); \
+    return value; \
+} \
+JSValue MODULE::js_##NAME(const std::vector<JSValue>& arguments, JSObject& this_object)
+
+#define TITANIUM_FUNCTION_NOHOOK(MODULE, NAME) \
+JSValue MODULE::js_##NAME(const std::vector<JSValue>& arguments, JSObject& this_object) \
+
+#define TITANIUM_FUNCTION_NOHOOK(MODULE, NAME) \
 JSValue MODULE::js_##NAME(const std::vector<JSValue>& arguments, JSObject& this_object)
 
 // For implementing the bridge getter function for a value property (cpp)
@@ -58,6 +74,9 @@ TITANIUM_PROPERTY_WRITE(MODULE, TYPE, NAME)
 
 // For adding a function as a property on the JS Object this type backs (cpp, in JSExportInitialize)
 #define TITANIUM_ADD_FUNCTION(MODULE, NAME) \
+JSExport<MODULE>::AddFunctionProperty(#NAME, std::mem_fn(&MODULE::js_hook_##NAME))
+
+#define TITANIUM_ADD_FUNCTION_NOHOOK(MODULE, NAME) \
 JSExport<MODULE>::AddFunctionProperty(#NAME, std::mem_fn(&MODULE::js_##NAME))
 
 // For adding a value as a read-only property on the JS Object this type backs (cpp, in JSExportInitialize)

--- a/Source/TitaniumKit/src/API.cpp
+++ b/Source/TitaniumKit/src/API.cpp
@@ -140,7 +140,6 @@ namespace Titanium
 		TITANIUM_ADD_FUNCTION(API, debug);
 		TITANIUM_ADD_FUNCTION(API, trace);
 		TITANIUM_ADD_FUNCTION(API, log);
-		TITANIUM_ADD_FUNCTION_NOHOOK(API, _saveStacktrace);
 	}
 
 	JSObject API::GetStaticObject(const JSContext& js_context) TITANIUM_NOEXCEPT
@@ -213,15 +212,5 @@ namespace Titanium
 		}
 
 		return js_context.CreateUndefined();
-	}
-
-	TITANIUM_FUNCTION_NOHOOK(API, _saveStacktrace)
-	{
-		const auto js_context = get_context();
-		std::vector<JSValue> stack;
-		for (auto iter = Titanium::Module::BackTrace__.rbegin(); iter != Titanium::Module::BackTrace__.rend(); ++iter) {
-			stack.push_back(js_context.CreateString(*iter));
-		}
-		return js_context.CreateArray(stack);
 	}
 }  // namespace Titanium

--- a/Source/TitaniumKit/src/API.cpp
+++ b/Source/TitaniumKit/src/API.cpp
@@ -140,6 +140,7 @@ namespace Titanium
 		TITANIUM_ADD_FUNCTION(API, debug);
 		TITANIUM_ADD_FUNCTION(API, trace);
 		TITANIUM_ADD_FUNCTION(API, log);
+		TITANIUM_ADD_FUNCTION_NOHOOK(API, _saveStacktrace);
 	}
 
 	JSObject API::GetStaticObject(const JSContext& js_context) TITANIUM_NOEXCEPT
@@ -214,4 +215,13 @@ namespace Titanium
 		return js_context.CreateUndefined();
 	}
 
+	TITANIUM_FUNCTION_NOHOOK(API, _saveStacktrace)
+	{
+		const auto js_context = get_context();
+		std::vector<JSValue> stack;
+		for (auto iter = Titanium::Module::BackTrace__.rbegin(); iter != Titanium::Module::BackTrace__.rend(); ++iter) {
+			stack.push_back(js_context.CreateString(*iter));
+		}
+		return js_context.CreateArray(stack);
+	}
 }  // namespace Titanium

--- a/Source/TitaniumKit/src/Application.cpp
+++ b/Source/TitaniumKit/src/Application.cpp
@@ -25,6 +25,8 @@ namespace Titanium
  */
 function Titanium_RedScreenOfDeath(e) {
 
+    var stacktrace = Ti.API._saveStacktrace();
+
     // We don't want to show RSOD in production mode. re-throw.
     if (Ti.App.deployType == "production") {
         throw e;
@@ -32,44 +34,58 @@ function Titanium_RedScreenOfDeath(e) {
 
     try {
         var win = Ti.UI.createWindow({
-                backgroundColor: "#f00",
+                backgroundColor: "#f4f4f4",
                 layout: "vertical"
             }),
-            view,
             button;
 
         function makeMessage(e) {
             return (e.fileName ? "In " + e.fileName + " " : "") + (e.message || e.toString()).trim() + (e.lineNumber ? " (line " + e.lineNumber + " column " + e.columnNumber + ")" : "");
-        } 
-        function makeLabel(text, height, color, fontSize) {
-            var label = Ti.UI.createView({
-                height: height,
-                width: Ti.UI.FILL
-            });
-            label.add(Ti.UI.createLabel({
-                color: color,
-                font: { fontSize: fontSize, fontWeight: "bold" },
-                width:  Ti.UI.FILL,
-                height: Ti.UI.FILL,
-                textAlign: Ti.UI.TEXT_ALIGNMENT_CENTER,
-                text: text
-            }));
-            win.add(label);
+        }
+		function formatTrace(traces) {
+			var str =  '\n';
+            for (var i = 0; i < traces.length; i++) {
+                str += (i + 1 + '').padStart(2) + '  ' + traces[i] + '\n';
+            }
+            return str;
         }
 
-        Ti.API.error("----- Titanium Javascript Runtime Error -----");
         Ti.API.error("Message: Uncaught Error: " + makeMessage(e));
+        if (stacktrace && stacktrace.length > 0) {
+            Ti.API.error(formatTrace(stacktrace));
+        }
 
-        win.add(view = Ti.UI.createView({ height: "12%" }));
-        makeLabel("Application Error", "15%", "#0f0", "34");
-        makeLabel(makeMessage(e), "45%", "#fff", "26");
-        win.add(view = Ti.UI.createView({ height: "12%" }));
-        view.add(button = Ti.UI.createButton({ title: "Dismiss" }));
+        var label = Ti.UI.createView({
+            height: '90%',
+            width: Ti.UI.FILL,
+            top: 10, left: 10,
+			layout: 'vertical',            
+        });
+        label.add(Ti.UI.createLabel({
+            color: 'red',
+            width:  Ti.UI.FILL,
+            height: Ti.UI.SIZE,
+            textAlign: Ti.UI.TEXT_ALIGNMENT_LEFT,
+            verticalAlign: Ti.UI.TEXT_VERTICAL_ALIGNMENT_TOP,
+            text: makeMessage(e),
+        }));
+		if (stacktrace && stacktrace.length > 0) {
+            label.add(Ti.UI.createView({width: Ti.UI.FILL, height: 20}));
+            label.add(Ti.UI.createLabel({
+                color: 'red',
+                width:  Ti.UI.FILL,
+                height: Ti.UI.SIZE,
+                textAlign: Ti.UI.TEXT_ALIGNMENT_LEFT,
+                verticalAlign: Ti.UI.TEXT_VERTICAL_ALIGNMENT_TOP,
+                text: formatTrace(stacktrace),
+            }));
+        }
+        win.add(label);
+
+        win.add(button = Ti.UI.createButton({ title: "CONTINUE", backgroundColor: 'red', width: Ti.UI.FILL, height: '10%', bottom: 0 }));
         button.addEventListener("click", function () {
             win.close();
         });
-
-        makeLabel("Error messages will only be displayed during development. When your app is packaged for final distribution, no error screen will appear. Test your code!", "16%", "#000", "20");
 
         win.open();
     } catch (er) {

--- a/Source/TitaniumKit/src/GlobalString.cpp
+++ b/Source/TitaniumKit/src/GlobalString.cpp
@@ -8,6 +8,7 @@
 
 #include "Titanium/GlobalString.hpp"
 #include "Titanium/Global/sprintf_js.hpp"
+#include "Titanium/Module.hpp"
 #include "Titanium/detail/TiImpl.hpp"
 
 namespace Titanium

--- a/Source/TitaniumKit/src/Module.cpp
+++ b/Source/TitaniumKit/src/Module.cpp
@@ -142,10 +142,20 @@ namespace Titanium
 	void Module::ShowRedScreenOfDeath(const JSContext& ctx, const std::string& message) TITANIUM_NOEXCEPT
 	{
 		try {
-			const auto what = ctx.CreateString(message);
+			std::ostringstream stacktrace;
+			std::uint32_t i = 0;
+			for (auto iter = Titanium::Module::BackTrace__.rbegin(); iter != Titanium::Module::BackTrace__.rend(); ++iter) {
+				i++;
+				stacktrace << i << "  " << *iter << "\n";
+			}
+
+			auto js_error = ctx.CreateError();
+			js_error.SetProperty("message", ctx.CreateString(message));
+			js_error.SetProperty("nativeStack", ctx.CreateString(stacktrace.str()));
+
 			const auto rsod = ctx.get_global_object().GetProperty("Titanium_RedScreenOfDeath");
 			auto rsod_func = static_cast<JSObject>(rsod);
-			const std::vector<JSValue> args = { what };
+			const std::vector<JSValue> args = { js_error };
 			rsod_func(args, rsod_func);
 		} catch (...) {
 			// Just to make sure we don't throw another exception :(

--- a/Source/TitaniumKit/src/Module.cpp
+++ b/Source/TitaniumKit/src/Module.cpp
@@ -14,6 +14,8 @@
 
 namespace Titanium
 {
+	std::deque<std::string> Module::BackTrace__;
+
 	Module::Module(const JSContext& js_context, const std::string& apiName) TITANIUM_NOEXCEPT
 	    : JSExportObject(js_context)
 	    , apiName__(apiName)


### PR DESCRIPTION
NOT READY FOR MERGE

[TIMOB-26048](https://jira.appcelerator.org/browse/TIMOB-26048)

- Refactor the red-screen of death (crash dialog) with stack traces to match the iOS/Android look and feel.

Note: On Windows we does not provide file name and file number where exception happens because Windows JavaScriptCore does not actually returns detailed information about where it happens. We are just providing the error message and Titanium call stacks here.

```js
var win = Ti.UI.createWindow({ backgroundColor: 'gray' });
win.addEventListener('open', function (e) {
    win.add(null);
});
win.open();
```

Expected: 
![timob-26048](https://user-images.githubusercontent.com/1661068/40479493-a7c8e728-5f86-11e8-9961-3e376c41db89.png)

