### PR TITLE
fix: only copy windows ti.main.js file

### DIFF
--- a/cli/commands/_build/copy.js
+++ b/cli/commands/_build/copy.js
@@ -393,7 +393,7 @@ function copyResources(next) {
 
 		// Copy all of the Titanium SDK's core JS files shared by all platforms.
 		function (cb) {
-			const src = path.join(this.titaniumSdkPath, 'common', 'Resources');
+			const src = path.join(this.titaniumSdkPath, 'common', 'Resources', 'windows');
 			_t.logger.debug(__('Copying %s', src.cyan));
 			copyDir.call(this, {
 				src: src,


### PR DESCRIPTION
Fixes [TIMOB-27452](https://jira.appcelerator.org/browse/TIMOB-27452), backport of #1430