### PR TITLE
[TIMOB-26115] Implement console.timeLog

### DIFF
--- a/Source/TitaniumKit/src/TiModule.cpp
+++ b/Source/TitaniumKit/src/TiModule.cpp
@@ -495,30 +495,38 @@ namespace Titanium
 				console.warn  = Ti.API.warn;
 				console.error = Ti.API.error;
 				console.debug = Ti.API.debug;
-				console.time = function (label) {
+				console.time = function (label = 'default') {
 					if (console._times[label]) {
-						console.warn('Label "' + label + '" already exists');
+						console.warn(`Label ${label} already exists`);
 						return;
-					}
-					if (!label) {
-						label = 'default';
 					}
 					console._times[label] = Date.now();
 				};
-				console.timeEnd = function (label) {
-					if (!label) {
-						label = 'default';
+				console.timeEnd = function (label = 'default') {
+					const warned = logTime(label);
+					if (!warned) {
+						delete console._times[label];
 					}
-					var startTime = console._times[label];
-					if (!startTime) {
-						console.warn('Label "' + label + '" does not exist');
-						return;
-					}
-					var duration = Date.now() - startTime;
-					console.log(label + ': ' + duration + 'ms');
-					delete console._times[label];
 				};
-			
+				
+				console.timeLog = function (label = 'default', ...logData) {
+					logTime(label, logData);
+				}
+
+				function logTime(label , logData) {
+					const startTime = console._times[label];
+					if (!startTime) {
+						console.warn(`Label "${label}" does not exist`);
+						return true;
+					}
+					const duration = Date.now() - startTime;
+					if (logData) {
+						console.log(`${label}: ${duration}ms`, ...logData);
+					} else {
+						console.log(`${label}: ${duration}ms`);
+					}
+					return false;
+				}
 
 				// Create the global alert function
 				alert = function (_msg) {


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-26115

Implement console.timeLog for Windows.

I've also cleaned up and aligned some of the code with Android as while looking to see if our JSCore version supported rest params (it does), that it supports default arguments.


Test:

```js
console.time('mytimer'); // Start timer
console.timeLog('mytimer'); // Log time taken so far
console.timeLog('mytimer', 'with', 'some', 'extra', 'info'); // Log time taken with extra logging
console.timeLog('mytimer', [ 'a', 'b', 'c' ], { objects: true }); // Should handle Arrays and Objects
console.timeEnd('mytimer');
```
Should log something like the below, there's some slight discrepancies between how Arrays/Objects are logged on platforms. Windows for example doesn't log an Objects properties, but logs  [object Object] (this may be something we wish to fix)
```
[INFO]  mytimer: 1ms
[INFO]  mytimer: 2ms with some extra info
[INFO]  mytimer: 3ms ["a","b","c"] {"objects":true}
[INFO]  mytimer: 3ms
```