### PR TITLE
[TIMOB-26579] Ti.UI.ImageView's load event object has no state property

### DIFF
--- a/Source/UI/include/TitaniumWindows/UI/ImageView.hpp
+++ b/Source/UI/include/TitaniumWindows/UI/ImageView.hpp
@@ -112,6 +112,7 @@ namespace TitaniumWindows
 			bool imageOpened__{ false };
 			std::vector<JSObject> to_image_queue__;
 
+			void fireLoadEvent(const bool& multiple);
 #pragma warning(pop)
 		};
 	} // namespace UI

--- a/Source/UI/src/ImageView.cpp
+++ b/Source/UI/src/ImageView.cpp
@@ -245,6 +245,14 @@ namespace TitaniumWindows
 			}
 		}
 
+		void ImageView::fireLoadEvent(const bool& multiple)
+		{
+			const auto ctx = get_context();
+			auto eventArgs = ctx.CreateObject();
+			eventArgs.SetProperty("state", ctx.CreateString(multiple ? "images" : "image"));
+			fireEvent("load", eventArgs);
+		}
+
 		void ImageView::loadBitmaps()
 		{
 			bitmaps__->Clear();
@@ -258,10 +266,7 @@ namespace TitaniumWindows
 			}
 			if (images.size() > 0) {
 				bitmaps_loaded__ = true;
-				const auto ctx = get_context();
-				auto eventArgs = ctx.CreateObject();
-				eventArgs.SetProperty("state", ctx.CreateString("images"));
-				fireEvent("load", eventArgs);
+				fireLoadEvent(true);
 				return;
 			}
 
@@ -277,10 +282,7 @@ namespace TitaniumWindows
 						// do we load all images?
 						if (bitmaps_loaded_count__ >= blobs_count) {
 							bitmaps_loaded__ = true;
-							const auto ctx = get_context();
-							auto eventArgs = ctx.CreateObject();
-							eventArgs.SetProperty("state", ctx.CreateString("images"));
-							fireEvent("load", eventArgs);
+							fireLoadEvent(true);
 							// start animation when we held it off
 							if (bitmaps_waiting__) {
 								start();
@@ -307,10 +309,7 @@ namespace TitaniumWindows
 						// do we load all images?
 						if (bitmaps_loaded_count__ >= files_count) {
 							bitmaps_loaded__ = true;
-							const auto ctx = get_context();
-							auto eventArgs = ctx.CreateObject();
-							eventArgs.SetProperty("state", ctx.CreateString("images"));
-							fireEvent("load", eventArgs);
+							fireLoadEvent(true);
 							// start animation when we held it off
 							if (bitmaps_waiting__) {
 								start();
@@ -341,11 +340,7 @@ namespace TitaniumWindows
 				);
 			layout->onComponentSizeChange(rect);
 
-			const auto ctx = get_context();
-			auto eventArgs = ctx.CreateObject();
-			eventArgs.SetProperty("state", ctx.CreateString("image"));
-
-			this->fireEvent("load", eventArgs);
+			fireLoadEvent(false);
 		}
 
 		void ImageView::loadBitmap(std::vector<std::uint8_t>& data, SetBitmapImageCallback_t callback)
@@ -422,10 +417,7 @@ namespace TitaniumWindows
 
 			image__->Source = ref new BitmapImage(TitaniumWindows::Utility::GetUriFromPath(path));
 
-			const auto ctx = get_context();
-			auto eventArgs = ctx.CreateObject();
-			eventArgs.SetProperty("state", ctx.CreateString("image"));
-			fireEvent("load", eventArgs);
+			fireLoadEvent(false);
 		}
 
 		void ImageView::set_images(const std::vector<std::string>& images) TITANIUM_NOEXCEPT

--- a/Source/UI/src/ImageView.cpp
+++ b/Source/UI/src/ImageView.cpp
@@ -258,7 +258,10 @@ namespace TitaniumWindows
 			}
 			if (images.size() > 0) {
 				bitmaps_loaded__ = true;
-				fireEvent("load");
+				const auto ctx = get_context();
+				auto eventArgs = ctx.CreateObject();
+				eventArgs.SetProperty("state", ctx.CreateString("images"));
+				fireEvent("load", eventArgs);
 				return;
 			}
 
@@ -274,7 +277,10 @@ namespace TitaniumWindows
 						// do we load all images?
 						if (bitmaps_loaded_count__ >= blobs_count) {
 							bitmaps_loaded__ = true;
-							fireEvent("load");
+							const auto ctx = get_context();
+							auto eventArgs = ctx.CreateObject();
+							eventArgs.SetProperty("state", ctx.CreateString("images"));
+							fireEvent("load", eventArgs);
 							// start animation when we held it off
 							if (bitmaps_waiting__) {
 								start();
@@ -301,7 +307,10 @@ namespace TitaniumWindows
 						// do we load all images?
 						if (bitmaps_loaded_count__ >= files_count) {
 							bitmaps_loaded__ = true;
-							fireEvent("load");
+							const auto ctx = get_context();
+							auto eventArgs = ctx.CreateObject();
+							eventArgs.SetProperty("state", ctx.CreateString("images"));
+							fireEvent("load", eventArgs);
 							// start animation when we held it off
 							if (bitmaps_waiting__) {
 								start();
@@ -332,7 +341,11 @@ namespace TitaniumWindows
 				);
 			layout->onComponentSizeChange(rect);
 
-			this->fireEvent("load");
+			const auto ctx = get_context();
+			auto eventArgs = ctx.CreateObject();
+			eventArgs.SetProperty("state", ctx.CreateString("image"));
+
+			this->fireEvent("load", eventArgs);
 		}
 
 		void ImageView::loadBitmap(std::vector<std::uint8_t>& data, SetBitmapImageCallback_t callback)
@@ -408,7 +421,11 @@ namespace TitaniumWindows
 			}
 
 			image__->Source = ref new BitmapImage(TitaniumWindows::Utility::GetUriFromPath(path));
-			fireEvent("load");
+
+			const auto ctx = get_context();
+			auto eventArgs = ctx.CreateObject();
+			eventArgs.SetProperty("state", ctx.CreateString("image"));
+			fireEvent("load", eventArgs);
 		}
 
 		void ImageView::set_images(const std::vector<std::string>& images) TITANIUM_NOEXCEPT


### PR DESCRIPTION
[TIMOB-26579](https://jira.appcelerator.org/browse/TIMOB-26579)

```js
var win = Ti.UI.createWindow();
var image = Ti.UI.createImageView();

image.addEventListener('load', function (e) {
    Ti.API.info(e.state);
});

win.addEventListener('open', function () {
    image.image = 'http://api.randomuser.me/portraits/women/0.jpg';
});

win.add(image);
win.open();
```

Expected: This should print `image` in console

```js
var win = Ti.UI.createWindow();
var image = Ti.UI.createImageView();

image.addEventListener('load', function (e) {
    Ti.API.info(e.state);
});

win.addEventListener('open', function () {
    image.images = [
        'http://api.randomuser.me/portraits/women/0.jpg',
        'http://api.randomuser.me/portraits/women/1.jpg',
    ];
});

win.add(image);
win.open();
```

Expected: This should print `images` in console