### PR TITLE
[TIMOB-26702] Make HAL more lightweight

### DIFF
--- a/Source/Media/src/Media.cpp
+++ b/Source/Media/src/Media.cpp
@@ -65,7 +65,7 @@ namespace TitaniumWindows
 		return js_context.CreateFunction(R"JS(
 			Ti.App.removeEventListener('windows.fileOpenFromPicker', this);
 			Ti.Media._postOpenPhotoGallery(e.files);
-		)JS", { "e" });
+		)JS", { JSString("e") });
 	}
 
 	JSFunction MediaModule::createFileOpenForMusicLibraryFunction(const JSContext& js_context) const TITANIUM_NOEXCEPT
@@ -73,7 +73,7 @@ namespace TitaniumWindows
 		return js_context.CreateFunction(R"JS(
 			Ti.App.removeEventListener('windows.fileOpenFromPicker', this);
 			Ti.Media._postOpenMusicLibrary(e.files);
-		)JS", { "e" });
+		)JS", { JSString("e") });
 	}
 
 	JSFunction MediaModule::createBeepFunction(const JSContext& js_context) const TITANIUM_NOEXCEPT

--- a/Source/Network/src/HTTPClient.cpp
+++ b/Source/Network/src/HTTPClient.cpp
@@ -257,7 +257,7 @@ namespace TitaniumWindows
 						const auto Titanium = static_cast<JSObject>(get_context().get_global_object().GetProperty("Titanium"));
 						const auto Filesystem = static_cast<JSObject>(Titanium.GetProperty("Filesystem"));
 						auto File = static_cast<JSObject>(Filesystem.GetProperty("File"));
-						const auto file = File.CallAsConstructor(file__);
+						const auto file = File.CallAsConstructor(get_context().CreateString(file__));
 						const auto file_ptr = file.GetPrivate<Titanium::Filesystem::File>();
 						TITANIUM_ASSERT(file_ptr->write(responseData__, 0, responseDataLen__, false));
 

--- a/Source/Ti/src/Contacts/Group.cpp
+++ b/Source/Ti/src/Contacts/Group.cpp
@@ -198,7 +198,7 @@ namespace TitaniumWindows
 			const auto loaded = group->loadJS();
 			if (loaded) {
 				auto getGroupByIdentifier_func = group->getTiObject().GetProperty("getGroupByIdentifier");
-				auto js_group = static_cast<JSObject>(getGroupByIdentifier_func)(id, js_context.get_global_object());
+				auto js_group = static_cast<JSObject>(getGroupByIdentifier_func)(js_context.CreateString(id), js_context.get_global_object());
 				if (js_group.IsNull() || js_group.IsUndefined()) {
 					return nullptr;
 				}

--- a/Source/Titanium/src/File.cpp
+++ b/Source/Titanium/src/File.cpp
@@ -298,7 +298,7 @@ namespace TitaniumWindows
 				File = static_cast<JSObject>(File_property);
 			});
 
-			return File.CallAsConstructor(parent).GetPrivate<Titanium::Filesystem::File>();
+			return File.CallAsConstructor(get_context().CreateString(parent)).GetPrivate<Titanium::Filesystem::File>();
 		}
 
 		bool File::get_readonly() const TITANIUM_NOEXCEPT

