### PR TITLE
[TIMOB-26782] Stop installing dependencies manually

### DIFF
--- a/cli/hooks/wp-run.js
+++ b/cli/hooks/wp-run.js
@@ -269,37 +269,6 @@ exports.init = function (logger, config, cli) {
 						});
 				}
 
-				if (!cli.argv.hasOwnProperty('skipInstallDependencies')) {
-					// Install dependencies
-					var possibleDependencies = fs.readdirSync(dependenciesDir);
-					possibleDependencies = possibleDependencies.filter(function(file) {
-						return appxExtensions.indexOf(path.extname(file)) !== -1;
-					});
-					possibleDependencies.forEach(function(file) {
-						installs.push(function (next) {
-							logger.info(__('Installing dependency: %s', file));
-							windowslib.install(builder.deviceId, path.resolve(dependenciesDir, file), installOnlyOpts)
-							.on('installed', function (handle) {
-								next();
-							})
-							.on('timeout', function (err) {
-								logRelay && logRelay.stop();
-								next(err.message);
-							})
-							.on('error', function (err) {
-								// We should skip installing dependency when it is aready there
-								if (err.message && err.message.indexOf('A debug application is already installed') != -1) {
-									logger.info(__('Skipping installing dependency: %s', file));
-									next();
-								} else {
-									logRelay && logRelay.stop();
-									next(err.message);
-								}
-							});
-						});
-					});
-				}
-
 				// Install actual app(s)
 				var possibleApps = fs.readdirSync(appxDir);
 				possibleApps = possibleApps.filter(function(file) {


### PR DESCRIPTION
[TIMOB-26782](https://jira.appcelerator.org/browse/TIMOB-26782)

Remove `skipInstallDependencies` option and stop installing dependencies manually by default because installing dependencies manually is no longer needed with latest Windows SDK.

Expected: Install app to Windows 10 mobile device with `appc run -p windows -l trace --target wp-device` command and it should successfully launch the app without errors.
