### PR TITLE
[7_5_X][TIMOB-26531] Build fails when module resources has sub folders

### DIFF
--- a/cli/commands/_build/copy.js
+++ b/cli/commands/_build/copy.js
@@ -533,9 +533,15 @@ function copyResources(next) {
 		});
 	});
 
-	// this.modules.forEach(function (module) {
-		// TODO: copy any module specific resources here
-	// }, this);
+	this.modules.forEach(function (module) {
+		// copy any module specific resources here
+		tasks.push(function (cb) {
+			copyDir.call(this, {
+				src: path.join(module.modulePath, 'platform', 'Assets'),
+				dest: path.join(this.buildTargetAssetsDir)
+			}, cb);
+		});
+	}, this);
 
 	var platformPaths = [];
 	// WARNING! This is pretty dangerous, but yes, we're intentionally copying

--- a/cli/commands/_build/generate.js
+++ b/cli/commands/_build/generate.js
@@ -804,9 +804,13 @@ function copyModuleOverride(next) {
 			if (fs.existsSync(moduleSrc)) {
 				wrench.readdirSyncRecursive(moduleSrc).forEach(function(res) {
 					var from = path.join(moduleSrc, res), 
-						to   = path.join(_t.buildDir, res);
+						to   = path.join(_t.buildDir, res),
+						todir = path.dirname(to);
 					if (fs.statSync(from).isFile()) {
 						_t.logger.info('Module [' + module.manifest.moduleid + '] overrides ' + res);
+						if (!fs.existsSync(todir)) {
+							wrench.mkdirSyncRecursive(todir)
+						}
 						fs.createReadStream(from).pipe(fs.createWriteStream(to));
 					}
 				});


### PR DESCRIPTION
[TIMOB-26531](https://jira.appcelerator.org/browse/TIMOB-26531)

Refer to the ticket for the test case.