### PR TITLE
fix(8_3_X): unit specifier for fontSize should be ignored

### DIFF
--- a/Source/UI/src/Windows/ViewHelper.cpp
+++ b/Source/UI/src/Windows/ViewHelper.cpp
@@ -40,9 +40,8 @@ namespace TitaniumWindows
 					}
 				}
 				if (font.fontSize.length() > 0) {
-					const auto defaultUnit = Titanium::UI::ViewLayoutDelegate::GetDefaultUnit(js_context);
-					const auto ppi = TitaniumWindows::UI::WindowsViewLayoutDelegate::ComputePPI(Titanium::LayoutEngine::ValueName::Width);
-					component->FontSize = Titanium::LayoutEngine::parseUnitValue(font.fontSize, Titanium::LayoutEngine::ValueType::Fixed, ppi, defaultUnit);
+					// unit specifier should be ignored
+					component->FontSize = atof(font.fontSize.c_str());
 				}
 
 				if (font.fontStyle == Titanium::UI::FONT_STYLE::ITALIC) {

--- a/Source/UI/src/WindowsViewLayoutDelegate.cpp
+++ b/Source/UI/src/WindowsViewLayoutDelegate.cpp
@@ -1998,6 +1998,12 @@ namespace TitaniumWindows
 			});
 
 			double ppi = LogicalDpi;
+
+			// raw dpi can be zero when the monitor doesn't provide physical dimensions
+			if (RawDpiX == 0 || RawDpiY == 0) {
+				return ppi;
+			}
+
 			switch (name) {
 			case Titanium::LayoutEngine::ValueName::CenterX:
 			case Titanium::LayoutEngine::ValueName::Left:


### PR DESCRIPTION
- Cherry-pick of https://github.com/appcelerator/titanium_mobile_windows/pull/1440

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-27638)