### PR TITLE
[TIMOB-26175] Label.text is ignored in ListView template

### DIFF
--- a/Source/TitaniumKit/src/UI/listview.js
+++ b/Source/TitaniumKit/src/UI/listview.js
@@ -169,7 +169,7 @@ function createSectionItemView(listview, section, item, sectionIndex, itemIndex,
 			item.properties.height = Ti.UI.SIZE;
 		}
 		// builtin template has different format
-		if (template.type == 'Ti.UI.Label') {
+		if (template.type == 'Ti.UI.Label' && item.properties.title) {
 			item.properties.text = item.properties.title;
 			view.applyProperties(item.properties);
 		} else {


### PR DESCRIPTION
[TIMOB-26175](https://jira.appcelerator.org/browse/TIMOB-26175)

Label.text is ignored in ListView template

```js
var win = Ti.UI.createWindow({ backgroundColor: 'white' });

var myTemplate = {
    childTemplates: [
        {
            type: 'Ti.UI.Label',
            properties: {
                color: 'blue',
                left: 10, top: 0,
                text: 'OMG :)'
            }
        },
        {
            type: 'Ti.UI.Label',
            bindId: 'info',
            properties: {
                color: 'black',
                left: 100, top: 0,
            }
        },
    ]
};

var listView = Ti.UI.createListView({
    templates: { 'template': myTemplate },
    defaultItemTemplate: 'template'
});
var sections = [];

var fruitSection = Ti.UI.createListSection({ headerTitle: 'Fruits / Frutas' });
var fruitDataSet = [
    { info: { text: 'Apple' } },
    { info: { text: 'Banana' } }
];
fruitSection.setItems(fruitDataSet);
sections.push(fruitSection);

var vegSection = Ti.UI.createListSection({ headerTitle: 'Vegetables / Verduras' });
var vegDataSet = [
    { info: { text: 'Carrot' } },
    { info: { text: 'Potato' } }
];
vegSection.setItems(vegDataSet);
sections.push(vegSection);

var grainSection = Ti.UI.createListSection({ headerTitle: 'Grains / Granos' });
var grainDataSet = [
    { info: { text: 'Corn' } },
    { info: { text: 'Rice' } }
];
grainSection.setItems(grainDataSet);
sections.push(grainSection);

listView.setSections(sections);
win.add(listView);
win.open();
```

Expected: `OMG :)` string should be shown in the list item.
