### PR TITLE
[TIMOB-26311] Unable to define rescap Capability

### DIFF
--- a/templates/build/Package.win10.appxmanifest.in.ejs
+++ b/templates/build/Package.win10.appxmanifest.in.ejs
@@ -4,7 +4,8 @@
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
   xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
-  IgnorableNamespaces="uap mp">
+  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+  IgnorableNamespaces="uap mp rescap">
 
   <Identity
     Name="@PACKAGE_GUID@"


### PR DESCRIPTION
[TIMOB-26311](https://jira.appcelerator.org/browse/TIMOB-26311)

Fix compile error when `rescap` Capabilities are set.

```xml
  <windows>
    <manifest>
      <Capabilities>
        <rescap:Capability Name="extendedBackgroundTaskTime"/>
        <rescap:Capability Name="extendedExecutionUnconstrained"/>
      </Capabilities>
    </manifest>
  </windows>
```

Expected: Defining `rescap` Capabilities in tiapp.xml (see above) should not fail.