### PR TITLE
[7_5_X][TIMOB-26540] Fix crash when using html property

### DIFF
--- a/Source/UI/src/WebView.cpp
+++ b/Source/UI/src/WebView.cpp
@@ -300,6 +300,9 @@ namespace TitaniumWindows
 			beforeload_event__ = webview__->NavigationStarting += ref new Windows::Foundation::TypedEventHandler
 				<Controls::WebView^, Controls::WebViewNavigationStartingEventArgs^>([this](Controls::WebView^, Controls::WebViewNavigationStartingEventArgs^ e) {
 				try {
+					if (e->Uri == nullptr) {
+						return;
+					}
 					// blacklistedURLs
 					const auto uri = TitaniumWindows::Utility::ConvertUTF8String(e->Uri->AbsoluteUri);
 					const auto blacklisted = std::find(blacklistedURLs__.begin(), blacklistedURLs__.end(), uri);


### PR DESCRIPTION
[TIMOB-26540](https://jira.appcelerator.org/browse/TIMOB-26540)

```js
var win = Ti.UI.createWindow({
    backgroundColor: '#fff'
});

var webView = Titanium.UI.createWebView({
    html: '<select name="selectBox"><option value="val1">Value 1</option><option value="val2">Value 2</option><option value="val3">Value 3</option></select>'
});

win.add(webView);
win.open();
```

Expected: Application should not crash