### PR TITLE
[TIMOB-26524] Can not compile folder with spaces

### DIFF
--- a/templates/build/CMakeLists.txt.ejs
+++ b/templates/build/CMakeLists.txt.ejs
@@ -99,7 +99,7 @@ set(SOURCE_Assets
   )
 set_property(SOURCE ${SOURCE_Assets} PROPERTY VS_DEPLOYMENT_CONTENT 1)
 
-<% var key_filter = /[\.\/|\@]/g -%>
+<% var key_filter = /[\.\/|\@ ]/g -%>
 <% for(var key in sourceGroups) {%>
 <% if (key == '.') { continue; } -%>
 set(SOURCE_<%= key.replace(key_filter, '_') %>


### PR DESCRIPTION
[TIMOB-26524](https://jira.appcelerator.org/browse/TIMOB-26524)

- Create `folder with spaces` folder under `Resources`
- Place `test.js` (can be anything, content does not matter) under `folder with spaces` folder
- Run the app

```js
var win = Ti.UI.createWindow({backgroundColor: 'green'});

win.addEventListener('open', function() {
    alert(Ti.Filesystem.getFile('folder with spaces/test.js').exists());
});

win.open();
```

Expected: The project compiles and app should launch, and should alert `true`.
