### PR TITLE
[8_0_X][TIMOB-26776]  App launch failed with "cyclic redundancy check"

### DIFF
--- a/cli/commands/_build/checks.js
+++ b/cli/commands/_build/checks.js
@@ -55,6 +55,20 @@ function checkIfShouldForceRebuild() {
 		return true;
 	}
 
+	// if encryption is enabled, then we must recompile the java files
+	if (this.encryptJS) {
+		this.logger.info(__('Forcing rebuild: JavaScript files need to be re-encrypted'));
+		return true;
+	}
+
+	// if encryptJS changed, then we need to recompile the java files
+	if (this.encryptJS !== manifest.encryptJS) {
+		this.logger.info(__('Forcing rebuild: JavaScript encryption flag changed'));
+		this.logger.info('  ' + __('Was: %s', manifest.encryptJS));
+		this.logger.info('  ' + __('Now: %s', this.encryptJS));
+		return true;
+	}
+
 	// check if the titanium sdk paths are different
 	if (this.platformPath !== manifest.platformPath) {
 		this.logger.info(__('Forcing rebuild: Titanium SDK path changed since last build'));


### PR DESCRIPTION
[TIMOB-26776](https://jira.appcelerator.org/browse/TIMOB-26776)

This basically reverts part of changes we did in #1282 - [cli/commands/_build/checks.js](https://github.com/appcelerator/titanium_mobile_windows/pull/1282/files#diff-fd07e68df4675cca1ea553ba6a2128e5). This happens only when re-build with no changes made in JS source.