### PR TITLE
fix(database): avoid integer overflows

### DIFF
--- a/Source/TitaniumKit/src/Database/ResultSet.cpp
+++ b/Source/TitaniumKit/src/Database/ResultSet.cpp
@@ -75,7 +75,7 @@ namespace Titanium
 					return get_context().CreateString(text);
 				}
 				case SQLITE_INTEGER:{
-					return get_context().CreateNumber(static_cast<double>(sqlite3_column_int(statement__, index)));
+					return get_context().CreateNumber(static_cast<double>(sqlite3_column_int64(statement__, index)));
 				}
 				case SQLITE_FLOAT:{
 					return get_context().CreateNumber(static_cast<double>(sqlite3_column_double(statement__, index)));
@@ -103,7 +103,7 @@ namespace Titanium
 					return get_context().CreateString(text);
 				}
 				case FIELD_TYPE::INT:{
-					return get_context().CreateNumber(static_cast<double>(sqlite3_column_int(statement__, index)));
+					return get_context().CreateNumber(static_cast<double>(sqlite3_column_int64(statement__, index)));
 				}
 				case FIELD_TYPE::DOUBLE:
 				case FIELD_TYPE::FLOAT:{


### PR DESCRIPTION
An attempt to see if this fixes DB integer overflow issues exposed by new unit test in our suite that has fixed on Android.

Basically JS and C++/Java have mismatches on what the range of values an "integer" can hold. JS defines it as 2^53 - 1, while Java/C++ use 2^31 -1. So this tries to read the integer columns as 64-bit integers (then cast to double and wrap in JS Number).

See failed test here: https://jenkins.appcelerator.org/job/titanium-sdk/job/titanium-mobile-mocha-suite/job/master/63/testReport/junit/windows.ws-local.Titanium/Database/Test___ws_local___db_read_write_integer_boundaries/