### PR TITLE
[TIMOB-27194] Expose Ti.API.warn and Ti.API.log in WebView

### DIFF
--- a/Source/TitaniumKit/src/API.cpp
+++ b/Source/TitaniumKit/src/API.cpp
@@ -117,7 +117,7 @@ namespace Titanium
 		});
 
 		LogSeverityLevel log_severity_level = LogSeverityLevel::API_UNKNOWN;
-		const auto position = log_severity_level_map.find(level);
+		const auto position = log_severity_level_map.find(boost::to_lower_copy(level));
 
 		if (position != log_severity_level_map.end()) {
 			log_severity_level = position->second;

--- a/Source/TitaniumKit/src/UI/webview.js
+++ b/Source/TitaniumKit/src/UI/webview.js
@@ -12,7 +12,13 @@
 			},
 			error: function (str) {
 				log('ERROR', str);
-			}
+			},
+			warn: function (str) {
+				log('WARN', str);
+			},
+			log: function (level, str) {
+				log(level, str);
+			},
 		},
 		App: {
 			_event_listeners: [],


### PR DESCRIPTION

- [TIMOB-27194](https://jira.appcelerator.org/browse/TIMOB-27194) Expose Ti.API.warn and Ti.API.log in WebView

### app.js

```js
var win = Ti.UI.createWindow();
var view = Ti.UI.createView({ backgroundColor: 'white' });
var webview = Ti.UI.createWebView({
    url: 'WebViewTestPage.htm',
    height: '80%',
    width: Ti.UI.FILL,
    bottom: 0
});
var button = Ti.UI.createButton({
    title: 'Test Button',
    height: '10%',
    width: Ti.UI.FILL,
    top: 0, left: 0
});
button.addEventListener('click', function (e) {
    Ti.App.fireEvent('app:fromTitanium', { message: 'event fired from Titanium, handled in WebView' });
});

view.add(webview);
view.add(button);
win.add(view);
win.open();
```

### WebViewTestPage.htm

```html
<html>
<head>
    <script>
        Ti.App.addEventListener("app:fromTitanium", function(e) {
            Ti.API.warn(e.message);
            Ti.API.log("WARN", e.message);
        });
    </script>
</head>
<body>

</body>
</html>
```

Expected: Following logs are printed when you click "Test Button".

```
[WARN] "event fired from Titanium, handled in WebView"
[WARN] "event fired from Titanium, handled in WebView"
```

