### PR TITLE
chore(build): Archive WindowsOnly docs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -147,8 +147,11 @@ timestamps {
 				echo 'copying generated docs to dist folder'
 				if (isUnix()) {
 					sh 'mv apidoc/Titanium dist/windows/doc/Titanium'
+					sh 'mv apidoc/WindowsOnly dist/windows/doc/WindowsOnly'
+
 				} else {
 					bat '(robocopy apidoc\\\\Titanium dist\\\\windows\\\\doc\\\\Titanium /e) ^& IF %ERRORLEVEL% LEQ 3 cmd /c exit 0'
+					bat '(robocopy apidoc\\\\WindowsOnly dist\\\\windows\\\\doc\\\\WindowsOnly /e) ^& IF %ERRORLEVEL% LEQ 3 cmd /c exit 0'
 				}
 				archiveArtifacts artifacts: 'dist/**/*'
 			} // stage('Docs')


### PR DESCRIPTION
Fixes https://jira.appcelerator.org/browse/TIMOB-26592.

This allows the Windows specific API namepsaces to be included in the api.jsca files (and similar).

Will test the process locally once the artifacts from this build are produced