### PR TITLE
Force Win10 sdk 10.0.14393 for x86/ARM build

### DIFF
--- a/Tools/Scripts/build/build.js
+++ b/Tools/Scripts/build/build.js
@@ -14,7 +14,7 @@ const spawn = require('child_process').spawn; // eslint-disable-line security/de
 const windowslib = require('windowslib');
 
 // Constants
-const WIN_10 = '10.0';
+const WIN_10_0_14393 = '10.0.14393.0';
 const MSBUILD_14 = '14.0';
 const MSBUILD_15 = '15.0';
 const VS_2015_GENERATOR = 'Visual Studio 14 2015';
@@ -122,7 +122,7 @@ async function runCMake(sourceDir, buildDir, buildType, msBuildVersion, platform
 		'-G', generator,
 		'-DCMAKE_SYSTEM_NAME=' + platform,
 		'-DCMAKE_BUILD_TYPE=' + buildType,
-		'-DCMAKE_SYSTEM_VERSION=' + WIN_10,
+		'-DCMAKE_SYSTEM_VERSION=' + WIN_10_0_14393,
 		'-DTitaniumWindows_DISABLE_TESTS=ON',
 		'-DTitaniumWindows_Ti_DISABLE_TESTS=ON',
 		'-DTitaniumWindows_Global_DISABLE_TESTS=ON',


### PR DESCRIPTION
It seems some Jenkins build jobs have been failing to build for latest Windows 10 SDK because required sdk is not installed. We need to specify installed SDK version instead of using "10.0" as default value.