### PR TITLE
[TIMOB-26464] Add Ti.UI.Window.safeAreaPadding and extendSafeArea

### DIFF
--- a/Source/TitaniumKit/CMakeLists.txt
+++ b/Source/TitaniumKit/CMakeLists.txt
@@ -318,6 +318,8 @@ set(SOURCE_UI
   src/UIModule.cpp
   include/Titanium/UI/View.hpp
   src/UI/View.cpp
+  include/Titanium/UI/ViewPadding.hpp
+  src/UI/ViewPadding.cpp
   include/Titanium/UI/ViewLayoutDelegate.hpp
   src/UI/ViewLayoutDelegate.cpp
   include/Titanium/UI/WebView.hpp

--- a/Source/TitaniumKit/include/Titanium/UI/ViewPadding.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/ViewPadding.hpp
@@ -1,0 +1,37 @@
+/**
+ * TitaniumKit ViewPadding
+ *
+ * Copyright (c) 2018 by Axway. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License.
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#ifndef _TITANIUM_VIEWPADDING_HPP_
+#define _TITANIUM_VIEWPADDING_HPP_
+
+#include "Titanium/detail/TiBase.hpp"
+
+namespace Titanium
+{
+	namespace UI
+	{
+		using namespace HAL;
+
+		/*!
+		  @struct
+		  @discussion Dictionary object of parameters for the padding applied to all kinds of views.
+		  This is an abstract type. Any object meeting this description can be used where this type is used.
+		  See https://docs.appcelerator.com/platform/latest/#!/api/ViewPadding
+		  */
+		struct ViewPadding {
+			double bottom  { 0.0 };
+			double left    { 0.0 };
+			double right   { 0.0 };
+			double top     { 0.0 };
+		};
+
+		TITANIUMKIT_EXPORT ViewPadding js_to_ViewPadding(const JSObject& object);
+		TITANIUMKIT_EXPORT JSObject ViewPadding_to_js(const JSContext& js_context, const ViewPadding& padding);
+	} // namespace UI
+} // namespace Titanium
+#endif // _TITANIUM_VIEWPADDING_HPP_

--- a/Source/TitaniumKit/include/Titanium/UI/Window.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/Window.hpp
@@ -12,6 +12,7 @@
 #include "Titanium/UI/View.hpp"
 #include "Titanium/UI/Constants.hpp"
 #include "Titanium/UI/TitleAttributesParams.hpp"
