### PR TITLE
[TIMOB-26048] Refactor RSOD UI

### DIFF
--- a/Source/TitaniumKit/include/Titanium/Module.hpp
+++ b/Source/TitaniumKit/include/Titanium/Module.hpp
@@ -153,6 +153,7 @@ namespace Titanium
 		// the YAML API docs.
 		static void JSExportInitialize();
 		static void ShowRedScreenOfDeath(const JSContext& js_context, const std::string& message) TITANIUM_NOEXCEPT;
+		static void ShowRedScreenOfDeath(const JSContext& js_context, const HAL::detail::js_runtime_error& ex) TITANIUM_NOEXCEPT;
 
 		TITANIUM_PROPERTY_DEF(bubbleParent);
 		TITANIUM_PROPERTY_READONLY_DEF(apiName);

--- a/Source/TitaniumKit/include/Titanium/detail/TiImpl.hpp
+++ b/Source/TitaniumKit/include/Titanium/detail/TiImpl.hpp
@@ -460,9 +460,7 @@ TITANIUM_PROPERTY_SETTER(MODULE, NAME) { \
 #define TITANIUM_EXCEPTION_CATCH_START try
 #define TITANIUM_EXCEPTION_CATCH_END_CTX(CTX) \
 catch (const HAL::detail::js_runtime_error& ex) { \
-    std::ostringstream os; \
-    os << "Runtime Error: " << ex.js_message(); \
-    Titanium::Module::ShowRedScreenOfDeath(CTX, os.str()); \
+    Titanium::Module::ShowRedScreenOfDeath(CTX, ex); \
 } catch (...) { \
     Titanium::Module::ShowRedScreenOfDeath(CTX, "Unknown Exception"); \
 }

--- a/Source/TitaniumKit/src/Application.cpp
+++ b/Source/TitaniumKit/src/Application.cpp
@@ -32,44 +32,51 @@ function Titanium_RedScreenOfDeath(e) {
 
     try {
         var win = Ti.UI.createWindow({
-                backgroundColor: "#f00",
+                backgroundColor: "#f4f4f4",
                 layout: "vertical"
             }),
-            view,
             button;
 
         function makeMessage(e) {
             return (e.fileName ? "In " + e.fileName + " " : "") + (e.message || e.toString()).trim() + (e.lineNumber ? " (line " + e.lineNumber + " column " + e.columnNumber + ")" : "");
-        } 
-        function makeLabel(text, height, color, fontSize) {
-            var label = Ti.UI.createView({
-                height: height,
-                width: Ti.UI.FILL
-            });
-            label.add(Ti.UI.createLabel({
-                color: color,
-                font: { fontSize: fontSize, fontWeight: "bold" },
-                width:  Ti.UI.FILL,
-                height: Ti.UI.FILL,
-                textAlign: Ti.UI.TEXT_ALIGNMENT_CENTER,
-                text: text
-            }));
-            win.add(label);
         }
 
-        Ti.API.error("----- Titanium Javascript Runtime Error -----");
         Ti.API.error("Message: Uncaught Error: " + makeMessage(e));
+        if (e.nativeStack) {
+            Ti.API.error(e.nativeStack);
+        }
 
-        win.add(view = Ti.UI.createView({ height: "12%" }));
-        makeLabel("Application Error", "15%", "#0f0", "34");
-        makeLabel(makeMessage(e), "45%", "#fff", "26");
-        win.add(view = Ti.UI.createView({ height: "12%" }));
-        view.add(button = Ti.UI.createButton({ title: "Dismiss" }));
+        var label = Ti.UI.createView({
+            height: '90%',
+            width: Ti.UI.FILL,
+            top: 10, left: 10,
+            layout: 'vertical',            
+        });
+        label.add(Ti.UI.createLabel({
+            color: 'red',
+            width:  Ti.UI.FILL,
+            height: Ti.UI.SIZE,
+            textAlign: Ti.UI.TEXT_ALIGNMENT_LEFT,
+            verticalAlign: Ti.UI.TEXT_VERTICAL_ALIGNMENT_TOP,
+            text: makeMessage(e),
+        }));
+        if (e.nativeStack) {
+            label.add(Ti.UI.createView({width: Ti.UI.FILL, height: 20}));
+            label.add(Ti.UI.createLabel({
+                color: 'red',
+                width:  Ti.UI.FILL,
+                height: Ti.UI.SIZE,
+                textAlign: Ti.UI.TEXT_ALIGNMENT_LEFT,
+                verticalAlign: Ti.UI.TEXT_VERTICAL_ALIGNMENT_TOP,
+                text: e.nativeStack,
+            }));
+        }
+        win.add(label);
+
+        win.add(button = Ti.UI.createButton({ title: "CONTINUE", backgroundColor: 'red', width: Ti.UI.FILL, height: '10%', bottom: 0 }));
         button.addEventListener("click", function () {
             win.close();
         });
-
-        makeLabel("Error messages will only be displayed during development. When your app is packaged for final distribution, no error screen will appear. Test your code!", "16%", "#000", "20");
 
         win.open();
     } catch (er) {

--- a/Source/TitaniumKit/src/Application.cpp
+++ b/Source/TitaniumKit/src/Application.cpp
@@ -38,10 +38,23 @@ function Titanium_RedScreenOfDeath(e) {
             button;
 
         function makeMessage(e) {
-            return (e.fileName ? "In " + e.fileName + " " : "") + (e.message || e.toString()).trim() + (e.lineNumber ? " (line " + e.lineNumber + " column " + e.columnNumber + ")" : "");
+            return "Runtime Exception: " + (e.fileName ? "In " + e.fileName + " " : "") + (e.message || e.toString()).trim() + (e.lineNumber ? " (line " + e.lineNumber + " column " + e.columnNumber + ")" : "");
+        }
+        function makeLabel(label, str) {
+            label.add(Ti.UI.createLabel({
+                color: 'red',
+                width:  Ti.UI.FILL,
+                height: Ti.UI.SIZE,
+                textAlign: Ti.UI.TEXT_ALIGNMENT_LEFT,
+                verticalAlign: Ti.UI.TEXT_VERTICAL_ALIGNMENT_TOP,
+                text: str,
+            }));
         }
 
         Ti.API.error("Message: Uncaught Error: " + makeMessage(e));
+        if (e.stack) {
+            Ti.API.error(e.stack);
+        }
         if (e.nativeStack) {
             Ti.API.error(e.nativeStack);
         }
@@ -52,24 +65,14 @@ function Titanium_RedScreenOfDeath(e) {
             top: 10, left: 10,
             layout: 'vertical',            
         });
-        label.add(Ti.UI.createLabel({
-            color: 'red',
-            width:  Ti.UI.FILL,
-            height: Ti.UI.SIZE,
-            textAlign: Ti.UI.TEXT_ALIGNMENT_LEFT,
-            verticalAlign: Ti.UI.TEXT_VERTICAL_ALIGNMENT_TOP,
-            text: makeMessage(e),
-        }));
+        makeLabel(label, makeMessage(e));
+        if (e.stack) {
+            label.add(Ti.UI.createView({width: Ti.UI.FILL, height: 20}));
+            makeLabel(label, e.stack);
+        }
         if (e.nativeStack) {
             label.add(Ti.UI.createView({width: Ti.UI.FILL, height: 20}));
-            label.add(Ti.UI.createLabel({
-                color: 'red',
-                width:  Ti.UI.FILL,
-                height: Ti.UI.SIZE,
-                textAlign: Ti.UI.TEXT_ALIGNMENT_LEFT,
-                verticalAlign: Ti.UI.TEXT_VERTICAL_ALIGNMENT_TOP,
-                text: e.nativeStack,
-            }));
+            makeLabel(label, e.nativeStack);
         }
         win.add(label);
 

--- a/Source/TitaniumKit/src/Application.cpp
+++ b/Source/TitaniumKit/src/Application.cpp
@@ -26,32 +26,33 @@ namespace Titanium
 function Titanium_RedScreenOfDeath(e) {
 
     // We don't want to show RSOD in production mode. re-throw.
-    if (Ti.App.deployType == "production") {
+    if (Ti.App.deployType == 'production') {
         throw e;
     }
 
     try {
         var win = Ti.UI.createWindow({
-                backgroundColor: "#f4f4f4",
-                layout: "vertical"
+                backgroundColor: '#F5F5F5',
+                layout: 'vertical'
             }),
             button;
 
         function makeMessage(e) {
-            return "Runtime Exception: " + (e.fileName ? "In " + e.fileName + " " : "") + (e.message || e.toString()).trim() + (e.lineNumber ? " (line " + e.lineNumber + " column " + e.columnNumber + ")" : "");
+            return 'Runtime Exception: ' + (e.fileName ? 'In ' + e.fileName + ' ' : '') + (e.message || e.toString()).trim() + (e.lineNumber ? ' (line ' + e.lineNumber + ' column ' + e.columnNumber + ')' : '');
         }
         function makeLabel(label, str) {
             label.add(Ti.UI.createLabel({
-                color: 'red',
+                color: '#E53935',
                 width:  Ti.UI.FILL,
                 height: Ti.UI.SIZE,
                 textAlign: Ti.UI.TEXT_ALIGNMENT_LEFT,
                 verticalAlign: Ti.UI.TEXT_VERTICAL_ALIGNMENT_TOP,
+                font: { fontFamily: 'Lucida Console'},
                 text: str,
             }));
         }
 
-        Ti.API.error("Message: Uncaught Error: " + makeMessage(e));
+        Ti.API.error('Message: Uncaught Error: ' + makeMessage(e));
         if (e.stack) {
             Ti.API.error(e.stack);
         }
@@ -76,8 +77,8 @@ function Titanium_RedScreenOfDeath(e) {
         }
         win.add(label);
 
-        win.add(button = Ti.UI.createButton({ title: "CONTINUE", backgroundColor: 'red', width: Ti.UI.FILL, height: '10%', bottom: 0 }));
-        button.addEventListener("click", function () {
+        win.add(button = Ti.UI.createButton({ title: 'CONTINUE', backgroundColor: '#E53935', width: Ti.UI.FILL, height: '10%', bottom: 0 }));
+        button.addEventListener('click', function () {
             win.close();
         });
 

--- a/Source/TitaniumKit/src/GeolocationModule.cpp
+++ b/Source/TitaniumKit/src/GeolocationModule.cpp
@@ -435,7 +435,9 @@ namespace Titanium
 
 	TITANIUM_PROPERTY_SETTER(GeolocationModule, accuracy)
 	{
-		TITANIUM_ASSERT_AND_THROW(argument.IsNumber(), "Ti.Geolocation.accuracy expects Number");
+		if (!argument.IsNumber()) {
+			HAL::detail::ThrowRuntimeError("Invalid argument supplied", "Ti.Geolocation.accuracy expects Number");
+		}
 		const auto accuracy = Titanium::Geolocation::Constants::to_ACCURACY(static_cast<std::underlying_type<Geolocation::ACCURACY>::type>(argument));
 		set_accuracy(accuracy);
 		return true;

--- a/Source/TitaniumKit/src/GeolocationModule.cpp
+++ b/Source/TitaniumKit/src/GeolocationModule.cpp
@@ -435,7 +435,7 @@ namespace Titanium
 
 	TITANIUM_PROPERTY_SETTER(GeolocationModule, accuracy)
 	{
-		TITANIUM_ASSERT(argument.IsNumber());
+		TITANIUM_ASSERT_AND_THROW(argument.IsNumber(), "Ti.Geolocation.accuracy expects Number");
 		const auto accuracy = Titanium::Geolocation::Constants::to_ACCURACY(static_cast<std::underlying_type<Geolocation::ACCURACY>::type>(argument));
 		set_accuracy(accuracy);
 		return true;

--- a/Source/Utility/include/TitaniumWindows/WindowsTiImpl.hpp
+++ b/Source/Utility/include/TitaniumWindows/WindowsTiImpl.hpp
@@ -14,9 +14,7 @@
 
 
 #define TITANIUMWINDOWS_EXCEPTION_SHOW_REDSCREEN(EX, CTX) \
-    std::ostringstream os; \
-    os << "Runtime Error: " << TitaniumWindows::Utility::ConvertString(EX->Message); \
-    Titanium::Module::ShowRedScreenOfDeath(CTX, os.str()); \
+    Titanium::Module::ShowRedScreenOfDeath(CTX, TitaniumWindows::Utility::ConvertString(EX->Message)); \
 
 #define TITANIUMWINDOWS_EXCEPTION_CATCH_END_CTX(CTX) \
 catch (::Platform::Exception^ ex) { \

--- a/tests/Resources/error.test.js
+++ b/tests/Resources/error.test.js
@@ -1,0 +1,87 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-Present by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* eslint-env mocha */
+/* global Ti */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+var should = require('./utilities/assertions'), // eslint-disable-line no-unused-vars
+	utilities = require('./utilities/utilities');
+
+describe('Error', function () {
+	it('JS error thrown', function () {
+		var e = {};
+
+		try {
+			Ti.API.info(e.test.crash);
+			should.fail('Expected to throw exception');
+		} catch (ex) {
+			ex.should.have.property('message').which.is.a.String;
+			if (utilities.isAndroid()) {
+				ex.message.should.equal('Cannot read property \'crash\' of undefined');
+			} else {
+				ex.message.should.equal('undefined is not an object (evaluating \'e.test.crash\')');
+			}
+
+			// has typical stack property
+			ex.should.have.property('stack').which.is.a.String;
+			if (utilities.isAndroid()) {
+				ex.stack.should.containEql('TypeError: Cannot read property \'crash\' of undefined');
+			}
+			// FIXME We should attempt to format the iOS stack to look/feel similar to Android/Node if possible.
+
+			// iOS Has just the stacktrace without a preceding message/type. Also has 'column', 'line', 'sourceURL'
+			// does not have java stack trace
+			ex.should.not.have.property('nativeStack');
+		}
+	});
+
+	it('Native exception surfaced', function () {
+		try {
+			Ti.Geolocation.accuracy = null; // The test assumes this will error out on the native side...
+			should.fail('Expected to throw exception');
+		} catch (ex) {
+			// message property
+			ex.should.have.property('message').which.is.a.String;
+			if (utilities.isAndroid()) {
+				ex.message.should.equal('Unable to convert null');
+			} else if (utilities.isIOS()) {
+				ex.message.should.equal('Invalid type passed to function');
+			} else if (utilities.isWindows()) {
+				ex.message.should.equal('Ti.Geolocation.accuracy expects Number');
+			}
+
+			// has typical stack property for JS
+			ex.should.have.property('stack').which.is.a.String;
+			if (utilities.isAndroid()) {
+				ex.stack.should.containEql('Error: Unable to convert null'); // TODO Verify app.js in stack?
+			}
+			// FIXME iOS just has a horrendous stack, it isn't prefixed by the message or type
+			// We do convert it to look like Android/Node in the error dialog, but can we do that in a lower place?
+			// Looks like this happens under the covers in JSC and I don't see how to affect it.
+
+			// has special nativeStack property for native stacktrace
+			ex.should.have.property('nativeStack').which.is.a.String;
+			if (utilities.isAndroid()) {
+				ex.nativeStack.should.containEql('org.appcelerator.titanium.util.TiConvert.toInt(TiConvert.java:'); // points to Java code in stack
+			} else if (utilities.isIOS()) {
+				ex.nativeStack.should.containEql('-[GeolocationModule setAccuracy:]');
+			}
+		}
+	});
+
+	it('throw(String)', function () {
+		try {
+			throw ('this is my error string'); // eslint-disable-line no-throw-literal
+		} catch (ex) {
+			ex.should.be.a.String;
+			ex.should.equal('this is my error string');
+			ex.should.not.have.property('message');
+			ex.should.not.have.property('stack');
+			ex.should.not.have.property('nativeStack');
+		}
+	});
+});


### PR DESCRIPTION
[TIMOB-26048](https://jira.appcelerator.org/browse/TIMOB-26048)

- Refactor the red-screen of death (crash dialog) with stack traces to match the iOS/Android look and feel.

Note: On Windows we does not provide file name and file number where exception happens because Windows JavaScriptCore does not actually returns detailed information about where it happens. We are just providing the error message and stack traces.

```js
var win = Ti.UI.createWindow({ backgroundColor: 'gray' });
win.addEventListener('open', function (e) {
    win.add(null);
});
win.open();
```

Expected:

![timob-26048](https://user-images.githubusercontent.com/1661068/40714065-8ec59d2e-643c-11e8-9c85-010f02271527.png)

- `add@[native code]` strings are the `stack` value that JavaScriptCore returns.
- `1  JSExportClass<class TitaniumWindows::UI::Window>::add` strings are the `nativeStack` values that represents Titanium module stack traces.

