### PR TITLE
[TIMOB-27640] unit specifier for fontSize should be ignored

### DIFF
--- a/Source/UI/src/Windows/ViewHelper.cpp
+++ b/Source/UI/src/Windows/ViewHelper.cpp
@@ -40,9 +40,8 @@ namespace TitaniumWindows
 					}
 				}
 				if (font.fontSize.length() > 0) {
-					const auto defaultUnit = Titanium::UI::ViewLayoutDelegate::GetDefaultUnit(js_context);
-					const auto ppi = TitaniumWindows::UI::WindowsViewLayoutDelegate::ComputePPI(Titanium::LayoutEngine::ValueName::Width);
-					component->FontSize = Titanium::LayoutEngine::parseUnitValue(font.fontSize, Titanium::LayoutEngine::ValueType::Fixed, ppi, defaultUnit);
+					// unit specifier should be ignored
+					component->FontSize = atof(font.fontSize.c_str());
 				}
 
 				if (font.fontStyle == Titanium::UI::FONT_STYLE::ITALIC) {

--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -1998,6 +1998,12 @@ namespace TitaniumWindows
 			});
 
 			double ppi = LogicalDpi;
+
+			// raw dpi can be zero when the monitor doesn't provide physical dimensions
+			if (RawDpiX == 0 || RawDpiY == 0) {
+				return ppi;
+			}
+
 			switch (name) {
 			case Titanium::LayoutEngine::ValueName::CenterX:
 			case Titanium::LayoutEngine::ValueName::Left:


### PR DESCRIPTION
[TIMOB-27640](https://jira.appcelerator.org/browse/TIMOB-27640)

In order to keep parity between iOS, unit specifier for fontSize should be ignored.

```javascript
var win = Ti.UI.createWindow({
    backgroundColor: 'green',
    layout: 'vertical',
    title: 'Label Demo'
});

var label1 = Ti.UI.createLabel({
    color: '#900',
    font: { fontSize: '48dp' },
    text: 'A simple label',
    top: 30,
    width: Ti.UI.SIZE, height: Ti.UI.SIZE
});

var label2 = Ti.UI.createLabel({
    color: '#900',
    font: { fontSize: 48 },
    text: 'A simple label',
    width: Ti.UI.SIZE, height: Ti.UI.SIZE
});

win.add(label1);
win.add(label2);
win.open();
```

Expected: Both Labels should be shown with same font size.
