### PR TITLE
Attempt to stabilize Jenkins tests

### DIFF
--- a/tests/Resources/app.js
+++ b/tests/Resources/app.js
@@ -64,7 +64,7 @@ function loadTests() {
 	require('./ti.contacts.person.test');
 	require('./ti.database.test');
 	require('./ti.filesystem.test');
-	//require('./ti.filesystem.file.test');
+	require('./ti.filesystem.file.test');
 	require('./ti.filesystem.filestream.test');
 	require('./ti.geolocation.test');
 	require('./ti.gesture.test');

--- a/tests/Resources/app.js
+++ b/tests/Resources/app.js
@@ -1,0 +1,322 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-Present by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* eslint-env mocha */
+/* global Ti, global */
+/* eslint no-unused-expressions: "off", no-global-assign: "off", no-native-reassign: "off" */
+'use strict';
+var utilities,
+	win,
+	$results = [],
+	failed = false,
+	should;
+
+require('./ti-mocha');
+// I *think* we need to load mocha first before utilities...
+utilities = require('./utilities/utilities');
+should = require('./utilities/assertions');
+
+// Must test global is available in first app.js explicitly!
+// (since app.js is treated slightly differently than required files on at least Android)
+describe('global', function () {
+	it('should be available as \'global\'', function () {
+		should(global).be.ok;
+	});
+});
+
+// Must have __dirname in the global scope, even in our app.js
+describe('__dirname', function () {
+	it.windowsMissing('should be available as \'__dirname\'', function () {
+		should(__dirname).be.ok;
+		should(__dirname).be.a.String;
+		should(__dirname).be.eql('/');
+	});
+});
+
+// Must have __filename in the global scope, even in our app.js
+describe('__filename', function () {
+	it.windowsMissing('should be available as \'__filename\'', function () {
+		should(__filename).be.ok;
+		should(__filename).be.a.String;
+		should(__filename).be.eql('/app.js');
+	});
+});
+
+function loadTests() {
+	// ============================================================================
+	// Add the tests here using "require"
+	// Titanium APIs
+	require('./ti.accelerometer.test');
+	require('./ti.analytics.test');
+	require('./ti.api.test');
+	require('./ti.app.test');
+	require('./ti.app.properties.test');
+	require('./ti.app.windows.backgroundservice.test');
+	require('./ti.blob.test');
+	require('./ti.bootstrap.test');
+	require('./ti.buffer.test');
+	require('./ti.codec.test');
+	require('./ti.contacts.test');
+	require('./ti.contacts.group.test');
+	require('./ti.contacts.person.test');
+	require('./ti.database.test');
+	require('./ti.filesystem.test');
+	//require('./ti.filesystem.file.test');
+	require('./ti.filesystem.filestream.test');
+	require('./ti.geolocation.test');
+	require('./ti.gesture.test');
+	require('./ti.locale.test');
+	require('./ti.map.test');
+	require('./ti.media.test');
+	require('./ti.media.audioplayer.test');
+	require('./ti.media.sound.test');
+	require('./ti.media.videoplayer.test');
+	require('./ti.network.test');
+	require('./ti.network.cookie.test');
+	require('./ti.network.httpclient.test');
+	require('./ti.network.socket.tcp.test');
+	require('./ti.network.socket.udp.test');
+	require('./ti.platform.test');
+	require('./ti.platform.displaycaps.test');
+	require('./ti.proxy.test');
+	require('./ti.stream.test');
+	require('./ti.test');
+	require('./ti.ui.test');
+	require('./ti.ui.2dmatrix.test');
+	require('./ti.ui.matrix2d.test');
+	require('./ti.ui.activityindicator.test');
+	require('./ti.ui.alertdialog.test');
+	require('./ti.ui.attributedstring.test');
+	require('./ti.ui.button.test');
+	require('./ti.ui.constants.test');
+	require('./ti.ui.emaildialog.test');
+	require('./ti.ui.imageview.test');
+	require('./ti.ui.label.test');
+	require('./ti.ui.layout.test');
+	require('./ti.ui.listview.test');
+	require('./ti.ui.navigationwindow.test');
+	require('./ti.ui.optiondialog.test');
+	require('./ti.ui.picker.test');
+	require('./ti.ui.progressbar.test');
+	require('./ti.ui.scrollableview.test');
+	require('./ti.ui.scrollview.test');
+	require('./ti.ui.searchbar.test');
+	require('./ti.ui.slider.test');
+	require('./ti.ui.switch.test');
+	require('./ti.ui.tab.test');
+	require('./ti.ui.tabbedbar.test');
+	require('./ti.ui.tabgroup.test');
+	require('./ti.ui.tableview.test');
+	require('./ti.ui.textarea.test');
+	require('./ti.ui.textfield.test');
+	require('./ti.ui.toolbar.test');
+	require('./ti.ui.view.test');
+	require('./ti.ui.webview.test');
+	require('./ti.ui.window.test');
+	require('./ti.ui.windows.commandbar.test');
+	require('./ti.utils.test');
+	require('./ti.xml.test');
+
+	// Load in any of the files added to the test/Resources folder of the SDK repos
+
+	loadAddonTestFiles(Ti.Filesystem.resourcesDirectory);
+}
+
+function loadAddonTestFiles (name) {
+	var info = Ti.Filesystem.getFile(name);
+	if (!info) {
+		console.warn('could not load addon test files: ' + name);
+		return;
+	}
+	if (info.isDirectory()) {
+		info.getDirectoryListing().forEach(function (listing) {
+			loadAddonTestFiles(listing);
+		});
+	// Only load the test files
+	} else if (/\w+.addontest\.js$/i.test(info.name)) {
+		try {
+			require(name.replace(/.js$/, '')); // eslint-disable-line security/detect-non-literal-require
+		} catch (e) {
+			console.log(e);
+		}
+	}
+}
+
+// ============================================================================
+
+/**
+ * To make Jenkins junit reporting happy, let's use anything up until '#'/'.' in
+ * suite names as the full "class name". Then concanetate the remainder with the test name.
+ * This should consolidate tests together under our API names like 'Ti.Buffer', with subsuites' tests
+ * just represented as separate tests (the sub-suite name gets prefixed to the test name)
+ * @param  {string[]} suites  stack of suite names
+ * @param  {string} testTitle single test name
+ * @return {object}
+ */
+function suiteAndTitle(suites, testTitle) {
+	var i;
+	var char;
+	var index = -1;
+	var suiteName = '';
+	var newTestTitle = '';
+	for (i = 0; i < suites.length; i++) {
+		char = suites[i].charAt(0);
+		if (char === '.' || char === '#') {
+			index = i;
+			break;
+		}
+	}
+	if (index !== -1) {
+		suiteName = suites.slice(0, index).join('.');
+		newTestTitle = suites.slice(index).join(' ') + ' ' + testTitle;
+	} else {
+		suiteName = suites.join('.');
+		newTestTitle = testTitle;
+	}
+	return {
+		suite: suiteName,
+		title: newTestTitle
+	};
+}
+
+function safeStringify(object) {
+	// Hack around cycles in structure!
+	const seen = [];
+	return JSON.stringify(object, (key, val) => {
+		if (val != null && typeof val === 'object') { // eslint-disable-line no-eq-null,eqeqeq
+			if (seen.indexOf(val) >= 0) {
+				return;
+			}
+			seen.push(val);
+		}
+		return val;
+	});
+}
+
+function escapeCharacters(string) {
+	return string.replace(/\\n/g, '\\n')
+		.replace(/\\'/g, '\\\'')
+		.replace(/\\"/g, '\\"')
+		.replace(/\\&/g, '\\&')
+		.replace(/\\r/g, '\\r')
+		.replace(/\\t/g, '\\t')
+		.replace(/\\b/g, '\\b')
+		.replace(/\\f/g, '\\f')
+		// remove non-printable and other non-valid JSON chars
+		.replace(/[\u0000-\u0019]+/g, ''); // eslint-disable-line no-control-regex
+}
+
+// add a special mocha reporter that will time each test run using
+// our microsecond timer
+function $Reporter(runner) {
+	var started,
+		suites = [];
+
+	runner.on('suite', function (suite) {
+		if (suite.title) {
+			suites.push(suite.title);
+		}
+	});
+
+	runner.on('suite end', function (suite) {
+		if (suite.title) {
+			suites.pop();
+		}
+	});
+
+	runner.on('test', function (test) {
+		Ti.API.info('!TEST_START: ' + test.title);
+		started = new Date().getTime();
+	});
+
+	runner.on('pending', function () {
+		// TODO Spit out something like !TEST_SKIP:  ?
+		started = new Date().getTime(); // reset timer. pending/skipped tests basically start and end immediately
+	});
+
+	// 'pending' hook for skipped tests? Does 'pending', then immediate 'test end'. No 'test' event
+
+	runner.on('fail', function (test, err) {
+		test.err = err;
+		failed = true;
+
+		const fixedNames = suiteAndTitle(suites, test.title);
+		Ti.API.error(`!TEST_FAIL: ${fixedNames.suite} - ${fixedNames.title} -> ${safeStringify(err)}`);
+	});
+
+	runner.on('test end', function (test) {
+		const tdiff = new Date().getTime() - started;
+		const fixedNames = suiteAndTitle(suites, test.title);
+		const result = {
+			state: test.state || 'skipped',
+			duration: tdiff,
+			suite: fixedNames.suite,
+			title: fixedNames.title,
+			error: test.err,
+			message: ''
+		};
+
+		if (test.err) {
+			let message = test.err.message || 'Error';
+			let stack = test.err.stack || '';
+			// uncaught
+			if (test.err.uncaught) {
+				message = 'Uncaught ' + message;
+			}
+
+			// if there's both a stack and message property and they differ, but message is in the stack, strip it from the stack
+			if (test.err.message && test.err.stack && stack.indexOf(message) !== -1) {
+				// stack trace includes the message in it!
+				const index = stack.indexOf(message) + message.length;
+				// indent stack trace without msg
+				stack = stack.slice(index ? index + 1 : index).replace(/^/gm, '  ');
+			}
+			result.message = message;
+			result.stack = stack;
+		}
+
+		// Hack around cycles in structure!
+		const stringified = escapeCharacters(safeStringify(result));
+		Ti.API.info('!TEST_END: ' + stringified);
+		$results.push(result);
+	});
+}
+
+if (utilities.isWindows()) {
+	if (Ti.App.Windows.requestExtendedExecution) {
+		Ti.App.Windows.requestExtendedExecution();
+	}
+}
+
+// Emit OS version
+Ti.API.info('OS_VERSION: ' + Ti.Platform.version);
+
+// Display a window to host the test and show the final result.
+win = Ti.UI.createWindow({
+	backgroundColor: 'yellow',
+	keepScreenOn: true
+});
+win.addEventListener('open', function () {
+	setTimeout(function () {
+		mocha.setup({
+			reporter: $Reporter,
+			quiet: true
+		});
+		loadTests();
+		// Start executing the test suite.
+		mocha.run(function () {
+			// We've finished executing all tests.
+			win.backgroundColor = failed ? 'red' : 'green';
+			Ti.API.info('!TEST_RESULTS_STOP!');
+			if (utilities.isWindows()) {
+				if (Ti.App.Windows.closeExtendedExecution) {
+					Ti.App.Windows.closeExtendedExecution();
+				}
+			}
+		});
+	}, 25);
+});
+win.open();

--- a/tests/Resources/ti.filesystem.filestream.test.js
+++ b/tests/Resources/ti.filesystem.filestream.test.js
@@ -1,0 +1,259 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-Present by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* eslint-env mocha */
+/* global Ti */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+
+var should = require('./utilities/assertions');
+
+describe('Titanium.Filesystem.FileStream', function () {
+
+	before(function () {
+		// prepare resource
+		var file = Ti.Filesystem.getFile(Ti.Filesystem.applicationDataDirectory, 'stream_test_in.txt');
+		if (file.exists()) {
+			file.deleteFile();
+		}
+		file.write('Remember, remember the 5th of November.\nThe gunpowder treason and plot.\nI know of no reason why the gunpowder treason should ever be forgot.');
+
+		file = Ti.Filesystem.getFile(Ti.Filesystem.applicationDataDirectory, 'stream_test_out.txt');
+		if (file.exists()) {
+			file.deleteFile();
+		}
+
+		file = Ti.Filesystem.getFile(Ti.Filesystem.applicationDataDirectory, 'stream_test_truncate.txt');
+		if (file.exists()) {
+			file.deleteFile();
+		}
+
+		file = Ti.Filesystem.getFile(Ti.Filesystem.applicationDataDirectory, 'fsappendtest.jpg');
+		if (file.exists()) {
+			file.deleteFile();
+		}
+
+		file = Ti.Filesystem.getFile(Ti.Filesystem.applicationDataDirectory, 'fswritetest.jpg');
+		if (file.exists()) {
+			file.deleteFile();
+		}
+
+		file = null;
+	});
+
+	it('apiName', function (finish) {
+		var resourceFileStream = Ti.Filesystem.openStream(Ti.Filesystem.MODE_READ, Ti.Filesystem.applicationDataDirectory, 'stream_test_in.txt');
+		try {
+			should(resourceFileStream).have.a.readOnlyProperty('apiName').which.is.a.String;
+			should(resourceFileStream.apiName).be.eql('Ti.Filesystem.FileStream');
+			finish();
+		} catch (err) {
+			finish(err);
+		} finally {
+			resourceFileStream.close();
+		}
+	});
+
+	it.windowsBroken('fileStreamBasicTest', function () {
+		should(Ti.createBuffer).be.a.Function;
+		should(Ti.Filesystem.openStream).be.a.Function;
+		var resourceFileStream = Ti.Filesystem.openStream(Ti.Filesystem.MODE_READ, Ti.Filesystem.applicationDataDirectory, 'stream_test_in.txt');
+		should(resourceFileStream).be.an.Object;
+		should(resourceFileStream.read).be.a.Function;
+		should(resourceFileStream.write).be.a.Function;
+		should(resourceFileStream.apiName).be.eql('Ti.Filesystem.FileStream');
+		var inBuffer = Ti.createBuffer();
+		should(inBuffer).be.an.Object;
+		var tempBufferLength = 50;
+		var tempBuffer = Ti.createBuffer({
+			length: tempBufferLength
+		});
+		should(tempBuffer).be.an.Object;
+		should(tempBuffer.length).eql(tempBufferLength);
+		var bytesRead = resourceFileStream.read(tempBuffer);
+		for (;bytesRead > -1;) {
+			Ti.API.info('bytes read ' + bytesRead);
+			// buffer is expanded to contain the new data and the length is updated to reflect this
+			var previousData = inBuffer.toString();
+			inBuffer.append(tempBuffer);
+			// assert that the append worked correctly
+			should(previousData + tempBuffer.toString()).eql(inBuffer.toString());
+			// clear the buffer rather than creating a new temp one
+			tempBuffer.clear();
+			bytesRead = resourceFileStream.read(tempBuffer);
+		}
+		resourceFileStream.close();
+		// assert that we can read/write successfully from the out file.
+		var appDataFileOutStream = Ti.Filesystem.openStream(Ti.Filesystem.MODE_WRITE, Ti.Filesystem.applicationDataDirectory, 'stream_test_out.txt');
+		appDataFileOutStream.write(inBuffer);
+		// write inBuffer to outfile
+		appDataFileOutStream.close();
+		var outBuffer = Ti.createBuffer({
+			length: 50
+		});
+		// have to set length on read buffer or no data will be read
+		var appDataFileInStream = Ti.Filesystem.openStream(Ti.Filesystem.MODE_READ, Ti.Filesystem.applicationDataDirectory, 'stream_test_out.txt');
+		bytesRead = appDataFileInStream.read(outBuffer);
+		// read 50 byes of data from outfile into outBuffer
+		appDataFileInStream.close();
+		for (var i = 0; bytesRead > i; i++) {
+			should(inBuffer[i]).be.equal(outBuffer[i]);
+		}
+	});
+
+	it.windowsBroken('fileStreamWriteTest', function () {
+		var infile = Ti.Filesystem.getFile(Ti.Filesystem.applicationDataDirectory, 'stream_test_in.txt');
+		var instream = infile.open(Ti.Filesystem.MODE_READ);
+		var outfile = Ti.Filesystem.getFile(Ti.Filesystem.applicationDataDirectory, 'fswritetest.jpg');
+		var outstream = outfile.open(Ti.Filesystem.MODE_WRITE);
+		var buffer = Ti.createBuffer({
+			length: 20
+		});
+		var totalWriteSize = 0;
+		var size = 0;
+		for (;(size = instream.read(buffer)) > -1;) {
+			outstream.write(buffer, 0, size);
+			totalWriteSize += size;
+		}
+		instream.close();
+		outstream.close();
+		infile = Ti.Filesystem.getFile(Ti.Filesystem.applicationDataDirectory, 'fswritetest.jpg');
+		instream = infile.open(Ti.Filesystem.MODE_READ);
+		var inBuffer = Ti.Stream.readAll(instream);
+		var totalReadSize = inBuffer.length;
+		should(totalReadSize).be.equal(totalWriteSize);
+		instream.close();
+	});
+
+	it.windowsBroken('fileStreamAppendTest', function () {
+		var infile = Ti.Filesystem.getFile(Ti.Filesystem.applicationDataDirectory, 'stream_test_in.txt');
+		var instream = infile.open(Ti.Filesystem.MODE_READ);
+		var outfile = Ti.Filesystem.getFile(Ti.Filesystem.applicationDataDirectory, 'fsappendtest.jpg');
+		if (outfile.exists()) {
+			outfile.deleteFile();
+		}
+		var outstream = outfile.open(Ti.Filesystem.MODE_WRITE);
+		var bytesStreamed = Ti.Stream.writeStream(instream, outstream, 40);
+		instream.close();
+		outstream.close();
+		infile = Ti.Filesystem.getFile(Ti.Filesystem.applicationDataDirectory, 'stream_test_in.txt');
+		instream = infile.open(Ti.Filesystem.MODE_READ);
+		var appendfile = Ti.Filesystem.getFile(Ti.Filesystem.applicationDataDirectory, 'fsappendtest.jpg');
+		var appendstream = appendfile.open(Ti.Filesystem.MODE_APPEND);
+		var buffer = Ti.createBuffer({
+			length: 20
+		});
+		var totalWriteSize = 0;
+		var size = 0;
+		for (;(size = instream.read(buffer)) > -1;) {
+			appendstream.write(buffer, 0, size);
+			totalWriteSize += size;
+		}
+		instream.close();
+		appendstream.close();
+		infile = Ti.Filesystem.getFile(Ti.Filesystem.applicationDataDirectory, 'fsappendtest.jpg');
+		instream = infile.open(Ti.Filesystem.MODE_READ);
+		var inBuffer = Ti.Stream.readAll(instream);
+		var totalReadSize = inBuffer.length;
+		Ti.API.info('Total read size: ' + totalReadSize);
+		Ti.API.info('Streamed: ' + bytesStreamed);
+		Ti.API.info('Total write size: ' + totalWriteSize);
+		should(totalReadSize).be.equal(bytesStreamed + totalWriteSize);
+		instream.close();
+	});
+
+	it.windowsBroken('fileStreamPumpTest', function () {
+		var pumpInputFile = Ti.Filesystem.getFile(Ti.Filesystem.applicationDataDirectory, 'stream_test_in.txt');
+		should(pumpInputFile).be.an.Object;
+		should(pumpInputFile.open).be.a.Function;
+		should(pumpInputFile.exists()).be.true;
+		var step = 10;
+		var pumpTotal = 0;
+		function pumpCallback(e) {
+			if (e.bytesProcessed != -1) { // eslint-disable-line eqeqeq
+				Ti.API.info('Received data chunk of size <' + e.bytesProcessed + '>');
+				Ti.API.info('Received buffer <' + e.buffer + '>');
+				Ti.API.info('Total bytes received thus far <' + e.totalBytesProcessed + '>');
+				should(e.bytesProcessed).eql(step);
+				should(e.totalBytesProcessed).eql(step + pumpTotal);
+				pumpTotal += e.bytesProcessed;
+			} else { // EOF
+				Ti.API.info('Reached EOF in pumpCallback');
+			}
+		}
+		var pumpStream = pumpInputFile.open(Ti.Filesystem.MODE_READ);
+		should(pumpStream).be.an.Object;
+		Ti.Stream.pump(pumpStream, pumpCallback, step);
+		pumpStream.close();
+	});
+
+	it.windowsBroken('fileStreamWriteStreamTest', function () {
+		var inBuffer = Ti.createBuffer({
+				value: 'huray for data, lets have a party for data1 huray for data, lets have a party for data2 huray for data, lets have a party for data3'
+			}),
+			inStream,
+			outFileStream,
+			bytesWritten;
+
+		should(inBuffer).be.an.Object;
+
+		inStream = Ti.Stream.createStream({
+			source: inBuffer,
+			mode: Ti.Stream.MODE_READ
+		});
+		should(inStream).not.be.null;
+
+		outFileStream = Ti.Filesystem.openStream(Ti.Filesystem.MODE_WRITE, Ti.Filesystem.applicationDataDirectory, 'stream_test_out.txt');
+		should(outFileStream).be.an.Object;
+
+		// writes all data from inBufferStream to outFileStream in chunks of 30
+		bytesWritten = Ti.Stream.writeStream(inStream, outFileStream, 30);
+		Ti.API.info('<' + bytesWritten + '> bytes written, closing both streams');
+		// assert that the length of the outBuffer is equal to the amount of bytes that were written
+		should(bytesWritten).eql(inBuffer.length);
+		outFileStream.close();
+	});
+
+	it.windowsBroken('fileStreamTruncateTest', function () {
+		var inBuffer = Ti.createBuffer({
+				value: 'huray for data, lets have a party for data1 huray for data, lets have a party for data2 huray for data, lets have a party for data3'
+			}),
+			inStream,
+			outFileStream,
+			bytesWritten,
+			outFileStream2,
+			inFileStream,
+			truncateBuffer;
+
+		should(inBuffer).be.an.Object;
+
+		inStream = Ti.Stream.createStream({
+			source: inBuffer,
+			mode: Ti.Stream.MODE_READ
+		});
+		should(inStream).not.be.null;
+
+		outFileStream = Ti.Filesystem.openStream(Ti.Filesystem.MODE_WRITE, Ti.Filesystem.applicationDataDirectory, 'stream_test_truncate.txt');
+		should(outFileStream).be.an.Object;
+
+		// writes all data from inBufferStream to outFileStream in chunks of 30
+		bytesWritten = Ti.Stream.writeStream(inStream, outFileStream, 30);
+		Ti.API.info('<' + bytesWritten + '> bytes written, closing both streams');
+		// assert that the length of the outBuffer is equal to the amount of bytes that were written
+		should(bytesWritten).eql(inBuffer.length);
+		outFileStream.close();
+
+		outFileStream2 = Ti.Filesystem.openStream(Ti.Filesystem.MODE_WRITE, Ti.Filesystem.applicationDataDirectory, 'stream_test_truncate.txt');
+		should(outFileStream2).be.an.Object;
+		outFileStream2.close();
+
+		inFileStream = Ti.Filesystem.openStream(Ti.Filesystem.MODE_READ, Ti.Filesystem.applicationDataDirectory, 'stream_test_truncate.txt');
+		should(inFileStream).be.an.Object;
+		truncateBuffer = Ti.Stream.readAll(inFileStream);
+		should(truncateBuffer.length).be.equal(0);
+		inFileStream.close();
+	});
+});


### PR DESCRIPTION
I've been trying to narrow down what makes the tests unstable. It seems JavaScriptCore becomes unstable probably because we loads too many tests that Titanium Windows can handle. So I ended up removing some suites that's not for Titanium APIs (for instance ES6 functions and JS builtins etc) then it makes the tests more stable. I also ended up skipping some tests that's still crashing, which might be related to accessing file systems. I'll raise separate ticket for them.