--- a/Source/TitaniumKit/include/Titanium/Accelerometer.hpp
+++ b/Source/TitaniumKit/include/Titanium/Accelerometer.hpp
@@ -22,7 +22,6 @@ namespace Titanium
 	{
 	public:
 		Accelerometer(const JSContext&) TITANIUM_NOEXCEPT;
-		virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;
 
 		virtual ~Accelerometer() = default;
 		Accelerometer(const Accelerometer&) = default;

--- a/Source/TitaniumKit/include/Titanium/App.hpp
+++ b/Source/TitaniumKit/include/Titanium/App.hpp
@@ -184,7 +184,6 @@ namespace Titanium
 		TITANIUM_FUNCTION_DEF(_loadAppInfo);
 
 		AppModule(const JSContext&) TITANIUM_NOEXCEPT;
-		virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;
 
 		virtual ~AppModule() = default;
 		AppModule(const AppModule&) = default;

--- a/Source/TitaniumKit/include/Titanium/App/Properties.hpp
+++ b/Source/TitaniumKit/include/Titanium/App/Properties.hpp
@@ -129,7 +129,6 @@ namespace Titanium
 			TITANIUM_FUNCTION_DEF(_loadAppProperties);
 
 			Properties(const JSContext&) TITANIUM_NOEXCEPT;
-			virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;
 
 			virtual ~Properties() = default;
 			Properties(const Properties&) = default;

--- a/Source/TitaniumKit/include/Titanium/Database/ResultSet.hpp
+++ b/Source/TitaniumKit/include/Titanium/Database/ResultSet.hpp
@@ -135,7 +135,6 @@ namespace Titanium
 			bool next() TITANIUM_NOEXCEPT;
 
 			ResultSet(const JSContext&) TITANIUM_NOEXCEPT;
-			virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;
 
 			/*!
 			  @method

--- a/Source/TitaniumKit/include/Titanium/DatabaseModule.hpp
+++ b/Source/TitaniumKit/include/Titanium/DatabaseModule.hpp
@@ -31,7 +31,6 @@ namespace Titanium
 		TITANIUM_PROPERTY_READONLY_DEF(FIELD_TYPE_STRING);
 
 		DatabaseModule(const JSContext&) TITANIUM_NOEXCEPT;
-		virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;
 
 		virtual ~DatabaseModule() TITANIUM_NOEXCEPT;  //= default;
 		DatabaseModule(const DatabaseModule&) = default;

--- a/Source/TitaniumKit/include/Titanium/GlobalObject.hpp
+++ b/Source/TitaniumKit/include/Titanium/GlobalObject.hpp
@@ -159,7 +159,6 @@ namespace Titanium
 		virtual void clearInterval(const unsigned& timerId) TITANIUM_NOEXCEPT final;
 
 		GlobalObject(const JSContext&) TITANIUM_NOEXCEPT;
-		virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;
 
 		virtual ~GlobalObject() TITANIUM_NOEXCEPT;  //= default;
 		GlobalObject(const GlobalObject&) = default;

--- a/Source/TitaniumKit/include/Titanium/MapModule.hpp
+++ b/Source/TitaniumKit/include/Titanium/MapModule.hpp
@@ -101,7 +101,6 @@ namespace Titanium
 		Titanium::Map::GOOGLE_PLAY_SERVICE_STATE isGooglePlayServicesAvailable() TITANIUM_NOEXCEPT;
 
 		MapModule(const JSContext&) TITANIUM_NOEXCEPT;
-		virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;
 
 		virtual ~MapModule() = default;
 		MapModule(const MapModule&) = default;

--- a/Source/TitaniumKit/include/Titanium/TiModule.hpp
+++ b/Source/TitaniumKit/include/Titanium/TiModule.hpp
@@ -28,7 +28,6 @@ namespace Titanium
 		virtual void setUserAgent(const std::string&) TITANIUM_NOEXCEPT final;
 
 		TiModule(const JSContext&) TITANIUM_NOEXCEPT;
-		virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;
 
 		virtual ~TiModule() = default;
 		TiModule(const TiModule&) = default;

--- a/Source/TitaniumKit/include/Titanium/UI/EmailDialog.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/EmailDialog.hpp
@@ -132,7 +132,6 @@ namespace Titanium
 			virtual void open(const bool& animated) TITANIUM_NOEXCEPT;
 
 			EmailDialog(const JSContext&) TITANIUM_NOEXCEPT;
-			virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;
 
 			virtual ~EmailDialog() = default;
 			EmailDialog(const EmailDialog&) = default;

--- a/Source/TitaniumKit/include/Titanium/UI/ListSection.hpp
+++ b/Source/TitaniumKit/include/Titanium/UI/ListSection.hpp
@@ -146,7 +146,6 @@ namespace Titanium
 			virtual void updateItemAt(const uint32_t& index, const ListDataItem& dataItem, const std::shared_ptr<ListViewAnimationProperties>& animation) TITANIUM_NOEXCEPT;
 
 			ListSection(const JSContext&) TITANIUM_NOEXCEPT;
-			virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;
 
 			virtual ~ListSection();
 			ListSection(const ListSection&) = default;

--- a/Source/TitaniumKit/include/Titanium/XML.hpp
+++ b/Source/TitaniumKit/include/Titanium/XML.hpp
@@ -22,7 +22,6 @@ namespace Titanium
 	{
 	public:
 		XML(const JSContext&) TITANIUM_NOEXCEPT;
-		virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;
 
 		virtual ~XML() = default;
 		XML(const XML&) = default;

--- a/Source/TitaniumKit/src/Accelerometer.cpp
+++ b/Source/TitaniumKit/src/Accelerometer.cpp
@@ -15,10 +15,6 @@ namespace Titanium
 		TITANIUM_LOG_DEBUG("Accelerometer:: ctor ", this);
 	}
 
-	void Accelerometer::postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) {
-		HAL_LOG_DEBUG("Accelerometer:: postCallAsConstructor ", this);
-	}
-
 	void Accelerometer::JSExportInitialize()
 	{
 		JSExport<Accelerometer>::SetClassVersion(1);

--- a/Source/TitaniumKit/src/App.cpp
+++ b/Source/TitaniumKit/src/App.cpp
@@ -31,7 +31,7 @@ namespace Titanium
 		static JSFunction readJson = get_context().CreateFunction(
 			"if (json != undefined && property in json) return json[property];"
 			"return null;",
-			{"json", "property"}
+			{JSString("json"), JSString("property")}
 		);
 
 		// Load _app_info_.json
@@ -81,10 +81,6 @@ namespace Titanium
 		_sdkVersion__("__TITANIUM_VERSION__") // FIXME This should live in TiModule!
 	{
 		TITANIUM_LOG_DEBUG("AppModule:: ctor ", this);
-	}
-
-	void AppModule::postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) {
-		HAL_LOG_DEBUG("AppModule:: postCallAsConstructor ", this);
 	}
 
 	void AppModule::loadAppInfo() TITANIUM_NOEXCEPT

--- a/Source/TitaniumKit/src/App/Properties.cpp
+++ b/Source/TitaniumKit/src/App/Properties.cpp
@@ -15,7 +15,7 @@ namespace Titanium
 	{
 		JSFunction Properties::createStringifyFunction(const JSContext& js_context) const TITANIUM_NOEXCEPT
 		{
-			return get_context().CreateFunction("return JSON.stringify(value);", { "value" });
+			return get_context().CreateFunction("return JSON.stringify(value);", { JSString("value") });
 		}
 
 		Properties::Properties(const JSContext& js_context) TITANIUM_NOEXCEPT
@@ -24,10 +24,6 @@ namespace Titanium
 			  app_properties__(js_context.CreateObject())
 		{
 			TITANIUM_LOG_DEBUG("Properties:: ctor ", this);
-		}
-
-		void Properties::postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) {
-			HAL_LOG_DEBUG("Properties:: postCallAsConstructor ", this);
 		}
 
 		void Properties::loadAppProperties() TITANIUM_NOEXCEPT
@@ -42,7 +38,7 @@ namespace Titanium
 			static JSFunction readJson = get_context().CreateFunction(
 				"if (json != undefined && property in json) return json[property];"
 				"return null;",
-				{ "json", "property" }
+				{ JSString("json"), JSString("property") }
 			);
 
 			// Load _app_props_.json

--- a/Source/TitaniumKit/src/Blob.cpp
+++ b/Source/TitaniumKit/src/Blob.cpp
@@ -85,7 +85,7 @@ namespace Titanium
 			TITANIUM_ASSERT(File_property.IsObject());  // precondition
 			JSObject File = static_cast<JSObject>(File_property);
 
-			return File.CallAsConstructor(get_nativePath()).GetPrivate<Filesystem::File>();
+			return File.CallAsConstructor(get_context().CreateString(get_nativePath())).GetPrivate<Filesystem::File>();
 		}
 		return nullptr;
 	}

--- a/Source/TitaniumKit/src/Database/DB.cpp
+++ b/Source/TitaniumKit/src/Database/DB.cpp
@@ -30,8 +30,6 @@ namespace Titanium
 
 		void DB::postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments)
 		{
-			HAL_LOG_DEBUG("DB:: postCallAsConstructor ", this);
-
 			// When called to represent class
 			if (arguments.empty()) {
 				return;
@@ -82,7 +80,7 @@ namespace Titanium
 			TITANIUM_ASSERT(File_property.IsObject());  // precondition
 			JSObject File = static_cast<JSObject>(File_property);
 
-			return File.CallAsConstructor(path__);
+			return File.CallAsConstructor(get_context().CreateString(path__));
 		}
 
 		int64_t DB::get_lastInsertRowId() const TITANIUM_NOEXCEPT

--- a/Source/TitaniumKit/src/Database/ResultSet.cpp
+++ b/Source/TitaniumKit/src/Database/ResultSet.cpp
@@ -25,11 +25,6 @@ namespace Titanium
 			close();
 		}
 
-		void ResultSet::postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments)
-		{
-			HAL_LOG_DEBUG("ResultSet:: postCallAsConstructor ", this);
-		}
-
 		uint32_t ResultSet::get_fieldCount() const TITANIUM_NOEXCEPT
 		{
 			return static_cast<uint32_t>(column_names__.size());
@@ -260,7 +255,7 @@ namespace Titanium
 			ENSURE_UINT_AT_INDEX(index, 0);
 
 			const std::string result = getFieldName(index);
-			if (result == nullptr) {
+			if (result.empty()) {
 				return get_context().CreateNull();
 			}
 			return get_context().CreateString(result);

--- a/Source/TitaniumKit/src/DatabaseModule.cpp
+++ b/Source/TitaniumKit/src/DatabaseModule.cpp
@@ -56,11 +56,6 @@ namespace Titanium
 		TITANIUM_LOG_DEBUG("DatabaseModule:: ctor ", this);
 	}
 
-	void DatabaseModule::postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments)
-	{
-		HAL_LOG_DEBUG("DatabaseModule:: postCallAsConstructor ", this);
-	}
-
 	DatabaseModule::~DatabaseModule() TITANIUM_NOEXCEPT
 	{
 		TITANIUM_LOG_DEBUG("DatabaseModule:: dtor ", this);

--- a/Source/TitaniumKit/src/FilesystemModule.cpp
+++ b/Source/TitaniumKit/src/FilesystemModule.cpp
@@ -31,7 +31,7 @@ namespace Titanium
 				throw new Error('Unable to open stream for MODE_READ');
 			}
 		)JS";
-		return js_context.CreateFunction(script, { "mode" });
+		return js_context.CreateFunction(script, { JSString("mode") });
 	}
 
 	FilesystemModule::FilesystemModule(const JSContext& js_context) TITANIUM_NOEXCEPT
@@ -68,7 +68,7 @@ namespace Titanium
 		TITANIUM_ASSERT(File_property.IsObject());  // precondition
 		JSObject File = static_cast<JSObject>(File_property);
 
-		return File.CallAsConstructor(path).GetPrivate<Titanium::Filesystem::File>();
+		return File.CallAsConstructor(get_context().CreateString(path)).GetPrivate<Titanium::Filesystem::File>();
 	}
 
 	File_shared_ptr_t FilesystemModule::createTempDirectory(const JSContext& js_context) TITANIUM_NOEXCEPT

--- a/Source/TitaniumKit/src/GlobalObject.cpp
+++ b/Source/TitaniumKit/src/GlobalObject.cpp
@@ -31,10 +31,6 @@ namespace Titanium
 		TITANIUM_LOG_DEBUG("GlobalObject:: ctor ", this);
 	}
 
-	void GlobalObject::postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) {
-		HAL_LOG_DEBUG("GlobalObject:: postCallAsConstructor ", this);
-	}
-
 	GlobalObject::~GlobalObject() TITANIUM_NOEXCEPT
 	{
 		TITANIUM_LOG_DEBUG("GlobalObject:: dtor ", this);

--- a/Source/TitaniumKit/src/GlobalString.cpp
+++ b/Source/TitaniumKit/src/GlobalString.cpp
@@ -20,8 +20,6 @@ namespace Titanium
 
 	void GlobalString::postInitialize(JSObject& this_object) 
 	{
-		HAL_LOG_DEBUG("GlobalString:: postInitialize ", this);
-
 		const auto ctx = this_object.get_context();
 
 		// Create cross-platform String.format

--- a/Source/TitaniumKit/src/MapModule.cpp
+++ b/Source/TitaniumKit/src/MapModule.cpp
@@ -17,11 +17,6 @@ namespace Titanium
 		TITANIUM_LOG_DEBUG("MapModule:: ctor ", this);
 	}
 
-	void MapModule::postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments)
-	{
-		HAL_LOG_DEBUG("MapModule:: postCallAsConstructor ", this);
-	}
-
 	TITANIUM_PROPERTY_GETTER(MapModule, HYBRID_TYPE)
 	{
 		return get_context().CreateNumber(Titanium::Map::Constants::to_underlying_type(Titanium::Map::MAP_TYPE::HYBRID));

--- a/Source/TitaniumKit/src/Stream.cpp
+++ b/Source/TitaniumKit/src/Stream.cpp
@@ -69,7 +69,7 @@ namespace Titanium
 				new Promise(function(resolve){ resolve(value); }).then(callback);
 			};
 		)JS";
-		return js_context.CreateFunction(script, { "callback" });
+		return js_context.CreateFunction(script, { JSString("callback") });
 	}
 
 	Stream::Stream(const JSContext& js_context) TITANIUM_NOEXCEPT

--- a/Source/TitaniumKit/src/TiModule.cpp
+++ b/Source/TitaniumKit/src/TiModule.cpp
@@ -176,11 +176,6 @@ namespace Titanium
 		TITANIUM_LOG_DEBUG("TiModule:: ctor ", this);
 	}
 
-	void TiModule::postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments)
-	{
-		HAL_LOG_DEBUG("TiModule:: postCallAsConstructor ", this);
-	}
-
 	void TiModule::JSExportInitialize()
 	{
 		JSExport<TiModule>::SetClassVersion(1);
@@ -493,7 +488,7 @@ namespace Titanium
 		// Titanium.String keeps a reference to Global.String module
 		titanium.SetProperty("String", global_string, { JSPropertyAttribute::ReadOnly, JSPropertyAttribute::DontDelete });
 
-		JSString builtin_functions_script = R"js(
+		std::string builtin_functions_script = R"js(
 			try {
 				console = {};
 				console._times = {};

--- a/Source/TitaniumKit/src/UI/EmailDialog.cpp
+++ b/Source/TitaniumKit/src/UI/EmailDialog.cpp
@@ -35,10 +35,6 @@ namespace Titanium
 			TITANIUM_LOG_DEBUG("EmailDialog:: ctor ", this);
 		}
 
-		void EmailDialog::postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) {
-			HAL_LOG_DEBUG("EmailDialog:: postCallAsConstructor ", this);
-		}
-
 		TITANIUM_PROPERTY_GETTER(EmailDialog, CANCELLED)
 		{
 			return cancelled__;

--- a/Source/TitaniumKit/src/UI/ListSection.cpp
+++ b/Source/TitaniumKit/src/UI/ListSection.cpp
@@ -28,9 +28,12 @@ namespace Titanium
 			}
 			item.templateId = static_cast<std::string>(object.GetProperty("template"));
 
+			const auto reserved1 = JSString("properties");
+			const auto reserved2 = JSString("templates");
+
 			// collect all binding properties
 			for (const auto& name : static_cast<std::vector<JSString>>(object.GetPropertyNames())) {
-				if (name == "properties" || name == "templates") {
+				if (name == reserved1 || name == reserved2) {
 					continue;
 				}
 				item.bindings.emplace(name, object.GetProperty(name));
@@ -82,10 +85,6 @@ namespace Titanium
 			headerTitle__("")
 		{
 			TITANIUM_LOG_DEBUG("ListSection:: ctor ", this);
-		}
-
-		void ListSection::postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) {
-			HAL_LOG_DEBUG("ListSection:: postCallAsConstructor ", this);
 		}
 
 		ListSection::~ListSection() 

--- a/Source/TitaniumKit/src/UI/TextArea.cpp
+++ b/Source/TitaniumKit/src/UI/TextArea.cpp
@@ -137,8 +137,7 @@ namespace Titanium
 
 		bool TextArea::hasText() TITANIUM_NOEXCEPT
 		{
-			auto value = get_value();
-			return value != nullptr && value.size() > 0;
+			return !get_value().empty();
 		}
 
 		void TextArea::JSExportInitialize() {

--- a/Source/TitaniumKit/src/XML.cpp
+++ b/Source/TitaniumKit/src/XML.cpp
@@ -41,10 +41,6 @@ this.exports.serializeToString = function(_xml) {
 		TITANIUM_LOG_DEBUG("XML:: ctor ", this);
 	}
 
-	void XML::postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) {
-		HAL_LOG_DEBUG("XML:: postCallAsConstructor ", this);
-	}
-
 	void XML::JSExportInitialize()
 	{
 		JSExport<XML>::SetClassVersion(1);

--- a/Source/UI/src/Clipboard.cpp
+++ b/Source/UI/src/Clipboard.cpp
@@ -107,7 +107,7 @@ namespace TitaniumWindows
 		void Clipboard::setData(const std::string& type, JSObject data) TITANIUM_NOEXCEPT
 		{
 #if WINAPI_FAMILY == WINAPI_FAMILY_PC_APP
-			auto json = static_cast<JSValue>(data).ToJSONString();
+			auto json = static_cast<std::string>(static_cast<JSValue>(data).ToJSONString());
 			setText(json);
 #endif
 		}

--- a/Source/UI/src/ImageView.cpp
+++ b/Source/UI/src/ImageView.cpp
@@ -314,7 +314,7 @@ namespace TitaniumWindows
 		{
 			const auto layout = getViewLayoutDelegate<WindowsImageViewLayoutDelegate>();
 
-			if (layout->get_borderRadius() > 0) {
+			if (!layout->get_borderRadius().empty()) {
 				this->border__->Background = WindowsImageViewLayoutDelegate::CreateImageBrushFromBitmapImage(bitmap);
 			} else {
 				this->image__->Source = bitmap;

--- a/Source/UI/src/ScrollView.cpp
+++ b/Source/UI/src/ScrollView.cpp
@@ -29,7 +29,7 @@ namespace TitaniumWindows
 			const std::string script = R"JS(
                  this._ti_scrollview_click_event_source_ = e.source;
             )JS";
-			return contentView.get_context().CreateFunction(script, {"e"});
+			return contentView.get_context().CreateFunction(script, {JSString("e")});
 		}
 
 		void ScrollViewLayoutDelegate::requestLayout(const bool& fire_event)


### PR DESCRIPTION
[TIMOB-26702](https://jira.appcelerator.org/browse/TIMOB-26702)

DO NOT MERGE THIS

rebase #1361 based on current master state.

This PR rewrites our `HAL` entirely from scratch to see how lightweight implementation of HAL affects performance. 

### Results

- No gain on application startup/rendering time (mostly no difference compared to 8.0.0)
- Lightweight HAL uses 16MB (18%) less application memory
- Lightweight HAL uses 15% less CPU

**BEFORE**
![before](https://user-images.githubusercontent.com/1661068/53779246-d1195300-3f42-11e9-8e20-838ce7cf1d50.png)

**AFTER**
![after](https://user-images.githubusercontent.com/1661068/53779242-c959ae80-3f42-11e9-96be-791d9782aa74.png)

However, because this is quite big internal change in our basic framework, I'm not sure if we should apply these changes to our master branch. 

- We don't have no difference on our startup/rendering time.
- This may work with less CPU/memory, but I think most users don't care about it because latest PC machines often work with rich CPU/memory compared to mobile devices. Because our performance gain on #1345 is pretty significant (up to 45% improvement), I'm not sure lightweight HAL is really worth it now.



