### PR TITLE
[TIMOB-25934] Attempt to implement TextField.hintTextColor

### DIFF
--- a/Source/TitaniumKit/include/Titanium/UI/TextArea.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/TextArea.hpp
@@ -150,6 +150,13 @@ namespace Titanium
 
 			/*!
 			  @property
+			  @abstract hintTextColor
+			  @discussion Color of hint text that displays when field is empty.
+			*/
+			TITANIUM_PROPERTY_IMPL_DEF(std::string, hintTextColor);
+
+			/*!
+			  @property
 			  @abstract handleLinks
 			  @discussion Specifies if the text area should allow user interaction with the given URL in the given range of text.
 			*/
@@ -300,6 +307,7 @@ namespace Titanium
 			TITANIUM_PROPERTY_DEF(enableReturnKey);
 			TITANIUM_PROPERTY_DEF(font);
 			TITANIUM_PROPERTY_DEF(hintText);
+			TITANIUM_PROPERTY_DEF(hintTextColor);
 			TITANIUM_PROPERTY_DEF(handleLinks);
 			TITANIUM_PROPERTY_DEF(keyboardToolbar);
 			TITANIUM_PROPERTY_DEF(keyboardToolbarColor);
@@ -344,6 +352,8 @@ namespace Titanium
 			TITANIUM_FUNCTION_DEF(setFont);
 			TITANIUM_FUNCTION_DEF(getHintText);
 			TITANIUM_FUNCTION_DEF(setHintText);
+			TITANIUM_FUNCTION_DEF(getHintTextColor);
+			TITANIUM_FUNCTION_DEF(setHintTextColor);
 			TITANIUM_FUNCTION_DEF(getHandleLinks);
 			TITANIUM_FUNCTION_DEF(setHandleLinks);
 			TITANIUM_FUNCTION_DEF(getKeyboardToolbar);
@@ -389,6 +399,7 @@ namespace Titanium
 			bool enableReturnKey__;
 			Font font__;
 			std::string hintText__;
+			std::string hintTextColor__;
 			bool handleLinks__;
 			JSValue keyboardToolbar__;
 			std::string keyboardToolbarColor__;

--- a/Source/TitaniumKit/include/Titanium/UI/TextField.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/TextField.hpp
@@ -141,26 +141,25 @@ namespace Titanium
 			TITANIUM_PROPERTY_IMPL_DEF(Font, font);
 
 			/*!
-			@method
-
-			@abstract hinttextid : String
-
-			@discussion Key identifying a string from the locale file to use for the TextField hintText.
-
+			  @method
+			  @abstract hinttextid : String
+			  @discussion Key identifying a string from the locale file to use for the TextField hintText.
 			*/
 			TITANIUM_PROPERTY_IMPL_DEF(std::string, hinttextid);
 
 			/*!
 			  @method
+			  @abstract hintTextColor : String
+			  @discussion Hint text color to display when the field is empty.
+			*/
+			TITANIUM_PROPERTY_IMPL_DEF(std::string, hintTextColor);
 
+			/*!
+			  @method
 			  @abstract hintText : String
-
 			  @discussion Hint text to display when the field is empty.
-
 			  Hint text is hidden when the user enters text into this text field.
-
 			  Use the backslash and letter n line feed character combination, ie \n, to force a new line.
-
 			  Use unicode characters, such as those included in (but not limited to) the Unicode List of Useful Symbols section of wikipedia, to insert special characters and symbols.
 			*/
 			TITANIUM_PROPERTY_IMPL_DEF(std::string, hintText);
@@ -364,6 +363,10 @@ namespace Titanium
 			TITANIUM_FUNCTION_DEF(getHintText);
 			TITANIUM_FUNCTION_DEF(setHintText);
 
+			TITANIUM_PROPERTY_DEF(hintTextColor);
+			TITANIUM_FUNCTION_DEF(getHintTextColor);
+			TITANIUM_FUNCTION_DEF(setHintTextColor);
+
 			TITANIUM_PROPERTY_DEF(keyboardType);
 			TITANIUM_FUNCTION_DEF(getKeyboardType);
 			TITANIUM_FUNCTION_DEF(setKeyboardType);
