### PR TITLE
[TIMOB-25582] Add support for dp in ti.ui.defaultunit

### DIFF
--- a/Source/TitaniumKit/src/UI/ViewLayoutDelegate.cpp
+++ b/Source/TitaniumKit/src/UI/ViewLayoutDelegate.cpp
@@ -525,8 +525,8 @@ namespace Titanium
 
 		std::string ViewLayoutDelegate::GetDefaultUnit(const JSContext& js_context) TITANIUM_NOEXCEPT
 		{
-			// IMPORTANT: We do not support "dp" for now!
-			// Supporting "dp" in ti.ui.defaultunit will introduce breaking change for most apps.
+			// IMPORTANT: We start supporting "dp" in ti.ui.defaultunit as of 8.0.0.
+			// This will introduce breaking change for most apps.
 			// See TIMOB-25582 for details.
 			if (DefaultUnit__.empty()) {
 				JSObject App = Titanium::AppModule::GetStaticObject(js_context);
@@ -549,7 +549,7 @@ namespace Titanium
 				if (DefaultUnit__ != "mm" && DefaultUnit__ != "cm" &&
 					DefaultUnit__ != "em" && DefaultUnit__ != "pt" &&
 					DefaultUnit__ != "pc" && DefaultUnit__ != "in" &&
-					DefaultUnit__ != "px" && /* DefaultUnit__ != "dp" && */
+					DefaultUnit__ != "px" && DefaultUnit__ != "dp" &&
 					DefaultUnit__ != "dip" && DefaultUnit__ != "ppx")
 				{
 					DefaultUnit__ = "px";


### PR DESCRIPTION
[TIMOB-25582](https://jira.appcelerator.org/browse/TIMOB-25582)

Add support for `dp` in `ti.ui.defaultunit`. This will introduce breaking change on view sizes because our `tiapp.xml` default unit is set to `dp` usually but we've been using `px` for Windows default unit. In order to keep consistency between old versions, you need to set ` <property name="ti.ui.defaultunit" type="string">px</property>` explicitly in `tiapp.xml`.

```js
var win = Ti.UI.createWindow();

var view1 = Ti.UI.createView({
    width: "100px", height: "100px",
    top: 100, left: 100,
    backgroundColor: 'blue',
});

var view2 = Ti.UI.createView({
    width: "100dp", height: "100dp",
    top: 200, left: 100,
    backgroundColor: 'red',
});

var view3 = Ti.UI.createView({
    width: "100", height: "100",
    top: 300, left: 100,
    backgroundColor: 'yellow',
});

win.add(view1);
win.add(view2);
win.add(view3);
win.open();
```

Expected: When you set `dp` for `ti.ui.defaultunit` in `tiapp.xml`, the size of red view and yellow view should be same. When you set `px` for `ti.ui.defaultunit` in `tiapp.xml`, the size of blue view and yellow view should be same. 
