### PR TITLE
[TIMOB-26525] ScrollView does not expand with Ti.UI.SIZE

### DIFF
--- a/Source/UI/src/ScrollView.cpp
+++ b/Source/UI/src/ScrollView.cpp
@@ -118,6 +118,16 @@ namespace TitaniumWindows
 			});
 			scroll_viewer__->Content = content->getComponent();
 
+			content->getComponent()->SizeChanged += ref new SizeChangedEventHandler([this](Platform::Object^ sender, SizeChangedEventArgs^ e) {
+				const auto SIZE = Titanium::UI::Constants::to_string(Titanium::UI::LAYOUT::SIZE);
+				if (layoutDelegate__->get_width() == SIZE) {
+					layoutDelegate__->set_minWidth(std::to_string(e->NewSize.Width));
+				}
+				if (layoutDelegate__->get_height() == SIZE) {
+					layoutDelegate__->set_minHeight(std::to_string(e->NewSize.Height));
+				}
+			});
+
 			Titanium::UI::ScrollView::setLayoutDelegate<ScrollViewLayoutDelegate>(this, contentView__);
 
 			layoutDelegate__->set_defaultHeight(Titanium::UI::LAYOUT::FILL);


### PR DESCRIPTION
[TIMOB-26525](https://jira.appcelerator.org/browse/TIMOB-26525)

ScrollView does not expand its size along with child content when Ti.UI.SIZE is specified. 

```js
var scrollView = Ti.UI.createScrollView({
    height: Ti.UI.SIZE,
    width: Ti.UI.SIZE,
    scrollType: 'vertical',
    layout: 'vertical',
    backgroundColor: 'red'
});

var view1 = Ti.UI.createView({
        width: '100',
        height: '50',
        backgroundColor: 'pink'
});

var view2 = Ti.UI.createView({
    width: '200',
    height: '100',
    backgroundColor: 'green'
});

scrollView.add(view1);
scrollView.add(view2);

var win = Ti.UI.createWindow({
    backgroundColor: 'white',
});
win.add(scrollView);
win.open();
```

Expected: 
![1](https://user-images.githubusercontent.com/1661068/48115948-e5f11d00-e2a7-11e8-826b-866eab766ada.png)