@@ -429,6 +432,7 @@ namespace Titanium
 			Font font__;
 			std::string hinttextid__;
 			std::string hintText__;
+			std::string hintTextColor__;
 			KEYBOARD keyboardType__;
 			INPUT_BUTTONMODE leftButtonMode__;
 			int32_t maxLength__;

--- a/Source/TitaniumKit/src/UI/TextArea.cpp
+++ b/Source/TitaniumKit/src/UI/TextArea.cpp
@@ -69,14 +69,11 @@ namespace Titanium
 			autocorrect__(false),
 			autoLink__({AUTOLINK::NONE}),
 			clearOnEdit__(false),
-			color__(""),
 			editable__(true),
 			ellipsize__(false),
 			enableReturnKey__(false),
-			hintText__(""),
 			handleLinks__(false),
 			keyboardToolbar__(js_context.CreateUndefined()),
-			keyboardToolbarColor__(""),
 			keyboardToolbarHeight__(0),
 			keyboardType__(KEYBOARD::DEFAULT),
 			maxLength__(-1),
@@ -85,7 +82,6 @@ namespace Titanium
 			suppressReturn__(false),
 			scrollable__(true),
 			textAlign__(TEXT_ALIGNMENT::LEFT),
-			value__(""),
 			verticalAlign__(TEXT_VERTICAL_ALIGNMENT::CENTER)
 		{
 		}
@@ -101,6 +97,7 @@ namespace Titanium
 		TITANIUM_PROPERTY_READWRITE(TextArea, bool, enableReturnKey)
 		TITANIUM_PROPERTY_READWRITE(TextArea, Font, font)
 		TITANIUM_PROPERTY_READWRITE(TextArea, std::string, hintText)
+		TITANIUM_PROPERTY_READWRITE(TextArea, std::string, hintTextColor)
 		TITANIUM_PROPERTY_READWRITE(TextArea, bool, handleLinks)
 		TITANIUM_PROPERTY_READWRITE(TextArea, JSValue, keyboardToolbar)
 		TITANIUM_PROPERTY_READWRITE(TextArea, std::string, keyboardToolbarColor)
@@ -157,6 +154,7 @@ namespace Titanium
 			TITANIUM_ADD_PROPERTY(TextArea, enableReturnKey);
 			TITANIUM_ADD_PROPERTY(TextArea, font);
 			TITANIUM_ADD_PROPERTY(TextArea, hintText);
+			TITANIUM_ADD_PROPERTY(TextArea, hintTextColor);
 			TITANIUM_ADD_PROPERTY(TextArea, handleLinks);
 			TITANIUM_ADD_PROPERTY(TextArea, keyboardToolbar);
 			TITANIUM_ADD_PROPERTY(TextArea, keyboardToolbarColor);
@@ -200,6 +198,8 @@ namespace Titanium
 			TITANIUM_ADD_FUNCTION(TextArea, setFont);
 			TITANIUM_ADD_FUNCTION(TextArea, getHintText);
 			TITANIUM_ADD_FUNCTION(TextArea, setHintText);
+			TITANIUM_ADD_FUNCTION(TextArea, getHintTextColor);
+			TITANIUM_ADD_FUNCTION(TextArea, setHintTextColor);
 			TITANIUM_ADD_FUNCTION(TextArea, getHandleLinks);
 			TITANIUM_ADD_FUNCTION(TextArea, setHandleLinks);
 			TITANIUM_ADD_FUNCTION(TextArea, getKeyboardToolbar);
@@ -299,6 +299,9 @@ namespace Titanium
 
 		TITANIUM_PROPERTY_GETTER_STRING(TextArea, hintText)
 		TITANIUM_PROPERTY_SETTER_STRING(TextArea, hintText)
+
+		TITANIUM_PROPERTY_GETTER_STRING(TextArea, hintTextColor)
+		TITANIUM_PROPERTY_SETTER_STRING(TextArea, hintTextColor)
 
 		TITANIUM_PROPERTY_GETTER_BOOL(TextArea, handleLinks)
 		TITANIUM_PROPERTY_SETTER_BOOL(TextArea, handleLinks)
