### PR TITLE
[TIMOB-26139] Fix build issue on phone device

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 	"vendorDependencies": {
 		"visual studio": ">=12.x <=14.x",
 		"windows phone sdk": "10.0",
-		"windows 10 sdk": ">=10.0.10240.0 <=10.0.15063.0",
+		"windows 10 sdk": ">=10.0.10240.0 <=10.0.17134.0",
 		"msbuild": ">=4.0",
 		"node": ">=0.10.0 <=0.12.x",
 		"java": ">=1.8.x"


### PR DESCRIPTION
[TIMOB-26139](https://jira.appcelerator.org/browse/TIMOB-26139)

I'm still not sure why Windows 10 SDK `10.0.15063.0` goes broken after installing latest Windows 10 SDK `10.0.17134.0`, but just bumping up the highest compatible target version fixes issue for me. I didn't have to uninstall `10.0.15063.0` SDK to make deployment work.
