### PR TITLE
[TIMOB-26152] ScrollView doesn't return correct event source

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/ScrollView.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/ScrollView.hpp
@@ -32,7 +32,7 @@ namespace TitaniumWindows
 			virtual void removeAllChildren() TITANIUM_NOEXCEPT override;
 			virtual void set_layout(const std::string& layout) TITANIUM_NOEXCEPT override;
 			virtual void requestLayout(const bool& fire_event = false) override;
-
+			virtual std::shared_ptr<Titanium::UI::View> sourceTest(::Platform::Object ^, const std::shared_ptr<Titanium::UI::View>& root = nullptr) override;
 		protected:
 #pragma warning(push)
 #pragma warning(disable : 4251)

--- a/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
@@ -575,6 +575,8 @@ namespace TitaniumWindows
 			virtual void fireSimplePositionEvent(const std::string& event_name, Windows::Foundation::Point position, ::Platform::Object^ originalSource);
 			virtual void firePostLayoutEvent();
 
+			virtual std::shared_ptr<Titanium::UI::View> sourceTest(::Platform::Object ^ originalSource, const std::shared_ptr<Titanium::UI::View>& root = nullptr);
+
 			static Windows::UI::Xaml::Media::ImageBrush^ CreateImageBrushFromPath(const std::string& path);
 			static Windows::UI::Xaml::Media::ImageBrush^ CreateImageBrushFromBitmapImage(Windows::UI::Xaml::Media::Imaging::BitmapImage^ image);
 			static Windows::UI::Xaml::Media::ImageBrush^ CreateImageBrushFromBlob(const std::shared_ptr<Titanium::Blob>& blob);
@@ -653,8 +655,6 @@ namespace TitaniumWindows
 			Windows::UI::Xaml::Media::Brush^ previousBackgroundBrush__{ nullptr };
 
 			Windows::UI::Xaml::Media::LinearGradientBrush^ backgroundLinearGradientBrush__{ nullptr };
-
-			std::shared_ptr<Titanium::UI::View> sourceTest(::Platform::Object^ originalSource, const std::shared_ptr<Titanium::UI::View>& root = nullptr);
 #pragma warning(pop)
 
 		};

--- a/Source/UI/src/ScrollView.cpp
+++ b/Source/UI/src/ScrollView.cpp
@@ -41,6 +41,26 @@ namespace TitaniumWindows
 
 			contentView__.GetPrivate<View>()->getViewLayoutDelegate<WindowsViewLayoutDelegate>()->requestLayout(fire_event);
 		}
+		std::shared_ptr<Titanium::UI::View> ScrollViewLayoutDelegate::sourceTest(::Platform::Object ^ source, const std::shared_ptr<Titanium::UI::View>& root)
+		{
+			const auto sender = WindowsViewLayoutDelegate::sourceTest(source, root);
+			if (sender) {
+				return sender;
+			}
+
+			// ScrollViewer may return one of its child components for click event
+			const auto grid = dynamic_cast<Controls::Grid ^>(source);
+			if (grid) {
+				for (unsigned int i = 0; i < grid->Children->Size; i++) {
+					if (dynamic_cast<Controls::ScrollContentPresenter ^>(grid->Children->GetAt(i))) {
+						return root;
+					}				
+				}
+			}
+
+			return nullptr;
+		}
+
 
 		
 		void ScrollViewLayoutDelegate::add(const std::shared_ptr<Titanium::UI::View>& view) TITANIUM_NOEXCEPT


### PR DESCRIPTION
[TIMOB-26152](https://jira.appcelerator.org/browse/TIMOB-26152)

ScrollView doesn't return correct source when event listener is added to the scroll view's parent and there's no child view underneath of scroll view.

```js
var win = Ti.UI.createWindow({
    backgroundColor: 'green',
    width: 800,
    height: 600
});

var view = Ti.UI.createView({
    backgroundColor: 'red',
    width: '80%',
    height: '80%',
    id: 'view'
}),
    view2 = Ti.UI.createScrollView({
        width: '70%', height: '70%', backgroundColor: 'blue', id: 'view2'
    }),
    view3 = Ti.UI.createView({
        width: '70%', height: '70%', backgroundColor: 'pink', id: 'view3'
    });

view2.add(view3);
view.add(view2);

view.addEventListener('click', function (e) {
    alert(e.source.id);
});

win.add(view);
win.open();
```

Expected: Clicking blue view should show "view2". Clicking pink view should show "view3".