### PR TITLE
[TIMOB-26503] Touch coordinate should not ignore default unit

### DIFF
--- a/Source/TitaniumKit/include/Titanium/UI/Constants.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/Constants.hpp
@@ -622,13 +622,16 @@ namespace Titanium
 		  @constant MM Unit constant representing units in millimeters.
 
 		  @constant PX Unit constant representing units in pixels.
+
+		  @constant PPX Unit constant representing units in pysical pixels.
 		*/
 		enum class TITANIUMKIT_EXPORT UNIT {
 			Cm,
 			Dip,
 			In,
 			Mm,
-			Px
+			Px,
+			Ppx
 		};
 
 		/*!
@@ -1246,7 +1249,7 @@ namespace Titanium
 			static std::underlying_type<GRADIENT_TYPE>::type to_underlying_type(const GRADIENT_TYPE&) TITANIUM_NOEXCEPT;
 
 			static std::string to_string(const UNIT&) TITANIUM_NOEXCEPT;
-			static UNIT to_UNIT(const std::string& textStyleName) TITANIUM_NOEXCEPT;
+			static UNIT to_UNIT(const std::string& name) TITANIUM_NOEXCEPT;
 			static UNIT to_UNIT(std::underlying_type<UNIT>::type) TITANIUM_NOEXCEPT;
 			static std::underlying_type<UNIT>::type to_underlying_type(const UNIT&) TITANIUM_NOEXCEPT;
 

--- a/Source/TitaniumKit/src/UI/Constants.cpp
+++ b/Source/TitaniumKit/src/UI/Constants.cpp
@@ -1626,11 +1626,12 @@ namespace Titanium
 			static std::unordered_map<UNIT, std::string> map;
 			static std::once_flag of;
 			std::call_once(of, []() {
-      map[UNIT::Cm]  = "UNIT_CM";
-      map[UNIT::Dip] = "UNIT_DIP";
-      map[UNIT::In]  = "UNIT_IN";
-      map[UNIT::Mm]  = "UNIT_MM";
-      map[UNIT::Px]  = "UNIT_PX";
+      map[UNIT::Cm]  = "cm";
+      map[UNIT::Dip] = "dip";
+      map[UNIT::In]  = "in";
+      map[UNIT::Mm]  = "mm";
+      map[UNIT::Px]  = "px";
+      map[UNIT::Ppx] = "ppx";
 			});
 
 			std::string string = unknown_string;
@@ -1647,11 +1648,13 @@ namespace Titanium
 			static std::unordered_map<std::string, UNIT> map;
 			static std::once_flag of;
 			std::call_once(of, []() {
-      map["UNIT_CM"]  = UNIT::Cm;
-      map["UNIT_DIP"] = UNIT::Dip;
-      map["UNIT_IN"]  = UNIT::In;
-      map["UNIT_MM"]  = UNIT::Mm;
-      map["UNIT_PX"]  = UNIT::Px;
+      map["cm"]  = UNIT::Cm;
+      map["dip"] = UNIT::Dip;
+	  map["dp"]  = UNIT::Dip;
+	  map["in"]  = UNIT::In;
+      map["mm"]  = UNIT::Mm;
+      map["px"]  = UNIT::Px;
+      map["ppx"] = UNIT::Ppx;
 			});
 
 			UNIT unit = UNIT::Dip;
@@ -1675,6 +1678,7 @@ namespace Titanium
       map[static_cast<std::underlying_type<UNIT>::type>(UNIT::In)]  = UNIT::In;
       map[static_cast<std::underlying_type<UNIT>::type>(UNIT::Mm)]  = UNIT::Mm;
       map[static_cast<std::underlying_type<UNIT>::type>(UNIT::Px)]  = UNIT::Px;
+      map[static_cast<std::underlying_type<UNIT>::type>(UNIT::Ppx)] = UNIT::Ppx;
 			});
 
 			UNIT unit = UNIT::Dip;

--- a/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/WindowsViewLayoutDelegate.hpp
@@ -581,6 +581,10 @@ namespace TitaniumWindows
 			static Windows::UI::Xaml::Media::ImageBrush^ CreateImageBrushFromBitmapImage(Windows::UI::Xaml::Media::Imaging::BitmapImage^ image);
 			static Windows::UI::Xaml::Media::ImageBrush^ CreateImageBrushFromBlob(const std::shared_ptr<Titanium::Blob>& blob);
 			static double ComputePPI(const Titanium::LayoutEngine::ValueName& name);
+			static double ComputeUnits(const Titanium::UI::UNIT& units, float value);
+
+			// Convert Windows effective pixels to default unit value
+			static double pxToUnitsValue(const Titanium::LayoutEngine::ValueName& valueName, const float& value, const JSContext& ctx);
 
 #pragma warning(push)
 #pragma warning(disable : 4251)
@@ -590,6 +594,8 @@ namespace TitaniumWindows
 		protected:
 #pragma warning(push)
 #pragma warning(disable : 4251)
+			static double RawPixelsPerViewPixel__;
+
 			bool sourceTest(::Platform::Object ^ source, Windows::UI::Xaml::DependencyObject^ target);
 
 			Windows::UI::Xaml::Controls::Border^ border__    { nullptr };

--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -63,16 +63,16 @@ namespace TitaniumWindows
 
 		}
 
+		double WindowsViewLayoutDelegate::RawPixelsPerViewPixel__;
 		WindowsViewLayoutDelegate::WindowsViewLayoutDelegate() TITANIUM_NOEXCEPT
 			: ViewLayoutDelegate()
 		{
 			// Update physical pixels factor for the current display information
-			static double RawPixelsPerViewPixel;
 			static std::once_flag of;
-			std::call_once(of, [=] {
-				RawPixelsPerViewPixel = Windows::Graphics::Display::DisplayInformation::GetForCurrentView()->RawPixelsPerViewPixel;
+			std::call_once(of, [] {
+				RawPixelsPerViewPixel__ = Windows::Graphics::Display::DisplayInformation::GetForCurrentView()->RawPixelsPerViewPixel;
 			});
-			Titanium::LayoutEngine::PhysicalPixelsFactor = RawPixelsPerViewPixel;
+			Titanium::LayoutEngine::PhysicalPixelsFactor = RawPixelsPerViewPixel__;
 		}
 
 		WindowsViewLayoutDelegate::~WindowsViewLayoutDelegate() TITANIUM_NOEXCEPT
@@ -1395,6 +1395,29 @@ namespace TitaniumWindows
 			return nullptr;
 		}
 
+		double WindowsViewLayoutDelegate::pxToUnitsValue(const Titanium::LayoutEngine::ValueName& valueName, const float& convertFromValue, const JSContext& ctx)
+		{
+			const auto ppi = ComputePPI(valueName);
+			const auto value = Titanium::LayoutEngine::parseUnitValue(std::to_string(convertFromValue), Titanium::LayoutEngine::ValueType::Fixed, ppi, "px");
+			const auto convertToUnits = Titanium::UI::Constants::to_UNIT(ViewLayoutDelegate::GetDefaultUnit(ctx));
+
+			if (convertToUnits == Titanium::UI::UNIT::Mm) {   // 1 mm = 0.0393701 in, 1 in = 25.4 mm
+				 return (value * 25.4) / ppi;                        // px = (mm / 25.4) * px/in
+			} else if (convertToUnits == Titanium::UI::UNIT::Cm) {  // 1 cm = .393700787 in, 1 in = 2.54 cm
+				 return (value * 2.54) / ppi;                        // px = (cm / 2.54) * px/in
+			} else if (convertToUnits == Titanium::UI::UNIT::In) {
+				 return value / ppi;  // px = inches * pixels/inch
+			} else if (convertToUnits == Titanium::UI::UNIT::Px) {
+				 return value;  // px is our base value
+			} else if (convertToUnits == Titanium::UI::UNIT::Dip) {
+				 return (value / ppi) * 160.0;  // px = device independent pixels * pixels/inch / 160, see https://www.google.com/design/spec/layout/units-measurements.html#units-measurements-designing-layouts-for-dp
+			} else if (convertToUnits == Titanium::UI::UNIT::Ppx) {
+				 return value * RawPixelsPerViewPixel__;
+			}
+
+			return value;
+		}
+
 		void WindowsViewLayoutDelegate::fireSimplePositionEvent(const std::string& event_name, Windows::Foundation::Point position, Platform::Object^ originalSource)
 		{
 			const auto event_delegate = event_delegate__.lock();
@@ -1402,8 +1425,8 @@ namespace TitaniumWindows
 			const auto ctx = event_delegate->get_context();
 
 			JSObject  eventArgs = ctx.CreateObject();
-			eventArgs.SetProperty("x", ctx.CreateNumber(position.X));
-			eventArgs.SetProperty("y", ctx.CreateNumber(position.Y));
+			eventArgs.SetProperty("x", ctx.CreateNumber(pxToUnitsValue(Titanium::LayoutEngine::ValueName::Width,  position.X, ctx)));
+			eventArgs.SetProperty("y", ctx.CreateNumber(pxToUnitsValue(Titanium::LayoutEngine::ValueName::Height, position.Y, ctx)));
 
 			const auto source = sourceTest(originalSource);
 			if (source) {
@@ -1427,12 +1450,12 @@ namespace TitaniumWindows
 					const auto event_delegate = event_delegate__.lock();
 					auto ctx = event_delegate->get_context();
 					JSObject  delta = ctx.CreateObject();
-					delta.SetProperty("x", ctx.CreateNumber(e->Delta.Translation.X));
-					delta.SetProperty("y", ctx.CreateNumber(e->Delta.Translation.Y));
+					delta.SetProperty("x", ctx.CreateNumber(pxToUnitsValue(Titanium::LayoutEngine::ValueName::Width,  e->Delta.Translation.X, ctx)));
+					delta.SetProperty("y", ctx.CreateNumber(pxToUnitsValue(Titanium::LayoutEngine::ValueName::Height, e->Delta.Translation.Y, ctx)));
 
 					JSObject  eventArgs = ctx.CreateObject();
-					eventArgs.SetProperty("x", ctx.CreateNumber(e->Position.X));
-					eventArgs.SetProperty("y", ctx.CreateNumber(e->Position.Y));
+					eventArgs.SetProperty("x", ctx.CreateNumber(pxToUnitsValue(Titanium::LayoutEngine::ValueName::Width, e->Delta.Translation.X, ctx)));
+					eventArgs.SetProperty("y", ctx.CreateNumber(pxToUnitsValue(Titanium::LayoutEngine::ValueName::Height, e->Delta.Translation.Y, ctx)));
 					eventArgs.SetProperty("delta", delta);
 
 					const auto source = sourceTest(e->OriginalSource);
@@ -1937,14 +1960,12 @@ namespace TitaniumWindows
 		double WindowsViewLayoutDelegate::ComputePPI(const Titanium::LayoutEngine::ValueName& name)
 		{
 			static float LogicalDpi, RawDpiX, RawDpiY;
-			static double RawPixelsPerViewPixel;
 			static std::once_flag of;
 			std::call_once(of, [=] {
 				const auto info = Windows::Graphics::Display::DisplayInformation::GetForCurrentView();
 				LogicalDpi = info->LogicalDpi;
 				RawDpiX = info->RawDpiX;
 				RawDpiY = info->RawDpiY;
-				RawPixelsPerViewPixel = info->RawPixelsPerViewPixel;
 			});
 
 			double ppi = LogicalDpi;
@@ -1954,14 +1975,14 @@ namespace TitaniumWindows
 			case Titanium::LayoutEngine::ValueName::Right:
 			case Titanium::LayoutEngine::ValueName::Width:
 			case Titanium::LayoutEngine::ValueName::MinWidth:
-				ppi = RawDpiX / RawPixelsPerViewPixel;
+				ppi = RawDpiX / RawPixelsPerViewPixel__;
 				break;
 			case Titanium::LayoutEngine::ValueName::CenterY:
 			case Titanium::LayoutEngine::ValueName::Top:
 			case Titanium::LayoutEngine::ValueName::Bottom:
 			case Titanium::LayoutEngine::ValueName::Height:
 			case Titanium::LayoutEngine::ValueName::MinHeight:
-				ppi = RawDpiY / RawPixelsPerViewPixel;
+				ppi = RawDpiY / RawPixelsPerViewPixel__;
 				break;
 			}
 			return ppi;


### PR DESCRIPTION
Note: This requires #1300 to be merged in order to use `dp` in `tiapp.xml`.

[TIMOB-26503](https://jira.appcelerator.org/browse/TIMOB-26503)

```js
var win = Ti.UI.createWindow({
    backgroundColor: 'green'
});

var view1 = Ti.UI.createView({
    width: 100, height: 100,
    top: 100, left: 100,
    backgroundColor: 'blue',
});

win.addEventListener('click', function (e) {
    view1.left = e.x;
    view1.top  = e.y;
});

win.add(view1);
win.open();
```

Expected: The blue view should move (based on upper-left corner) to where you click even when you set `ti.ui.defaultunit` to `dp`.