@@ -461,6 +464,9 @@ namespace Titanium
 
 		TITANIUM_FUNCTION_AS_GETTER(TextArea, getHintText, hintText)
 		TITANIUM_FUNCTION_AS_SETTER(TextArea, setHintText, hintText)
+
+		TITANIUM_FUNCTION_AS_GETTER(TextArea, getHintTextColor, hintTextColor)
+		TITANIUM_FUNCTION_AS_SETTER(TextArea, setHintTextColor, hintTextColor)
 
 		TITANIUM_FUNCTION_AS_GETTER(TextArea, getHandleLinks, handleLinks)
 		TITANIUM_FUNCTION_AS_SETTER(TextArea, setHandleLinks, handleLinks)

--- a/Source/TitaniumKit/src/UI/TextField.cpp
+++ b/Source/TitaniumKit/src/UI/TextField.cpp
@@ -50,18 +50,15 @@ namespace Titanium
 		      autocapitalization__(TEXT_AUTOCAPITALIZATION::NONE),
 		      borderStyle__(INPUT_BORDERSTYLE::NONE),
 		      clearButtonMode__(INPUT_BUTTONMODE::NEVER),
-			  color__(js_context.CreateString()),
-			  editable__(js_context.CreateBoolean(true)),
-			  ellipsize__(js_context.CreateBoolean(false)),
-			  hintText__(js_context.CreateString()),
-		      leftButtonMode__(INPUT_BUTTONMODE::NEVER),
-			  maxLength__(js_context.CreateNumber(-1)),
-			  passwordMask__(js_context.CreateBoolean(false)),
+			  editable__(true),
+			  ellipsize__(false),
+			  leftButtonMode__(INPUT_BUTTONMODE::NEVER),
+			  maxLength__(-1),
+			  passwordMask__(false),
 		      returnKeyType__(RETURNKEY::DEFAULT),
 		      rightButtonMode__(INPUT_BUTTONMODE::NEVER),
-			  suppressReturn__(js_context.CreateBoolean(false)),
+			  suppressReturn__(false),
 		      textAlign__(TEXT_ALIGNMENT::LEFT),
-			  value__(js_context.CreateString()),
 		      verticalAlign__(TEXT_VERTICAL_ALIGNMENT::CENTER)
 		{
 		}
@@ -75,6 +72,7 @@ namespace Titanium
 		TITANIUM_PROPERTY_READWRITE(TextField, bool, enableReturnKey)
 		TITANIUM_PROPERTY_READWRITE(TextField, Font, font)
 		TITANIUM_PROPERTY_READWRITE(TextField, std::string, hintText)
+		TITANIUM_PROPERTY_READWRITE(TextField, std::string, hintTextColor)
 		TITANIUM_PROPERTY_READWRITE(TextField, KEYBOARD, keyboardType)
 		TITANIUM_PROPERTY_READWRITE(TextField, INPUT_BUTTONMODE, leftButtonMode)
 		TITANIUM_PROPERTY_READWRITE(TextField, int32_t, maxLength)
@@ -127,6 +125,7 @@ namespace Titanium
 			TITANIUM_ADD_PROPERTY(TextField, font);
 			TITANIUM_ADD_PROPERTY(TextField, hinttextid);
 			TITANIUM_ADD_PROPERTY(TextField, hintText);
+			TITANIUM_ADD_PROPERTY(TextField, hintTextColor);
 			TITANIUM_ADD_PROPERTY(TextField, keyboardType);
 			TITANIUM_ADD_PROPERTY(TextField, leftButtonMode);
 			TITANIUM_ADD_PROPERTY(TextField, maxLength);
@@ -168,6 +167,8 @@ namespace Titanium
 			TITANIUM_ADD_FUNCTION(TextField, setHinttextid);
 			TITANIUM_ADD_FUNCTION(TextField, getHintText);
 			TITANIUM_ADD_FUNCTION(TextField, setHintText);
+			TITANIUM_ADD_FUNCTION(TextField, getHintTextColor);
+			TITANIUM_ADD_FUNCTION(TextField, setHintTextColor);
 			TITANIUM_ADD_FUNCTION(TextField, getKeyboardType);
 			TITANIUM_ADD_FUNCTION(TextField, setKeyboardType);
 			TITANIUM_ADD_FUNCTION(TextField, getLeftButtonMode);
