### PR TITLE
await fs.readFile returns undefined for some reason.

### DIFF
--- a/Tools/Scripts/build/build.js
+++ b/Tools/Scripts/build/build.js
@@ -80,7 +80,7 @@ async function updateBuildValuesInTitaniumModule(githash, tiModuleCPP) {
 	if (!githash) {
 		githash = await getGitHash(path.dirname(tiModuleCPP));
 	}
-	const contents = await fs.readFile(tiModuleCPP, 'utf8');
+	const contents = fs.readFileSync(tiModuleCPP, 'utf8');
 	const date = new Date();
 	const timestamp = (date.getMonth() + 1) + '/' + date.getDate() + '/' + date.getFullYear() + ' ' + date.getHours() + ':' + date.getMinutes();
 


### PR DESCRIPTION
Relates to #1319

Jenkins master build is failing because of `TypeError: Cannot read property 'replace' of undefined` and turns out `await fs.readFile` returns undefined for some reason. Pushing a workaround.
