### PR TITLE
[TIMOB-26311] Capability should have Name property only

### DIFF
--- a/cli/commands/_build/generate.js
+++ b/cli/commands/_build/generate.js
@@ -519,12 +519,14 @@ function generateAppxManifestForPlatform(target, properties) {
 				// Just write the XML out as is
 				// TODO Do some validation of DeviceCapability name?
 				if (node.tagName == 'DeviceCapability') {
-					var cap = node.toString();
+					// Capability should have Name property only
+					var cap = '<' + node.tagName + ' Name="' +  appc.xml.getAttr(node, "Name") + '" />';
 					if (deviceCapabilities.indexOf(cap) == -1) {
 						deviceCapabilities.push(cap);
 					}
 				} else {
-					var cap = node.toString();
+					// Capability should have Name property only
+					var cap = '<' + node.tagName + ' Name="' +  appc.xml.getAttr(node, "Name") + '" />';
 					if (capabilities.indexOf(cap) == -1) {
 						capabilities.push(cap);
 					}


### PR DESCRIPTION
Fix 'DOMParser' toString output that includes invalid string for `Capabilities`

```xml
  <windows>
    <manifest>
      <Capabilities>
        <rescap:Capability Name="extendedBackgroundTaskTime"/>
        <rescap:Capability Name="extendedExecutionUnconstrained"/>
      </Capabilities>
    </manifest>
  </windows>
```