@@ -306,6 +307,12 @@ namespace Titanium
 
 		TITANIUM_FUNCTION_AS_GETTER(TextField, getHintText, hintText)
 		TITANIUM_FUNCTION_AS_SETTER(TextField, setHintText, hintText)
+
+		TITANIUM_PROPERTY_GETTER_STRING(TextField, hintTextColor)
+		TITANIUM_PROPERTY_SETTER_STRING(TextField, hintTextColor)
+
+		TITANIUM_FUNCTION_AS_GETTER(TextField, getHintTextColor, hintTextColor)
+		TITANIUM_FUNCTION_AS_SETTER(TextField, setHintTextColor, hintTextColor)
 
 		TITANIUM_PROPERTY_GETTER(TextField, keyboardType)
 		{

--- a/Source/UI/include/TitaniumWindows/UI/TextField.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/TextField.hpp
@@ -62,6 +62,7 @@ namespace TitaniumWindows
 //			virtual void set_enableReturnKey(const bool& enableReturnKey) TITANIUM_NOEXCEPT override final;
 			virtual void set_font(const Titanium::UI::Font& font) TITANIUM_NOEXCEPT override final;
 			virtual void set_hintText(const std::string& hintText) TITANIUM_NOEXCEPT override final;
+			virtual void set_hintTextColor(const std::string& color) TITANIUM_NOEXCEPT override final;
 			virtual void set_keyboardType(const Titanium::UI::KEYBOARD& keyboardType) TITANIUM_NOEXCEPT override final;
 //			virtual void set_leftButtonMode(const Titanium::UI::INPUT_BUTTONMODE& leftButtonMode) TITANIUM_NOEXCEPT override final;
 			virtual void set_maxLength(const int32_t& maxLength) TITANIUM_NOEXCEPT override final;
@@ -87,11 +88,14 @@ namespace TitaniumWindows
 		private:
 			void initTextComponent();
 			void updateClearButtonVisibility(const bool& hasFocus = true) TITANIUM_NOEXCEPT;
+			// Update pointers of internal UI elements such as delete button.
+			void loadTextComponent();
 
 			Windows::UI::Xaml::Controls::Border^ border__{ nullptr };
 			Windows::UI::Xaml::Controls::TextBox^ text_box__{ nullptr };
 			Windows::UI::Xaml::Controls::PasswordBox^ password_box__{ nullptr };
 			Windows::UI::Xaml::Controls::Button^ delete_button__{ nullptr };
+			Windows::UI::Xaml::Controls::TextBlock^ hint_text_box__{ nullptr };
 
 			// Event handlers
 			Windows::Foundation::EventRegistrationToken change_event__;


### PR DESCRIPTION
DO NOT MERGE THIS

[TIMOB-25934](https://jira.appcelerator.org/browse/TIMOB-25934)

Attempt to implement `TextField.hintTextColor`. Because Windows TextBox component does not expose any properties to change hint text color, I ended up traversing visual component trees by using [VisualTreeHelper](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.media.visualtreehelper) and tries to change its color directly by code. Unfortunately _this does not work well_, for some reason hint text color resets to default when text field looses focus. I tried to reset the color by checking focus state but it caused UI blinking, seems like it causes conflict between native hint text color.

```js
var win = Ti.UI.createWindow({
    backgroundColor: 'white',
    id: 'win'
}),
    view = Ti.UI.createView({
        backgroundColor: 'green',
        width: Ti.UI.FILL,
        height: Ti.UI.FILL,
        id: 'view'
    }),
    textfield = Ti.UI.createTextField({
        id: 'textfield',
        hintText: 'This is a hint text',
        hintTextColor: 'blue',
        //passwordMask: true
    });

win.addEventListener('open', function () {
    setTimeout(function () {
        textfield.hintTextColor = 'pink';
    }, 5000);
});

win.addEventListener('click', function () {
    textfield.hintTextColor = 'red';
});

view.add(textfield);
win.add(view);
win.open();
```