### PR TITLE
[TIMOB-24366] Throw error when target sdk version is less than min version

### DIFF
--- a/cli/commands/_build/config/wpSDK.js
+++ b/cli/commands/_build/config/wpSDK.js
@@ -31,6 +31,10 @@ module.exports = function configOptionSDK(order) {
 	return {
 		abbr: 'S',
 		callback: function (value) {
+			var min =  this.cli.tiapp.windows['TargetPlatformMinVersion']
+			if (min && appc.version.lt(value, min)) {
+				throw new Error(__('The target version "%s" must be greater than or equal to the TargetPlatformMinVersion value.', value));
+			}
 			// target various Windows 10.0.X SDKs
 			if (value.startsWith('10.0.')) {
 				this.targetPlatformSdkVersion = value;

--- a/cli/commands/_build/config/wpSDK.js
+++ b/cli/commands/_build/config/wpSDK.js
@@ -31,12 +31,12 @@ module.exports = function configOptionSDK(order) {
 	return {
 		abbr: 'S',
 		callback: function (value) {
-			var min =  this.cli.tiapp.windows['TargetPlatformMinVersion']
-			if (min && appc.version.lt(value, min)) {
-				throw new Error(__('The target version "%s" must be greater than or equal to the TargetPlatformMinVersion value.', value));
-			}
 			// target various Windows 10.0.X SDKs
 			if (value.startsWith('10.0.')) {
+				var min =  this.cli.tiapp.windows['TargetPlatformMinVersion']
+				if (min && appc.version.lt(value, min)) {
+					throw new Error(__('The target version "%s" must be greater than or equal to the TargetPlatformMinVersion value.', value));
+				}
 				this.targetPlatformSdkVersion = value;
 				this.cli.argv['win-sdk'] = '10.0';
 			}


### PR DESCRIPTION
[TIMOB-24366](https://jira.appcelerator.org/browse/TIMOB-24366)

tiapp.xml
```xml
<windows>
    <TargetPlatformVersion>10.0.14393.0</TargetPlatformVersion>
    <TargetPlatformMinVersion>10.0.14393.0</TargetPlatformMinVersion>
</windows>
```

### Test Case 1

```
> appc run -p windows --target ws-local -S 10.0.10586.0
```

Expected: App build should error out with following error message.

```
| ERROR  | An uncaught exception was thrown!
The target version "10.0.10586.0" must be greater than or equal to the TargetPlatformMinVersion value.
```

### Test Case 2

Build app with following commands and it should go through without errors.

```
> appc run -p windows --target ws-local
```

```
> appc run -p windows --target ws-local -S 10.0.15063.0
```

```
> appc run -p windows --target ws-local -S 10.0.14393.0
```

