### PR TITLE
[TIMOB-25983] Ti.UI.TextArea is not resized when its size is not specified

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/TextArea.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/TextArea.hpp
@@ -80,7 +80,7 @@ namespace TitaniumWindows
 #pragma warning(push)
 #pragma warning(disable : 4251)
 			std::unordered_map<std::string, std::string> custom_fonts__;
-			bool dirty__ { false };
+			bool isLoaded__ { false };
 #pragma warning(pop)
 			Windows::UI::Xaml::Controls::Border^ border__;
 			Windows::UI::Xaml::Controls::TextBox^ text_box__;

--- a/Source/UI/src/TextArea.cpp
+++ b/Source/UI/src/TextArea.cpp
@@ -37,21 +37,25 @@ namespace TitaniumWindows
 			border__->Child = text_box__;
 
 			// TIMOB-25983: TextArea should be resized when its size is set to auto or Ti.UI.SIZE
-			border__->SizeChanged += ref new Windows::UI::Xaml::SizeChangedEventHandler([this](Platform::Object^, Windows::UI::Xaml::SizeChangedEventArgs^ e) {
+			border__->Loaded += ref new Windows::UI::Xaml::RoutedEventHandler([this](Platform::Object^, Windows::UI::Xaml::RoutedEventArgs^) {
+				isLoaded__ = true;
 				const auto panel = dynamic_cast<FrameworkElement^>(border__->Parent);
-				if (dirty__ && panel && panel->ActualWidth > 0 && panel->ActualHeight > 0) {
-					dirty__ = false;
-
+				if (panel && panel->ActualWidth > 0 && panel->ActualHeight > 0) {
 					const auto layout = getViewLayoutDelegate<WindowsViewLayoutDelegate>();
 					const auto width = layout->get_width();
 					const auto height = layout->get_height();
 					const auto TI_UI_SIZE = Titanium::UI::Constants::to_string(Titanium::UI::LAYOUT::SIZE);
+
 					if ((width.empty() || width == TI_UI_SIZE || width == "auto")) {
 						text_box__->MaxWidth = panel->ActualWidth;
 					}
 					if ((height.empty() || height == TI_UI_SIZE || height == "auto")) {
 						text_box__->MaxHeight = panel->ActualHeight;
 					}
+				}
+				// Lazy initializing text value
+				if (!value__.empty()) {
+					text_box__->Text = TitaniumWindows::Utility::ConvertUTF8String(value__);
 				}
 			});
 
@@ -101,7 +105,6 @@ namespace TitaniumWindows
 		{
 			Titanium::UI::TextArea::set_hintText(hintText);
 			text_box__->PlaceholderText = TitaniumWindows::Utility::ConvertUTF8String(hintText);
-			dirty__ = true;
 		}
 
 		void TextArea::set_keyboardType(const Titanium::UI::KEYBOARD& keyboardType) TITANIUM_NOEXCEPT
@@ -190,8 +193,9 @@ namespace TitaniumWindows
 		void TextArea::set_value(const std::string& value) TITANIUM_NOEXCEPT
 		{
 			Titanium::UI::TextArea::set_value(value);
-			text_box__->Text = TitaniumWindows::Utility::ConvertUTF8String(value);
-			dirty__ = true;
+			if (isLoaded__) {
+				text_box__->Text = TitaniumWindows::Utility::ConvertUTF8String(value);
+			}
 		}
 
 		void TextArea::set_verticalAlign(const Titanium::UI::TEXT_VERTICAL_ALIGNMENT& verticalAlign) TITANIUM_NOEXCEPT


### PR DESCRIPTION
[TIMOB-25983](https://jira.appcelerator.org/browse/TIMOB-25983)

`Ti.UI.TextArea` should resize its size when it is not specified. Revised #1230 because it did not consider `value` property.

```js
var win = Ti.UI.createWindow({
    backgroundColor: 'green',
});

var parent = Ti.UI.createView({
    width: '60%',
    height: '60%',
    backgroundColor: 'gray'
});
var textArea = Ti.UI.createTextArea({
    width: Ti.UI.FILL,
    backgroundColor: 'white',
    color: 'black',
    left: 40,
    right: 40,
    hintText: 'this is a long hint that is not wrapping in windows version. Not sure what is the problem. All text show in single line instead of multi line. please check',
    value: 'this is a long text that is not wrapping in windows version. Not sure what is the problem. All text show in single line instead of multi line. please check',
});

parent.add(textArea);
win.add(parent);
win.open();
```

Expected: TextArea should not be shown in single line. It should have multiple lines and texts should be wrapped.

![timob-25983](https://user-images.githubusercontent.com/1661068/39176142-06f72b72-47e7-11e8-9295-123cbfa913d3.png)