+#include "Titanium/UI/ViewPadding.hpp"
 
 namespace Titanium
 {
@@ -252,6 +253,26 @@ namespace Titanium
 			TITANIUM_PROPERTY_IMPL_DEF(std::shared_ptr<Tab>, tab);
 
 
+			/*!
+			  @method
+
+			  @abstract extendSafeArea : Boolean
+
+			  @discussion Specifies whether the content (subviews) of the window will render inside the safe-area or not.
+
+			  Default: false
+			*/
+			TITANIUM_PROPERTY_IMPL_DEF(bool, extendSafeArea);
+
+			/*!
+			  @method
+
+			  @abstract safeAreaPadding : ViewPadding
+
+			  @discussion The padding needed to safely display content without it being overlapped by the screen insets and notches.
+			*/
+			TITANIUM_PROPERTY_IMPL_READONLY_DEF(ViewPadding, safeAreaPadding);
+
 			Window(const JSContext&) TITANIUM_NOEXCEPT;
 
 			virtual ~Window() TITANIUM_NOEXCEPT;  //= default;
@@ -325,6 +346,13 @@ namespace Titanium
 			TITANIUM_FUNCTION_DEF(getTranslucent);
 			TITANIUM_FUNCTION_DEF(setTranslucent);
 
+			TITANIUM_PROPERTY_DEF(extendSafeArea);
+			TITANIUM_FUNCTION_DEF(getExtendSafeArea);
+			TITANIUM_FUNCTION_DEF(setExtendSafeArea);
+
+			TITANIUM_PROPERTY_DEF(safeAreaPadding);
+			TITANIUM_FUNCTION_DEF(getSafeAreaPadding);
+
 		protected:
 // Silence 4251 on Windows since private member variables do not
 // need to be exported from a DLL.
@@ -348,6 +376,9 @@ namespace Titanium
 			bool translucent__;
 			JSObject openWindowParams_ctor__;
 			JSObject closeWindowParams_ctor__;
+
+			bool extendSafeArea__;
+			ViewPadding safeAreaPadding__;
 
 			std::shared_ptr<Tab> tab__;
 			bool is_opened__ { false }; // Indicates this window is already opened

--- a/Source/TitaniumKit/src/UI/ViewPadding.cpp
+++ b/Source/TitaniumKit/src/UI/ViewPadding.cpp
@@ -1,0 +1,45 @@
+/**
+ * TitaniumKit ViewPadding
+ *
+ * Copyright (c) 2018 by Axway. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License.
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#include "Titanium/UI/ViewPadding.hpp"
+
+namespace Titanium
+{
+	namespace UI
+	{
+		using namespace HAL;
+
+		ViewPadding js_to_ViewPadding(const JSObject& object)
+		{
+			ViewPadding padding;
+			if (object.HasProperty("bottom")) {
+				padding.bottom = static_cast<double>(object.GetProperty("bottom"));
+			}
+			if (object.HasProperty("left")) {
+				padding.left = static_cast<double>(object.GetProperty("left"));
+			}
+			if (object.HasProperty("right")) {
+				padding.right = static_cast<double>(object.GetProperty("right"));
+			}
+			if (object.HasProperty("top")) {
+				padding.top = static_cast<double>(object.GetProperty("top"));
+			}
+			return padding;
+		};
+
+		JSObject ViewPadding_to_js(const JSContext& context, const ViewPadding& padding)
+		{
+			auto object = context.CreateObject();
+			object.SetProperty("bottom", context.CreateNumber(padding.bottom));
+			object.SetProperty("left",   context.CreateNumber(padding.left));
+			object.SetProperty("right",  context.CreateNumber(padding.right));
+			object.SetProperty("top",    context.CreateNumber(padding.top));
+			return object;
+		};
+	} // namespace UI
+} // namespace Titanium

--- a/Source/TitaniumKit/src/UI/Window.cpp
+++ b/Source/TitaniumKit/src/UI/Window.cpp
@@ -37,6 +37,7 @@ namespace Titanium
 		      barColor__(""),
 		      exitOnClose__(false),
 		      extendEdges__({EXTEND_EDGE::NONE}),
+		      extendSafeArea__(false),
 		      fullscreen__(false),
 		      hideShadow__(false),
 		      modal__(false),
@@ -97,6 +98,9 @@ namespace Titanium
 		TITANIUM_PROPERTY_READWRITE(Window, std::shared_ptr<Tab>, tab)
 		TITANIUM_PROPERTY_READWRITE(Window, std::string, title)
 		TITANIUM_PROPERTY_READ(Window, std::string, titleid)
+		TITANIUM_PROPERTY_READWRITE(Window, bool, extendSafeArea)
+		TITANIUM_PROPERTY_READ(Window, ViewPadding, safeAreaPadding)
+
 		void Window::set_titleid(const std::string& titleid) TITANIUM_NOEXCEPT
 		{
 			titleid__ = titleid;
@@ -128,6 +132,8 @@ namespace Titanium
 			TITANIUM_ADD_PROPERTY(Window, translucent);
 			TITANIUM_ADD_PROPERTY(Window, title);
 			TITANIUM_ADD_PROPERTY(Window, titleid);
+			TITANIUM_ADD_PROPERTY(Window, extendSafeArea);
+			TITANIUM_ADD_PROPERTY_READONLY(Window, safeAreaPadding);
 
 			// accessors
 			TITANIUM_ADD_FUNCTION(Window, getBarColor);
@@ -158,6 +164,9 @@ namespace Titanium
 			TITANIUM_ADD_FUNCTION(Window, setTitleAttributes);
 			TITANIUM_ADD_FUNCTION(Window, getTranslucent);
 			TITANIUM_ADD_FUNCTION(Window, setTranslucent);
+			TITANIUM_ADD_FUNCTION(Window, getExtendSafeArea);
+			TITANIUM_ADD_FUNCTION(Window, setExtendSafeArea);
+			TITANIUM_ADD_FUNCTION(Window, getSafeAreaPadding);
 		}
 
 		TITANIUM_FUNCTION(Window, close)
@@ -393,5 +402,14 @@ namespace Titanium
 		TITANIUM_PROPERTY_SETTER_STRING(Window, titleid)
 		TITANIUM_FUNCTION_AS_GETTER(Window, getTitleid, titleid)
 		TITANIUM_FUNCTION_AS_SETTER(Window, setTitleid, titleid)
+
+		TITANIUM_PROPERTY_GETTER_BOOL(Window, extendSafeArea)
+		TITANIUM_PROPERTY_SETTER_BOOL(Window, extendSafeArea)
+		TITANIUM_FUNCTION_AS_GETTER(Window, getExtendSafeArea, extendSafeArea)
+		TITANIUM_FUNCTION_AS_SETTER(Window, setExtendSafeArea, extendSafeArea)
+
+		TITANIUM_PROPERTY_GETTER_STRUCT(Window, safeAreaPadding, ViewPadding)
+		TITANIUM_FUNCTION_AS_GETTER(Window, getSafeAreaPadding, safeAreaPadding)
+
 	} // namespace UI
 }  // namespace Titanium


### PR DESCRIPTION
[TIMOB-26464](https://jira.appcelerator.org/browse/TIMOB-26464)

Add `safeAreaPadding` and `extendSafeArea` property for `Ti.UI.Window`.

On Windows, we just hard-code the padding to all zeros because safe are is just not supported on Windows. I wouldn't update the API doc to state these properties are "supported" because these properties only intend to be a placeholder on Windows just to make sure use of these properties doesn't cause runtime errors.

```js
Ti.API.info(JSON.stringify(win.safeAreaPadding));
Ti.API.info(win.extendSafeArea);
```

Expected: `safeAreaPadding` returns empty padding. `extendSafeArea` defaults to `false`.

```
[INFO] {"bottom":0,"left":0,"right":0,"top":0}
[INFO] false
```
