### PR TITLE
Fix default unit to 'px' before unit tests

### DIFF
--- a/Tools/Scripts/build/test.js
+++ b/Tools/Scripts/build/test.js
@@ -199,6 +199,13 @@ function addTiAppProperties(sdkVersion, next) {
 	// Not so smart but this should work...
 	var content = [];
 	fs.readFileSync(tiapp_xml).toString().split(/\r?\n/).forEach(function(line) {
+
+		// Fix ti.ui.defaultunit. We should use 'px' for it on Windows.
+		if (line.indexOf('<property name="ti.ui.defaultunit" type="string">dp</property>') >= 0) {
+			content.push('\t<property name="ti.ui.defaultunit" type="string">px</property>');
+			return;
+		}
+
 		content.push(line);
 		if (line.indexOf('<guid>') >= 0) {
 			content.push('\t<property name="presetString" type="string">Hello!</property>');


### PR DESCRIPTION
#1300 introduces breaking change on `ti.ui.defaultunit`. We should explicitly declare to use `px` in order to keep consistency between previous versions.
