### PR TITLE
Fix: Label.minimumFontSize does not work

### DIFF
--- a/Source/UI/src/Label.cpp
+++ b/Source/UI/src/Label.cpp
@@ -228,10 +228,19 @@ namespace TitaniumWindows
 			label__->Measure(desiredSize);
 
 			const auto layout = getViewLayoutDelegate<WindowsViewLayoutDelegate>();
+			const auto layout_node = layout->getLayoutNode();
+
+			// Calculate the label size when label is not loaded yet. This effectively updates node element properties.
+			if (!layout->isLoaded()) {
+				const auto root = Titanium::LayoutEngine::nodeRequestLayout(layout_node);
+				if (root) {
+					Titanium::LayoutEngine::nodeLayout(root);
+				}
+			}
 
 			// minimumFontSize decreases the fontsize of the text to fit the width. This enables single-line mode. Only works with minimumFontSize > 0
 			const auto minimumFontSize = get_minimumFontSize();
-			const auto measuredWidth = layout->getLayoutNode()->element.measuredWidth;
+			const auto measuredWidth = layout_node->element.measuredWidth;
 			if (minimumFontSize > 0 && measuredWidth > 0) {
 				auto previousFontSize = label__->FontSize;
 				while (previousFontSize > minimumFontSize && minimumFontSize > 1.0 && measuredWidth < label__->ActualWidth) {


### PR DESCRIPTION
Fix `Label.minimumFontSize` in 7.5.0 nightly build.

```js
var win = Ti.UI.createWindow({ backgroundColor: 'green' });

var label = Ti.UI.createLabel({
    width: 600, height: 200, backgroundColor: 'gray',
    text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
    minimumFontSize: 2,
});

win.add(label);
win.open();
```


Expected: Label texts decrease its size to fit Label content size.

![1](https://user-images.githubusercontent.com/1661068/35611101-3d8895b2-06a7-11e8-9975-4c6af68b336c.png)
