### PR TITLE
[TIMOB-26403] Pass logger to analyzeJs call

### DIFF
--- a/cli/commands/_build/copy.js
+++ b/cli/commands/_build/copy.js
@@ -663,7 +663,8 @@ function copyResources(next) {
 								targets: {
 									safari: '10' // matches the version of jscore we use
 								},
-								resourcesDir: this.buildTargetAssetsDir
+								resourcesDir: this.buildTargetAssetsDir,
+								logger: t_.logger
 							});
 							const newContents = r.contents;
 


### PR DESCRIPTION
JIRA: jira.appcelerator.org/browse/TIMOB-26403

- Pass logger into to analyzeJs so we can log deprecation warning
To test:

Build kitchensink-v2 to device or simulator
You should see a warning log about "implicit global scope being deprecated
It should launch successfully