### PR TITLE
refactor(cli/build): move to using common processjstask (#1435)

### DIFF
--- a/cli/commands/_build/initialize.js
+++ b/cli/commands/_build/initialize.js
@@ -87,6 +87,7 @@ function initialize(next) {
 	this.buildSrcDir = path.join(this.buildDir, 'src'); // Where the src files go
 	this.cmakeTargetDir = path.join(this.buildDir, this.cmakeTarget); // where cmake generates the VS solution
 	this.buildTargetAssetsDir = path.join(this.buildDir, 'Assets');
+	this.buildAssetsDir = this.buildTargetAssetsDir; // This property is used by the ProcessJSTask so just alias it to the one Windows CLI uses
 	this.buildTargetStringsDir = path.join(this.buildDir, 'Strings');
 
 	// files


### PR DESCRIPTION
* refactor(cli/build): move to using common processjstask

This aligns Windows with the same js processing code as Android and iOS, which handles all the knowledge like dont minify the internal common files, incremental builds etc

Fixes TIMOB-27452

* fix: correctly construct tasks array