### PR TITLE
[TIMOB-25983] Fix TextArea value until loaded

### DIFF
--- a/Source/UI/src/TextArea.cpp
+++ b/Source/UI/src/TextArea.cpp
@@ -184,10 +184,10 @@ namespace TitaniumWindows
 
 		std::string TextArea::get_value() const TITANIUM_NOEXCEPT
 		{
-			if (text_box__) {
+			if (isLoaded__) {
 				return TitaniumWindows::Utility::ConvertUTF8String(text_box__->Text);
 			}
-			return std::string();
+			return Titanium::UI::TextArea::get_value();
 		}
 
 		void TextArea::set_value(const std::string& value) TITANIUM_NOEXCEPT


### PR DESCRIPTION
```js
it('value', function () {
	var textArea = Ti.UI.createTextArea({
		value: 'this is some text'
	});
	should(textArea.value).be.a.String;
	should(textArea.getValue).be.a.Function;
	should(textArea.value).eql('this is some text');
	should(textArea.getValue()).eql('this is some text');
	textArea.value = 'other text';
	should(textArea.value).eql('other text');
	should(textArea.getValue()).eql('other text');
});
```