### PR TITLE
[TIMOB-26508] Setting undefined should clear layout value

### DIFF
--- a/Source/LayoutEngine/src/ParseProperty.cpp
+++ b/Source/LayoutEngine/src/ParseProperty.cpp
@@ -24,7 +24,7 @@ namespace Titanium
 				return Size;
 			} else if (value == "UI.FILL") {
 				return Fill;
-			} else if (value == "NONE") {
+			} else if (value == "NONE" || value == "undefined") {
 				return None;
 			} else if (value.find("%") != std::string::npos) {
 				return Percent;


### PR DESCRIPTION
[TIMOB-26508](https://jira.appcelerator.org/browse/TIMOB-26508)

Setting `undefined` to layout property should "clear" layout value. For instance, setting both `left` and `top` disables `center` property (expected behavior) but we should be able to enable `center` property again by setting `undefined` for `left` and `top` properties.

```js
var win = Ti.UI.createWindow();

var view1 = Ti.UI.createView({
    width: 100, height: 100,
    top: 100, left: 100,
    backgroundColor: 'blue',
});

win.addEventListener('click', function (e) {
    view1.top  = undefined;
    view1.left = undefined;
    view1.center = { x: e.x, y:e.y };
});

win.add(view1);
win.open();
```

Expected: The blue view should move to where you click.