### PR TITLE
[TIMOB-26158] Fix resourcesDir path

### DIFF
--- a/cli/commands/_build/copy.js
+++ b/cli/commands/_build/copy.js
@@ -663,7 +663,7 @@ function copyResources(next) {
 								targets: {
 									safari: '10' // matches the version of jscore we use
 								},
-								resourcesDir: path.join(this.buildDir, 'Assets')
+								resourcesDir: this.buildTargetAssetsDir
 							});
 							const newContents = r.contents;
 

--- a/cli/commands/_build/copy.js
+++ b/cli/commands/_build/copy.js
@@ -663,7 +663,7 @@ function copyResources(next) {
 								targets: {
 									safari: '10' // matches the version of jscore we use
 								},
-								resourcesDir: path.join(this.buildDir, 'bin', 'assets', 'Resources')
+								resourcesDir: path.join(this.buildDir, 'Assets')
 							});
 							const newContents = r.contents;
 


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-26158

- `<buildDir>/bin/assets/Resources` does not exist on Windows. `<buildDir>/Assets` is I believe the correct path

Test steps

- Enable transpilation in your tiapp, `<transpile>true</transpile>`
- Build the project