### PR TITLE
[TIMOB-26766] Timeout when installing to wp-device

### DIFF
--- a/cli/hooks/wp-run.js
+++ b/cli/hooks/wp-run.js
@@ -203,7 +203,7 @@ exports.init = function (logger, config, cli) {
 					opts = appc.util.mix({
 						forceUnInstall: cli.argv.hasOwnProperty('forceUnInstall'),
 						killIfRunning: false,
-						timeout: config.get('windows.log.timeout', 60000),
+						timeout: config.get('windows.log.timeout', 120000),
 						wpsdk: builder.wpsdk
 					}, builder.windowslibOptions),
 					// Options for dependencies


### PR DESCRIPTION
[TIMOB-26766](https://jira.appcelerator.org/browse/TIMOB-26766)

Increase timeout for wp-device.

Expected: Installing app with Hyperloop should go through
