### PR TITLE
[TIMOB-25986] Add physical pixels support 

### DIFF
--- a/Source/LayoutEngine/include/LayoutEngine/LayoutEngine.hpp
+++ b/Source/LayoutEngine/include/LayoutEngine/LayoutEngine.hpp
@@ -21,6 +21,8 @@ namespace Titanium
 {
 	namespace LayoutEngine
 	{
+		extern double PhysicalPixelsFactor;
+
 		struct Rect
 		{
 			double width = 0;

--- a/Source/LayoutEngine/src/ParseProperty.cpp
+++ b/Source/LayoutEngine/src/ParseProperty.cpp
@@ -16,6 +16,8 @@ namespace Titanium
 {
 	namespace LayoutEngine
 	{
+		double PhysicalPixelsFactor = 1.0;
+
 		enum ValueType _getValueType(const std::string& value)
 		{
 			if (value == "UI.SIZE") {
@@ -41,10 +43,10 @@ namespace Titanium
 			} else if (valueType == Fixed) {
 				if ((value.find("mm") != std::string::npos) || (value.find("cm") != std::string::npos) ||
 				    (value.find("em") != std::string::npos) || (value.find("pt") != std::string::npos) ||
-				    (value.find("pc") != std::string::npos) ||
+				    (value.find("pc") != std::string::npos) || (value.find("ppx") != std::string::npos) ||
 				    (value.find("in") != std::string::npos) || (value.find("px") != std::string::npos) ||
 				    (value.find("dp") != std::string::npos) || (value.find("dip") != std::string::npos)) {
-					if ((value.find("dip") != std::string::npos)) {
+					if ((value.find("dip") != std::string::npos) || (value.find("ppx") != std::string::npos)) {
 						units = value.substr(value.size() - 3, 3);
 						parsedValue = atof(value.substr(0, value.size() - 3).c_str());
 					} else {
@@ -70,6 +72,8 @@ namespace Titanium
 					return parsedValue; // px is our base value
 				} else if (units == "dp" || units == "dip") { 
 					return (parsedValue * ppi) / 160.0; // px = device independent pixels * pixels/inch / 160, see https://www.google.com/design/spec/layout/units-measurements.html#units-measurements-designing-layouts-for-dp
+				} else if (units == "ppx") {
+					return parsedValue / PhysicalPixelsFactor;
 				}
 			}
 			return 0;

--- a/Source/Titanium/src/TitaniumWindows.cpp
+++ b/Source/Titanium/src/TitaniumWindows.cpp
@@ -71,6 +71,7 @@
 #include "TitaniumWindows/GlobalString.hpp"
 #include "TitaniumWindows/Utility.hpp"
 #include "Titanium/detail/TiImpl.hpp"
+#include "LayoutEngine/LayoutEngine.hpp"
 
 #include <Windows.h>
 #include <collection.h>

--- a/Source/TitaniumKit/include/Titanium/App.hpp
+++ b/Source/TitaniumKit/include/Titanium/App.hpp
@@ -56,8 +56,6 @@ namespace Titanium
 		*/
 		virtual std::string copyright() const TITANIUM_NOEXCEPT;
 
-		std::string defaultUnit() TITANIUM_NOEXCEPT;
-
 		/*!
 		  @property
 		  @abstract deployType
@@ -247,7 +245,6 @@ namespace Titanium
 		bool accessibilityEnabled__;
 		bool analytics__;
 		std::string copyright__;
-		std::string defaultUnit__;
 		std::string deployType__;
 		std::string description__;
 		bool disableNetworkActivityIndicator__;

--- a/Source/TitaniumKit/include/Titanium/UI/ViewLayoutDelegate.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/ViewLayoutDelegate.hpp
@@ -619,9 +619,12 @@ namespace Titanium
 			ViewLayoutDelegate() TITANIUM_NOEXCEPT;
 			virtual ~ViewLayoutDelegate();
 
+			static std::string GetDefaultUnit(const JSContext& js_context) TITANIUM_NOEXCEPT;
 		protected:
 #pragma warning(push)
 #pragma warning(disable : 4251)
+			static std::string DefaultUnit__;
+
 			std::shared_ptr<View> parent__;
 			std::vector<std::shared_ptr<View>> children__;
 			std::string backgroundImage__;

--- a/Source/TitaniumKit/src/App.cpp
+++ b/Source/TitaniumKit/src/App.cpp
@@ -62,7 +62,6 @@ namespace Titanium
 		accessibilityEnabled__(false),
 		analytics__(false),
 		copyright__("__COPYRIGHT__"),
-		defaultUnit__(""),
 		deployType__("__DEPLOY_TYPE__"),
 		description__("__DESCRIPTION__"),
 		disableNetworkActivityIndicator__(false),
@@ -130,36 +129,6 @@ namespace Titanium
 	std::string AppModule::copyright() const TITANIUM_NOEXCEPT
 	{
 		return copyright__;
-	}
-
-	std::string AppModule::defaultUnit() TITANIUM_NOEXCEPT
-	{
-		if (defaultUnit__.empty()) {
-			JSObject App = GetStaticObject(get_context());
-
-			JSValue Properties_property = App.GetProperty("Properties");
-			TITANIUM_ASSERT(Properties_property.IsObject());  // precondition
-			JSObject Properties = static_cast<JSObject>(Properties_property);
-
-			auto props = Properties.GetPrivate<::Titanium::App::Properties>();
-			auto defaultUnit = props->getString("ti.ui.defaultunit", boost::optional<std::string>("px"));
-
-			if (!defaultUnit || *defaultUnit == "system")
-			{
-				defaultUnit__ = "px";
-			}
-			// Validate that unit is one of our set of known units!
-			// FIXME Some platforms allow other units. See "sp" and "sip" for Android
-			if (defaultUnit__ != "mm" && defaultUnit__ != "cm" &&
-				defaultUnit__ != "em" && defaultUnit__ != "pt" &&
-				defaultUnit__ != "pc" && defaultUnit__ != "in" &&
-				defaultUnit__ != "px" && defaultUnit__ != "dp" &&
-				defaultUnit__ != "dip")
-			{
-				defaultUnit__ = "px";
-			}
-		}
-		return defaultUnit__;
 	}
 
 	std::string AppModule::deployType() const TITANIUM_NOEXCEPT

--- a/Source/UI/src/ActivityIndicator.cpp
+++ b/Source/UI/src/ActivityIndicator.cpp
@@ -91,8 +91,9 @@ namespace TitaniumWindows
 		void ActivityIndicator::set_indicatorDiameter(const std::string& diameter) TITANIUM_NOEXCEPT
 		{
 			Titanium::UI::ActivityIndicator::set_indicatorDiameter(diameter);
+			const auto defaultUnit = Titanium::UI::ViewLayoutDelegate::GetDefaultUnit(get_context());
 			const auto ppi = TitaniumWindows::UI::WindowsViewLayoutDelegate::ComputePPI(Titanium::LayoutEngine::ValueName::Width);
-			const auto value = Titanium::LayoutEngine::parseUnitValue(diameter, Titanium::LayoutEngine::ValueType::Fixed, ppi, "px");
+			const auto value = Titanium::LayoutEngine::parseUnitValue(diameter, Titanium::LayoutEngine::ValueType::Fixed, ppi, defaultUnit);
 			ring__->Width  = value;
 			ring__->Height = value;
 		}

--- a/Source/UI/src/Label.cpp
+++ b/Source/UI/src/Label.cpp
@@ -90,7 +90,8 @@ namespace TitaniumWindows
 								}
 								if (!layout->get_right().empty()) {
 									const auto ppi = WindowsViewLayoutDelegate::ComputePPI(Titanium::LayoutEngine::ValueName::Width);
-									const auto rightPadding = Titanium::LayoutEngine::parseUnitValue(layout->get_right(), Titanium::LayoutEngine::ValueType::Fixed, ppi, "px");
+									const auto defaultUnit = Titanium::UI::ViewLayoutDelegate::GetDefaultUnit(get_context());
+									const auto rightPadding = Titanium::LayoutEngine::parseUnitValue(layout->get_right(), Titanium::LayoutEngine::ValueType::Fixed, ppi, defaultUnit);
 									if (width > rightPadding) {
 										label__->MaxWidth -= rightPadding;
 									}
@@ -101,8 +102,9 @@ namespace TitaniumWindows
 									label__->MaxHeight = height;
 								}
 								if (!layout->get_bottom().empty()) {
+									const auto defaultUnit = Titanium::UI::ViewLayoutDelegate::GetDefaultUnit(get_context());
 									const auto ppi = WindowsViewLayoutDelegate::ComputePPI(Titanium::LayoutEngine::ValueName::Height);
-									const auto bottomPadding = Titanium::LayoutEngine::parseUnitValue(layout->get_height(), Titanium::LayoutEngine::ValueType::Fixed, ppi, "px");
+									const auto bottomPadding = Titanium::LayoutEngine::parseUnitValue(layout->get_height(), Titanium::LayoutEngine::ValueType::Fixed, ppi, defaultUnit);
 									if (height > bottomPadding) {
 										label__->MaxHeight -= bottomPadding;
 									}

--- a/Source/UI/src/ProgressBar.cpp
+++ b/Source/UI/src/ProgressBar.cpp
@@ -44,7 +44,10 @@ namespace TitaniumWindows
 
 			// set margin to the progress bar to make both border and bar shown.
 			auto margin = bar__->Margin;
-			margin.Bottom = Titanium::LayoutEngine::parseUnitValue(borderWidth, Titanium::LayoutEngine::ValueType::Fixed, WindowsViewLayoutDelegate::ComputePPI(Titanium::LayoutEngine::ValueName::Width), "px") * 2;
+			auto event_delegate = event_delegate__.lock();
+			TITANIUM_ASSERT(event_delegate != nullptr);
+			const auto defaultUnit = Titanium::UI::ViewLayoutDelegate::GetDefaultUnit(event_delegate->get_context());
+			margin.Bottom = Titanium::LayoutEngine::parseUnitValue(borderWidth, Titanium::LayoutEngine::ValueType::Fixed, WindowsViewLayoutDelegate::ComputePPI(Titanium::LayoutEngine::ValueName::Width), defaultUnit) * 2;
 			bar__->Margin = margin;
 		}
 

--- a/Source/UI/src/Window.cpp
+++ b/Source/UI/src/Window.cpp
@@ -334,11 +334,14 @@ namespace TitaniumWindows
 			float width  = currentBounds.Width;
 			float height = currentBounds.Height;
 
-			if (!strWidth.empty() && std::all_of(strWidth.begin(), strWidth.end(), ::isdigit)) {
-				width = std::stof(strWidth);
+			const auto defaultUnit = Titanium::UI::ViewLayoutDelegate::GetDefaultUnit(get_context());
+			const auto ppi = TitaniumWindows::UI::WindowsViewLayoutDelegate::ComputePPI(Titanium::LayoutEngine::ValueName::Width);
+
+			if (!strWidth.empty()) {
+				width = static_cast<float>(Titanium::LayoutEngine::parseUnitValue(strWidth, Titanium::LayoutEngine::ValueType::Fixed, ppi, defaultUnit));
 			}
-			if (!strHeight.empty() && std::all_of(strHeight.begin(), strHeight.end(), ::isdigit)) {
-				height = std::stof(strHeight);
+			if (!strHeight.empty()) {
+				height = static_cast<float>(Titanium::LayoutEngine::parseUnitValue(strHeight, Titanium::LayoutEngine::ValueType::Fixed, ppi, defaultUnit));
 			}
 
 			// TryResizeView returns false when given size is too small/big. We don't have a way to get valid range here unfortunately.

--- a/Source/UI/src/Windows/ViewHelper.cpp
+++ b/Source/UI/src/Windows/ViewHelper.cpp
@@ -40,8 +40,9 @@ namespace TitaniumWindows
 					}
 				}
 				if (font.fontSize.length() > 0) {
+					const auto defaultUnit = Titanium::UI::ViewLayoutDelegate::GetDefaultUnit(js_context);
 					const auto ppi = TitaniumWindows::UI::WindowsViewLayoutDelegate::ComputePPI(Titanium::LayoutEngine::ValueName::Width);
-					component->FontSize = Titanium::LayoutEngine::parseUnitValue(font.fontSize, Titanium::LayoutEngine::ValueType::Fixed, ppi, "px");
+					component->FontSize = Titanium::LayoutEngine::parseUnitValue(font.fontSize, Titanium::LayoutEngine::ValueType::Fixed, ppi, defaultUnit);
 				}
 
 				if (font.fontStyle == Titanium::UI::FONT_STYLE::ITALIC) {


### PR DESCRIPTION
EXPERIMENTAL FEATURE

[TIMOB-25986](https://jira.appcelerator.org/browse/TIMOB-25986)

Introduce new unit specifier `ppx` to give ability to layout with physical pixels on Windows.

## Background

On Windows, the default unit specifier `px` is used as _effective pixels_, not actual physical pixels. Effective pixels are a virtual unit of measurement, and they're used to express layout dimensions and spacing, independent of screen density. (See [Introduction to UWP app design](https://docs.microsoft.com/en-us/windows/uwp/design/basics/design-and-ui-intro) for details). So when Microsoft uses the term "pixels" it doesn't mean actual physical pixels and that's why Titanium is using this effective pixels when you use "px" unit specifier. 

In order to support layout with actual physical pixels, we are introducing new unit specifier `ppx` (physical pixels) that is specific to Windows.

## Use Cases

Easiest way to deal with physical pixels is setting `ppx` for `i.ui.defaultunit` property in `tiapp.xml`. In this case layout will be done with physical pixels.

```xml
  <property name="ti.ui.defaultunit" type="string">ppx</property>
```

```js
var win = Ti.UI.createWindow({
    width: 1920, height: 1400, backgroundColor: 'red'
});

var view = Ti.UI.createView({
    width: 1916, height: 1396, backgroundColor: 'white'
});

win.add(view);
win.open();
```

You can also specify unit specifier explicitly.

```js
var win = Ti.UI.createWindow({
    width: `1920ppx`, height: `1400ppx`, backgroundColor: 'red'
});

var view = Ti.UI.createView({
    width: `1916ppx`, height: `1396ppx`, backgroundColor: 'white'
});

win.add(view);
win.open();
```
